### PR TITLE
Simplify local development setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,57 +1,66 @@
+# Atom local development config.
+#
+#   cp .env.example .env
+#
+# These defaults boot a working local stack with BOTH flows:
+#   - `make up`     : everything in Docker Compose
+#   - `cargo run`   : Atom on the host, Postgres in Docker (`make db`)
+#
+# Log in with identifier `admin` and the ADMIN_SECRET below.
+# Do NOT use these values outside local development.
+
+# --- Postgres -----------------------------------------------------------
+# Credentials match `make up` so Cargo and Compose share one Postgres volume.
 POSTGRES_USER=atom
-POSTGRES_PASSWORD=replace-with-a-long-random-password
+POSTGRES_PASSWORD=atom
 POSTGRES_DB=atom
-DATABASE_URL=postgres://atom:replace-with-a-long-random-password@localhost:5432/atom
+# Used by a host `cargo run`. The Compose `atom` service overrides this with
+# the in-network postgres:5432 address, so it is safe to keep localhost here.
+DATABASE_URL=postgres://atom:atom@localhost:5432/atom
+
+# --- Atom service -------------------------------------------------------
 LISTEN_ADDR=0.0.0.0:8080
 GRPC_ADDR=0.0.0.0:8081
 JWT_EXPIRY_SECS=3600
 RUST_LOG=info
-ATOM_CORS_ALLOWED_ORIGINS=http://localhost:8080
+ATOM_PUBLIC_BASE_URL=http://localhost:8080
+ATOM_CORS_ALLOWED_ORIGINS=http://localhost:8080,http://localhost:3005,http://localhost:3000
 
-# Certificate authority settings. Certificates are enabled by default.
-# Atom loads issuer CA material from mounted files and does not store CA certs
-# or CA private keys in Postgres. file_intermediate_issuer is recommended for
-# production; file_root_issuer is supported for local/dev when only root CA
-# material exists.
-ATOM_CERTS_ENABLED=true
-ATOM_CERTS_CA_MODE=file_intermediate_issuer
-ATOM_CERTS_ROOT_CA_CERT_PATH=/certs/root-ca.crt
-ATOM_CERTS_INTERMEDIATE_CA_CERT_PATH=/certs/intermediate-ca.crt
-ATOM_CERTS_INTERMEDIATE_CA_KEY_PATH=/certs/intermediate-ca.key
-# Required only when ATOM_CERTS_CA_MODE=file_root_issuer.
+# --- Admin bootstrap ----------------------------------------------------
+# Creates the admin password credential on first boot. Log in as `admin`.
+ADMIN_SECRET=12345678
+ATOM_MIN_PASSWORD_CHARS=8
+# ADMIN_ENTITY_ID=00000000-0000-0000-0000-000000000001
+
+# --- Local convenience --------------------------------------------------
+# Allow password login before email verification, so local dev needs no SMTP.
+ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=true
+# Allow unauthenticated human self-registration. Defaults to true.
+# ATOM_SELF_REGISTRATION_ENABLED=true
+
+# --- Certificates (disabled for local dev) ------------------------------
+# Off by default so a fresh `cp .env.example .env` boots without CA files.
+# To enable: generate a root CA under ./certs (see README "Certificates"),
+# set ATOM_CERTS_ENABLED=true and ATOM_CERTS_CA_MODE=file_root_issuer.
+ATOM_CERTS_ENABLED=false
+# ATOM_CERTS_CA_MODE=file_root_issuer
+# ATOM_CERTS_ROOT_CA_CERT_PATH=/certs/root-ca.crt
 # ATOM_CERTS_ROOT_CA_KEY_PATH=/certs/root-ca.key
-# Docker Compose mounts this host directory at /certs:ro.
-ATOM_CERTS_CA_DIR=./certs
+# ATOM_CERTS_CA_DIR=./certs
+# For cargo run, point cert paths at host files instead, e.g. ./certs/root-ca.crt
+# ATOM_CERTS_INTERMEDIATE_CA_CERT_PATH=/certs/intermediate-ca.crt
+# ATOM_CERTS_INTERMEDIATE_CA_KEY_PATH=/certs/intermediate-ca.key
 # ATOM_CERTS_LEAF_DEFAULT_TTL_SECS=2592000
 # ATOM_CERTS_LEAF_MAX_TTL_SECS=2592000
 
-# Optional: set on first boot to create an admin password credential
-# ADMIN_SECRET=replace-with-a-long-random-admin-password
-# ADMIN_ENTITY_ID=00000000-0000-0000-0000-000000000001
-# ATOM_MIN_PASSWORD_CHARS=12
-
-# Optional: expose registration in the Next UI. Defaults to true.
-# ATOM_UI_REGISTRATION_ENABLED=true
-
-# Optional: allow unauthenticated global human self-registration. Defaults to true.
-# ATOM_SELF_REGISTRATION_ENABLED=true
-# Legacy alias: ATOM_SIGNUP_ENABLED=true
-
-# Development only: allow password login before email verification
-# ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN=false
-
-# Public URL used as JWT issuer and base for redirect URL defaults
-# ATOM_PUBLIC_BASE_URL=http://localhost:8080
-
-# Optional redirect URL overrides. If you're running the Next UI locally, point
-# the frontend routes at ATOM_UI_HTTP_PORT (default 3005).
+# --- Optional: email verification redirects (only if SMTP enabled) ------
 # ATOM_EMAIL_VERIFICATION_REDIRECT=http://localhost:8080/auth/email/verify
 # ATOM_OAUTH_SUCCESS_REDIRECT=http://localhost:3005/auth/callback
 # ATOM_OAUTH_ERROR_REDIRECT=http://localhost:3005/auth/callback
 # ATOM_PASSWORD_RESET_REDIRECT=http://localhost:3005/reset-password
 # ATOM_INVITATION_REDIRECT=http://localhost:3005/invitations/accept
 
-# Optional SMTP settings for signup verification email
+# --- Optional: SMTP for signup verification email -----------------------
 # ATOM_SMTP_HOST=smtp.example.com
 # ATOM_SMTP_PORT=587
 # ATOM_SMTP_USERNAME=atom@example.com
@@ -59,17 +68,15 @@ ATOM_CERTS_CA_DIR=./certs
 # ATOM_SMTP_FROM=atom@example.com
 # ATOM_SMTP_TLS=starttls
 
-# Optional OIDC providers JSON. Example:
+# --- Optional: OIDC providers JSON --------------------------------------
 # ATOM_OIDC_PROVIDERS=[{"name":"google","issuer":"https://accounts.google.com","client_id":"...","client_secret":"...","scopes":["openid","email","profile"]}]
 
-# Optional Docker Compose host ports
+# --- Optional: Docker Compose host ports --------------------------------
 # POSTGRES_HOST_PORT=5432
 # ATOM_HTTP_PORT=8080
-# ATOM_DEV_HTTP_PORT=8081
 # ATOM_UI_HTTP_PORT=3005
 
-# Optional: GraphQL endpoint used by the Dockerized Next.js UI
+# --- Optional: Dockerized Next UI ---------------------------------------
+# GraphQL endpoint the Dockerized UI calls (in-network default).
 # ATOM_GRAPHQL_URL=http://atom:8080/graphql
-
-# Start the optional Atom Next UI with:
-# docker compose --profile atom-ui up -d --build
+# ATOM_UI_REGISTRATION_ENABLED=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,29 +7,14 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs
 FROM base AS deps-release
 RUN cargo build --release && rm -rf src
 
-FROM base AS deps-dev
-RUN cargo build && rm -rf src
-
 FROM deps-release AS builder-release
 COPY . .
 RUN touch src/main.rs && cargo build --release
-
-FROM deps-dev AS builder-dev
-COPY . .
-RUN touch src/main.rs && cargo build
 
 FROM alpine:3.20 AS release
 RUN apk add --no-cache ca-certificates libgcc
 WORKDIR /app
 COPY --from=builder-release /app/target/release/atom /usr/local/bin/atom
-COPY migrations ./migrations
-EXPOSE 8080
-CMD ["atom"]
-
-FROM alpine:3.20 AS dev
-RUN apk add --no-cache ca-certificates libgcc
-WORKDIR /app
-COPY --from=builder-dev /app/target/debug/atom /usr/local/bin/atom
 COPY migrations ./migrations
 EXPOSE 8080
 CMD ["atom"]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ COMPOSE ?= docker compose
 COMPOSE_PROFILES ?= --profile default --profile atom-ui
 DEV_ENV_FILE ?= .env
 COMPOSE_ENV = ATOM_IMAGE="$(ATOM_IMAGE)" ATOM_UI_IMAGE="$(ATOM_UI_IMAGE)"
+# Ports for the host `make dev` flow. Kept distinct from the Compose ports
+# (8080 / 3005) so `make up` and `make dev` can run at once on one Postgres.
+DEV_HTTP_PORT ?= 8090
+DEV_UI_PORT ?= 3000
 
 .PHONY: help db dev build atom-build ui-build up down logs restart docker-build docker-build-release
 
@@ -23,7 +27,7 @@ help:
 	@echo "  make ui-build            Build and tag only the Atom UI image"
 	@echo "  make up                  Build and start Postgres, Atom, and Atom UI"
 	@echo "  make db                  Start only Postgres (for host 'cargo run')"
-	@echo "  make dev                 Postgres (Docker) + host cargo run + host UI dev server"
+	@echo "  make dev                 Postgres (Docker) + host cargo run (:$(DEV_HTTP_PORT)) + host UI (:$(DEV_UI_PORT)); runs alongside 'make up'"
 	@echo "  make restart             Rebuild and restart Postgres, Atom, and Atom UI"
 	@echo "  make logs                Follow Atom + Atom UI logs"
 	@echo "  make down                Stop the local Compose stack"
@@ -34,6 +38,8 @@ help:
 	@echo "  COMPOSE=$(COMPOSE)"
 	@echo "  COMPOSE_PROFILES=$(COMPOSE_PROFILES)"
 	@echo "  DEV_ENV_FILE=$(DEV_ENV_FILE)"
+	@echo "  DEV_HTTP_PORT=$(DEV_HTTP_PORT)"
+	@echo "  DEV_UI_PORT=$(DEV_UI_PORT)"
 	@echo "  IMAGE_NAME=$(IMAGE_NAME)"
 	@echo "  IMAGE_TAG=$(IMAGE_TAG)"
 	@echo "  ATOM_IMAGE=$(ATOM_IMAGE)"
@@ -46,13 +52,16 @@ db:
 	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) up -d postgres
 
 # Full host dev loop: Postgres in Docker, Atom and the Next UI on the host.
-# Backend on :8080, UI on :3000. Ctrl-C stops both. Do not run alongside `make up`.
+# Backend on :$(DEV_HTTP_PORT), UI on :$(DEV_UI_PORT), sharing the Compose
+# Postgres. Distinct from `make up` (8080 / 3005), so both can run at once.
+# Ctrl-C stops both host processes.
 dev: db
 	@command -v cargo >/dev/null 2>&1 || { echo "cargo is required for 'make dev'"; exit 1; }
 	@command -v pnpm  >/dev/null 2>&1 || { echo "pnpm is required for 'make dev'"; exit 1; }
 	@trap 'kill 0' INT TERM EXIT; \
-	cargo run & \
-	( cd app && pnpm install --frozen-lockfile && pnpm dev ) & \
+	LISTEN_ADDR=0.0.0.0:$(DEV_HTTP_PORT) ATOM_PUBLIC_BASE_URL=http://localhost:$(DEV_HTTP_PORT) cargo run & \
+	( cd app && pnpm install --frozen-lockfile && \
+	  ATOM_GRAPHQL_URL=http://localhost:$(DEV_HTTP_PORT)/graphql PORT=$(DEV_UI_PORT) pnpm dev ) & \
 	wait
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ help:
 	@echo "First run: cp .env.example .env"
 	@echo ""
 	@echo "Available targets:"
-	@echo "  make build               Build and tag Atom backend + Atom UI images for local dev"
-	@echo "  make atom-build          Build and tag only the Atom backend image"
-	@echo "  make ui-build            Build and tag only the Atom UI image"
-	@echo "  make up                  Build and start Postgres, Atom, and Atom UI"
+	@echo "  make build               Rebuild Atom backend + Atom UI images (run after code changes)"
+	@echo "  make atom-build          Rebuild only the Atom backend image"
+	@echo "  make ui-build            Rebuild only the Atom UI image"
+	@echo "  make up                  Start Postgres, Atom, and Atom UI (builds images only if missing)"
 	@echo "  make db                  Start only Postgres (for host 'cargo run')"
 	@echo "  make dev                 Postgres (Docker) + host cargo run (:$(DEV_HTTP_PORT)) + host UI (:$(DEV_UI_PORT)); runs alongside 'make up'"
-	@echo "  make restart             Rebuild and restart Postgres, Atom, and Atom UI"
+	@echo "  make restart             Restart the Compose stack (no rebuild; use 'make build' first)"
 	@echo "  make logs                Follow Atom + Atom UI logs"
 	@echo "  make down                Stop the local Compose stack"
 	@echo "  make docker-build        Build the raw Atom Docker image for BUILD_TARGET"
@@ -74,7 +74,7 @@ ui-build:
 	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom-ui
 
 up:
-	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) up -d --build postgres atom atom-ui
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) up -d postgres atom atom-ui
 
 restart: down up
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 IMAGE_NAME ?= ghcr.io/absmach/atom
 IMAGE_TAG ?= latest
 ATOM_IMAGE ?= $(IMAGE_NAME):$(IMAGE_TAG)
-ATOM_DEV_IMAGE ?= $(IMAGE_NAME):dev
 ATOM_UI_IMAGE_NAME ?= ghcr.io/absmach/atom-ui
 ATOM_UI_IMAGE_TAG ?= $(IMAGE_TAG)
 ATOM_UI_IMAGE ?= $(ATOM_UI_IMAGE_NAME):$(ATOM_UI_IMAGE_TAG)
@@ -10,24 +9,26 @@ DOCKERFILE ?= Dockerfile
 BUILD_CONTEXT ?= .
 COMPOSE ?= docker compose
 COMPOSE_PROFILES ?= --profile default --profile atom-ui
-DEV_ENV_FILE ?= .env.dev
-COMPOSE_IMAGE_ENV = ATOM_IMAGE="$(ATOM_IMAGE)" ATOM_DEV_IMAGE="$(ATOM_DEV_IMAGE)" ATOM_UI_IMAGE="$(ATOM_UI_IMAGE)"
+DEV_ENV_FILE ?= .env
+COMPOSE_ENV = ATOM_IMAGE="$(ATOM_IMAGE)" ATOM_UI_IMAGE="$(ATOM_UI_IMAGE)"
 
-.PHONY: help dev-env build atom-build ui-build up down logs restart docker-build docker-build-release docker-build-dev
+.PHONY: help db dev build atom-build ui-build up down logs restart docker-build docker-build-release
 
 help:
+	@echo "First run: cp .env.example .env"
+	@echo ""
 	@echo "Available targets:"
 	@echo "  make build               Build and tag Atom backend + Atom UI images for local dev"
 	@echo "  make atom-build          Build and tag only the Atom backend image"
 	@echo "  make ui-build            Build and tag only the Atom UI image"
 	@echo "  make up                  Build and start Postgres, Atom, and Atom UI"
+	@echo "  make db                  Start only Postgres (for host 'cargo run')"
+	@echo "  make dev                 Postgres (Docker) + host cargo run + host UI dev server"
 	@echo "  make restart             Rebuild and restart Postgres, Atom, and Atom UI"
 	@echo "  make logs                Follow Atom + Atom UI logs"
 	@echo "  make down                Stop the local Compose stack"
-	@echo "  make dev-env             Create $(DEV_ENV_FILE) with local dev defaults"
 	@echo "  make docker-build        Build the raw Atom Docker image for BUILD_TARGET"
 	@echo "  make docker-build-release Build the raw release Docker image"
-	@echo "  make docker-build-dev    Build the raw dev Docker image"
 	@echo ""
 	@echo "Variables:"
 	@echo "  COMPOSE=$(COMPOSE)"
@@ -36,70 +37,43 @@ help:
 	@echo "  IMAGE_NAME=$(IMAGE_NAME)"
 	@echo "  IMAGE_TAG=$(IMAGE_TAG)"
 	@echo "  ATOM_IMAGE=$(ATOM_IMAGE)"
-	@echo "  ATOM_DEV_IMAGE=$(ATOM_DEV_IMAGE)"
 	@echo "  ATOM_UI_IMAGE=$(ATOM_UI_IMAGE)"
 	@echo "  BUILD_TARGET=$(BUILD_TARGET)"
 	@echo "  DOCKERFILE=$(DOCKERFILE)"
 	@echo "  BUILD_CONTEXT=$(BUILD_CONTEXT)"
 
-dev-env:
-	@if [ -f "$(DEV_ENV_FILE)" ]; then \
-		echo "$(DEV_ENV_FILE) already exists"; \
-	else \
-		mkdir -p certs; \
-		if [ ! -f certs/root-ca.crt ] || [ ! -f certs/root-ca.key ]; then \
-			if ! command -v openssl >/dev/null 2>&1; then \
-				echo "openssl is required to generate local dev CA files"; \
-				exit 1; \
-			fi; \
-			openssl req -x509 -newkey rsa:2048 -nodes \
-				-keyout certs/root-ca.key \
-				-out certs/root-ca.crt \
-				-days 3650 \
-				-subj "/CN=Atom Dev Root CA" \
-				-addext "basicConstraints=critical,CA:TRUE" \
-				-addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1; \
-		fi; \
-		{ \
-			echo "POSTGRES_USER=atom"; \
-			echo "POSTGRES_PASSWORD=atom"; \
-			echo "POSTGRES_DB=atom"; \
-			echo "ADMIN_SECRET=12345678"; \
-			echo "ATOM_MIN_PASSWORD_CHARS=8"; \
-			echo "ATOM_SERVICE_SECRET=atom-dev-service-password"; \
-			echo "ATOM_CERTS_ENABLED=true"; \
-			echo "ATOM_CERTS_CA_MODE=file_root_issuer"; \
-			echo "ATOM_CERTS_ROOT_CA_CERT_PATH=/certs/root-ca.crt"; \
-			echo "ATOM_CERTS_ROOT_CA_KEY_PATH=/certs/root-ca.key"; \
-			echo "ATOM_CERTS_CA_DIR=./certs"; \
-			echo "ATOM_SELF_REGISTRATION_ENABLED=false"; \
-			echo "ATOM_HTTP_PORT=18080"; \
-			echo "ATOM_PUBLIC_BASE_URL=http://localhost:18080"; \
-			echo "ATOM_UI_HTTP_PORT=3005"; \
-			echo "ATOM_GRAPHQL_URL=http://atom:8080/graphql"; \
-		} > "$(DEV_ENV_FILE)"; \
-		echo "Created $(DEV_ENV_FILE) with local developer defaults"; \
-	fi
+db:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) up -d postgres
 
-build: dev-env
-	$(COMPOSE_IMAGE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom atom-ui
+# Full host dev loop: Postgres in Docker, Atom and the Next UI on the host.
+# Backend on :8080, UI on :3000. Ctrl-C stops both. Do not run alongside `make up`.
+dev: db
+	@command -v cargo >/dev/null 2>&1 || { echo "cargo is required for 'make dev'"; exit 1; }
+	@command -v pnpm  >/dev/null 2>&1 || { echo "pnpm is required for 'make dev'"; exit 1; }
+	@trap 'kill 0' INT TERM EXIT; \
+	cargo run & \
+	( cd app && pnpm install --frozen-lockfile && pnpm dev ) & \
+	wait
 
-atom-build: dev-env
-	$(COMPOSE_IMAGE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom
+build:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom atom-ui
 
-ui-build: dev-env
-	$(COMPOSE_IMAGE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom-ui
+atom-build:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom
 
-up: dev-env
-	$(COMPOSE_IMAGE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) up -d --build postgres atom atom-ui
+ui-build:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) build atom-ui
+
+up:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) up -d --build postgres atom atom-ui
 
 restart: down up
 
-logs: dev-env
-	$(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) logs -f atom atom-ui
+logs:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) logs -f atom atom-ui
 
-down: dev-env
-	$(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) down
+down:
+	$(COMPOSE_ENV) $(COMPOSE) --env-file $(DEV_ENV_FILE) $(COMPOSE_PROFILES) down
 
 docker-build:
 	docker build \
@@ -110,6 +84,3 @@ docker-build:
 
 docker-build-release:
 	$(MAKE) docker-build BUILD_TARGET=release IMAGE_TAG=release
-
-docker-build-dev:
-	$(MAKE) docker-build BUILD_TARGET=dev IMAGE_TAG=dev

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ This README is the quick start and orientation document. It should not duplicate
 
 Atom’s normal product model uses these ideas:
 
-| Atom word | Simple meaning | Example |
-|-----------|----------------|---------|
-| Tenant | Top boundary | Magistrala domain `d1` |
-| Action | One action | `read`, `write`, `publish`, `role.manage` |
-| Action Applicability | Which object types support an action | `publish` is valid for channels, not clients |
-| Permission Block | Scope + actions + effect + conditions | channels in Plant-A -> read, publish |
-| Role | Named collection of Permission Blocks | `Plant Operator` bundles client and channel access |
-| Role Assignment | Gives a role to an entity or Principal Group | assign `Plant Operator` to `user1` |
-| Direct Policy | Gives one Permission Block directly to a subject | `client1` can publish to `channel1` |
-| Principal Group | Collection of identities | `Operators` contains `user1`, `user2`, `mg-service` |
-| Object Group | Boundary/container for objects | `Plant-A` contains clients, channels, child groups |
+| Atom word            | Simple meaning                                   | Example                                             |
+| -------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| Tenant               | Top boundary                                     | Magistrala domain `d1`                              |
+| Action               | One action                                       | `read`, `write`, `publish`, `role.manage`           |
+| Action Applicability | Which object types support an action             | `publish` is valid for channels, not clients        |
+| Permission Block     | Scope + actions + effect + conditions            | channels in Plant-A -> read, publish                |
+| Role                 | Named collection of Permission Blocks            | `Plant Operator` bundles client and channel access  |
+| Role Assignment      | Gives a role to an entity or Principal Group     | assign `Plant Operator` to `user1`                  |
+| Direct Policy        | Gives one Permission Block directly to a subject | `client1` can publish to `channel1`                 |
+| Principal Group      | Collection of identities                         | `Operators` contains `user1`, `user2`, `mg-service` |
+| Object Group         | Boundary/container for objects                   | `Plant-A` contains clients, channels, child groups  |
 
 Action naming is hybrid:
 
@@ -59,11 +59,11 @@ Action naming is hybrid:
 That means Atom does not use one naming style for every action. It chooses the
 name that makes the authorization decision easiest to understand:
 
-| Action style | What it means | Example |
-|--------------|---------------|---------|
-| Generic object action | The action is common, and the object kind gives it meaning. | `read` on `audit_log`, `revoke` on `credential` |
-| Scoped access admin action | The action manages access rules inside a specific scope. | `role.manage` for roles in one tenant or group scope |
-| Runtime operation action | The action protects a service operation, not a stored row. | `authz.check` for services allowed to call the PDP |
+| Action style               | What it means                                               | Example                                              |
+| -------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- |
+| Generic object action      | The action is common, and the object kind gives it meaning. | `read` on `audit_log`, `revoke` on `credential`      |
+| Scoped access admin action | The action manages access rules inside a specific scope.    | `role.manage` for roles in one tenant or group scope |
+| Runtime operation action   | The action protects a service operation, not a stored row.  | `authz.check` for services allowed to call the PDP   |
 
 For stored objects, the object kind is part of the authorization question:
 
@@ -147,11 +147,11 @@ Object Group           = where
 
 ## Quick start
 
-Use the Makefile for local Docker Compose development:
+There is one config file. Copy the example and start the stack:
 
 ```bash
-# 1. Create .env.dev and local dev CA files under certs/
-make dev-env
+# 1. Create your local config
+cp .env.example .env
 
 # 2. Build and start Postgres, Atom, and the Atom Next UI
 make up
@@ -160,12 +160,25 @@ make up
 make logs
 ```
 
-`make up` runs Docker Compose with `.env.dev`, `--profile default`, and
+`.env.example` ships working local defaults: admin login `admin` /
+`12345678`, password login allowed before email verification
+(`ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=true`), and certificates disabled, so a
+fresh copy boots with no SMTP, OAuth, or CA setup.
+
+`make up` runs Docker Compose with `.env`, `--profile default`, and
 `--profile atom-ui`. It starts:
 
-- Atom REST/GraphQL on `http://localhost:18080`
+- Atom REST/GraphQL on `http://localhost:8080`
 - Atom Next UI on `http://localhost:3005`
 - Postgres on `127.0.0.1:5432`
+
+Log in to get a token:
+
+```bash
+curl -s -X POST http://localhost:8080/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "admin", "secret": "12345678"}'
+```
 
 Stop or rebuild the stack with:
 
@@ -174,50 +187,77 @@ make down
 make restart
 ```
 
-GraphQL is available at `POST /graphql` in both images. With the Makefile
-Compose flow, use `POST http://localhost:18080/graphql`.
+GraphQL is available at `POST http://localhost:8080/graphql`. Migrations apply
+automatically on startup.
 
-To run Atom directly with Cargo instead of the Compose backend:
+### Backend development with Cargo
+
+Run Atom on the host and keep only Postgres in Docker. Postgres is published on
+`127.0.0.1:5432`, and `.env` points `DATABASE_URL` at `localhost:5432`, so
+`cargo run` connects with no extra setup:
 
 ```bash
-# 1. Copy and edit config
-cp .env.example .env
-# set ADMIN_SECRET on first boot to create the admin password
-# set ATOM_CERTS_ENABLED=false for a minimal local run, or point certificate
-# paths at host files under certs/
-
-# 2. Start Postgres
-docker compose --env-file .env up -d postgres
-
-# 3. Run Atom on LISTEN_ADDR, default http://localhost:8080
-cargo run
+make db        # start only Postgres
+cargo run      # Atom on http://localhost:8080
 ```
 
-Migrations apply automatically on startup.
+Do not run `make up` and `cargo run` at the same time — both bind `8080`. Use
+`make db` for the Cargo flow, or override `ATOM_HTTP_PORT` for the Compose
+backend.
 
-Certificate support is enabled by default. Atom loads issuer CA material from mounted files and does not store CA certificates or CA private keys in Postgres. Production deployments should use `ATOM_CERTS_CA_MODE=file_intermediate_issuer` with root certificate, intermediate certificate, and intermediate private key files mounted read-only; `file_root_issuer` is supported for local/dev when only root certificate and root private key files exist. Public PKI endpoints are available at `GET /certs/ca-chain`, `GET /certs/crl`, and `POST /certs/ocsp`.
+### UI development
 
-The Atom Next UI is a separate optional service. In the Makefile-backed Docker
-Compose flow it is enabled by default with the `atom-ui` profile and is
-available at `http://localhost:3005`. Registration UI is exposed at `/register`
-when `ATOM_UI_REGISTRATION_ENABLED=true` and backend self-registration is
-enabled.
+For frontend work, run the Next UI from source against a running backend
+instead of the `atom-ui` container (which would also bind `3005`).
 
-Shared Magistrala/Cube deployments may consume `ghcr.io/absmach/atom:latest` and `ghcr.io/absmach/atom-ui:latest`, but those tags are mutable. Before consuming `latest`, publish both images from the same stabilized Atom commit. Production deployments that need immutability should override the image with a digest or fixed release tag.
-
-For local UI development, run the backend and frontend separately:
+The shortcut runs Postgres (Docker) plus Atom and the UI on the host in one
+command (Ctrl-C stops both; needs host `cargo` and `pnpm`):
 
 ```bash
-# backend on http://localhost:8080
-cargo run
+make dev                 # Postgres + cargo run (:8080) + pnpm dev (:3000)
+```
 
-# Next UI on http://localhost:3000
+Or run the pieces yourself:
+
+```bash
+make db && cargo run     # or: make up   (backend on :8080)
+
 cd app
 pnpm install
-pnpm dev
+pnpm dev                 # Next UI on http://localhost:3000
 ```
 
-When using the dev Docker backend on `http://localhost:8081`, set `ATOM_GRAPHQL_URL=http://localhost:8081/graphql` for the Next UI.
+The dev UI calls `http://localhost:8080/graphql` (already allowed by the
+default `ATOM_CORS_ALLOWED_ORIGINS`).
+
+### Certificates (optional)
+
+Certificates are off by default for local dev. To enable the PKI endpoints
+(`GET /certs/ca-chain`, `GET /certs/crl`, `POST /certs/ocsp`), generate a local
+root CA and flip the cert vars in `.env`:
+
+```bash
+mkdir -p certs
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout certs/root-ca.key -out certs/root-ca.crt -days 3650 \
+  -subj "/CN=Atom Dev Root CA" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,keyCertSign,cRLSign"
+
+# in .env:
+#   ATOM_CERTS_ENABLED=true
+#   ATOM_CERTS_CA_MODE=file_root_issuer
+#   ATOM_CERTS_ROOT_CA_CERT_PATH=/certs/root-ca.crt   (host: ./certs/root-ca.crt for cargo run)
+#   ATOM_CERTS_ROOT_CA_KEY_PATH=/certs/root-ca.key
+```
+
+Compose mounts `./certs` at `/certs:ro`; a host `cargo run` reads the files
+directly, so use `./certs/...` paths there. Production should use
+`ATOM_CERTS_CA_MODE=file_intermediate_issuer` with root certificate,
+intermediate certificate, and intermediate private key files mounted
+read-only. Atom never stores CA certificates or CA private keys in Postgres.
+
+### Port overrides
 
 If a host port is already occupied, override only the host-side port:
 
@@ -225,25 +265,28 @@ If a host port is already occupied, override only the host-side port:
 POSTGRES_HOST_PORT=55432 ATOM_HTTP_PORT=28080 ATOM_UI_HTTP_PORT=3006 make up
 ```
 
-The Atom container still connects to Postgres through Docker DNS at `postgres:5432`.
+The Atom container still connects to Postgres through Docker DNS at
+`postgres:5432`.
+
+Shared Magistrala/Cube deployments may consume `ghcr.io/absmach/atom:latest` and `ghcr.io/absmach/atom-ui:latest`, but those tags are mutable. Before consuming `latest`, publish both images from the same stabilized Atom commit. Production deployments that need immutability should override the image with a digest or fixed release tag.
 
 ## Makefile commands
 
 Run `make help` to print the current target list from the Makefile.
 
-| Command | What it does |
-|---------|--------------|
-| `make dev-env` | Creates `.env.dev` with local defaults and generates local dev CA files under `certs/` if needed. |
-| `make build` | Builds and tags the Atom backend and Atom UI images for local Compose use. |
-| `make atom-build` | Builds and tags only the Atom backend image. |
-| `make ui-build` | Builds and tags only the Atom UI image. |
-| `make up` | Builds and starts Postgres, Atom, and Atom UI with `.env.dev`. |
-| `make restart` | Stops the local Compose stack, then rebuilds and starts it again. |
-| `make logs` | Follows Atom backend and Atom UI logs. |
-| `make down` | Stops the local Compose stack. |
-| `make docker-build` | Builds the raw Atom Docker image using `BUILD_TARGET`, `IMAGE_NAME`, and `IMAGE_TAG`. |
-| `make docker-build-release` | Builds the raw release Docker image. |
-| `make docker-build-dev` | Builds the raw dev Docker image. |
+| Command                     | What it does                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| `make db`                   | Starts only Postgres (for a host `cargo run`).                                        |
+| `make dev`                  | Postgres (Docker) + host `cargo run` + host UI dev server; Ctrl-C stops both.         |
+| `make build`                | Builds and tags the Atom backend and Atom UI images for local Compose use.            |
+| `make atom-build`           | Builds and tags only the Atom backend image.                                          |
+| `make ui-build`             | Builds and tags only the Atom UI image.                                               |
+| `make up`                   | Builds and starts Postgres, Atom, and Atom UI with `.env`.                            |
+| `make restart`              | Stops the local Compose stack, then rebuilds and starts it again.                     |
+| `make logs`                 | Follows Atom backend and Atom UI logs.                                                |
+| `make down`                 | Stops the local Compose stack.                                                        |
+| `make docker-build`         | Builds the raw Atom Docker image using `BUILD_TARGET`, `IMAGE_NAME`, and `IMAGE_TAG`. |
+| `make docker-build-release` | Builds the raw release Docker image.                                                  |
 
 Common overrides:
 
@@ -309,7 +352,7 @@ Profiles keep Atom's internal runtime/authz kind separate from user/domain subty
 ```graphql
 mutation {
   login(input: {
-    identifier: "atom-admin",
+    identifier: "admin",
     secret: "change-me",
     kind: "password"
   }) {
@@ -389,58 +432,57 @@ Generic application mapping:
 
 `.env.example` is the local template. These are the main runtime and Compose variables:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DATABASE_URL` | *(required)* | Postgres connection string |
-| `LISTEN_ADDR` | `0.0.0.0:8080` | HTTP bind address |
-| `GRPC_ADDR` | `0.0.0.0:8081` | gRPC bind address |
-| `JWT_EXPIRY_SECS` | `3600` | JWT lifetime in seconds |
-| `ATOM_JWT_ISSUER` | `ATOM_PUBLIC_BASE_URL` | JWT issuer claim |
-| `ATOM_JWT_AUDIENCE` | `magistrala` | JWT audience claim |
-| `ADMIN_SECRET` | *(optional)* | Seeds the admin password on first boot |
-| `ADMIN_ENTITY_ID` | `00000000-0000-0000-0000-000000000001` | Override seeded admin UUID |
-| `ATOM_SERVICE_SECRET` / `ATOM_SERVICE_ENTITY_ID` | *(optional)* / seeded service UUID | Seeds a service entity password on first boot |
-| `ATOM_MIN_PASSWORD_CHARS` | `12` | Minimum password length |
-| `ATOM_CORS_ALLOWED_ORIGINS` | `ATOM_PUBLIC_BASE_URL` | Comma-separated allowed CORS origins |
-| `ATOM_AUTH_COOKIE_SECURE` / `ATOM_AUTH_COOKIE_DOMAIN` | auto-detect HTTPS / *(unset)* | Auth cookie options for UI flows |
-| `ATOM_SELF_REGISTRATION_ENABLED` | `true` | Enables unauthenticated global human self-registration |
-| `ATOM_UI_REGISTRATION_ENABLED` | `true` | UI service only; exposes `/register` and the login-page signup link |
-| `ATOM_SIGNUP_ENABLED` | *(legacy alias)* | Backward-compatible alias for `ATOM_SELF_REGISTRATION_ENABLED` |
-| `ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN` | `false` | Development-only password login before email verification |
-| `ATOM_PUBLIC_BASE_URL` | `http://localhost:8080` | Public URL used for issuer and redirect defaults |
-| `ATOM_EMAIL_VERIFICATION_REDIRECT` | `http://localhost:8080/auth/email/verify` | URL that verifies email tokens |
-| `ATOM_PASSWORD_RESET_REDIRECT` | `http://localhost:8080/reset-password` | Frontend URL for password reset tokens |
-| `ATOM_INVITATION_REDIRECT` | `http://localhost:8080/invitations/accept` | Frontend URL for invitation tokens |
-| `ATOM_OAUTH_SUCCESS_REDIRECT` | `http://localhost:8080/auth/callback` | Frontend URL that receives the OAuth exchange code |
-| `ATOM_OAUTH_ERROR_REDIRECT` | `http://localhost:8080/auth/callback` | Frontend URL that receives OAuth errors |
-| `ATOM_OIDC_PROVIDERS` | `[]` | JSON array of OIDC providers, for example Google |
-| `ATOM_EMAIL_VERIFICATION_EXPIRY_SECS` | `86400` | Email verification token lifetime |
-| `ATOM_INVITATION_EXPIRY_SECS` | `604800` | Invitation token lifetime |
-| `ATOM_OAUTH_STATE_EXPIRY_SECS` | `600` | OAuth state token lifetime |
-| `ATOM_AUTH_EXCHANGE_CODE_EXPIRY_SECS` | `300` | OAuth exchange code lifetime |
-| `ATOM_SMTP_HOST` / `ATOM_SMTP_FROM` | *(optional)* | Required pair for signup and password reset email delivery |
-| `ATOM_SMTP_PORT` / `ATOM_SMTP_TLS` | `587` / `starttls` | SMTP port and TLS mode |
-| `ATOM_SMTP_USERNAME` / `ATOM_SMTP_PASSWORD` | *(optional)* | SMTP credentials |
-| `ATOM_CERTS_ENABLED` | `true` | Enables certificate lifecycle support |
-| `ATOM_CERTS_CA_MODE` | `file_intermediate_issuer` | CA mode: `file_intermediate_issuer` or `file_root_issuer` |
-| `ATOM_CERTS_ROOT_CA_CERT_PATH` | *(optional)* | Mounted root CA certificate path |
-| `ATOM_CERTS_INTERMEDIATE_CA_CERT_PATH` | *(optional)* | Mounted intermediate CA certificate path |
-| `ATOM_CERTS_INTERMEDIATE_CA_KEY_PATH` | *(optional)* | Mounted intermediate CA private key path |
-| `ATOM_CERTS_ROOT_CA_KEY_PATH` | *(optional)* | Mounted root CA private key path for `file_root_issuer` |
-| `ATOM_CERTS_LEAF_DEFAULT_TTL_SECS` | `2592000` | Default issued certificate lifetime |
-| `ATOM_CERTS_LEAF_MAX_TTL_SECS` | `2592000` | Maximum issued certificate lifetime |
-| `ATOM_CERTS_CA_DIR` | `./certs` | Docker Compose host directory mounted at `/certs:ro` |
-| `POSTGRES_HOST_PORT` / `ATOM_HTTP_PORT` / `ATOM_DEV_HTTP_PORT` / `ATOM_UI_HTTP_PORT` | `5432` / `8080` / `8081` / `3005` | Docker Compose host ports; `.env.dev` generated by `make dev-env` sets `ATOM_HTTP_PORT=18080` |
-| `ATOM_GRAPHQL_URL` | `http://atom:8080/graphql` | GraphQL endpoint used by the Dockerized Next UI |
-| `RUST_LOG` | `info` | Log level filter |
+| Variable                                                      | Default                                    | Description                                                         |
+| ------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
+| `DATABASE_URL`                                                | *(required)*                               | Postgres connection string                                          |
+| `LISTEN_ADDR`                                                 | `0.0.0.0:8080`                             | HTTP bind address                                                   |
+| `GRPC_ADDR`                                                   | `0.0.0.0:8081`                             | gRPC bind address                                                   |
+| `JWT_EXPIRY_SECS`                                             | `3600`                                     | JWT lifetime in seconds                                             |
+| `ATOM_JWT_ISSUER`                                             | `ATOM_PUBLIC_BASE_URL`                     | JWT issuer claim                                                    |
+| `ATOM_JWT_AUDIENCE`                                           | `magistrala`                               | JWT audience claim                                                  |
+| `ADMIN_SECRET`                                                | *(optional)*                               | Seeds the admin password on first boot                              |
+| `ADMIN_ENTITY_ID`                                             | `00000000-0000-0000-0000-000000000001`     | Override seeded admin UUID                                          |
+| `ATOM_SERVICE_SECRET` / `ATOM_SERVICE_ENTITY_ID`              | *(optional)* / seeded service UUID         | Seeds a service entity password on first boot                       |
+| `ATOM_MIN_PASSWORD_CHARS`                                     | `12`                                       | Minimum password length                                             |
+| `ATOM_CORS_ALLOWED_ORIGINS`                                   | `ATOM_PUBLIC_BASE_URL`                     | Comma-separated allowed CORS origins                                |
+| `ATOM_AUTH_COOKIE_SECURE` / `ATOM_AUTH_COOKIE_DOMAIN`         | auto-detect HTTPS / *(unset)*              | Auth cookie options for UI flows                                    |
+| `ATOM_SELF_REGISTRATION_ENABLED`                              | `true`                                     | Enables unauthenticated global human self-registration              |
+| `ATOM_UI_REGISTRATION_ENABLED`                                | `true`                                     | UI service only; exposes `/register` and the login-page signup link |
+| `ATOM_SIGNUP_ENABLED`                                         | *(legacy alias)*                           | Backward-compatible alias for `ATOM_SELF_REGISTRATION_ENABLED`      |
+| `ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN`                           | `false`                                    | Development-only password login before email verification           |
+| `ATOM_PUBLIC_BASE_URL`                                        | `http://localhost:8080`                    | Public URL used for issuer and redirect defaults                    |
+| `ATOM_EMAIL_VERIFICATION_REDIRECT`                            | `http://localhost:8080/auth/email/verify`  | URL that verifies email tokens                                      |
+| `ATOM_PASSWORD_RESET_REDIRECT`                                | `http://localhost:8080/reset-password`     | Frontend URL for password reset tokens                              |
+| `ATOM_INVITATION_REDIRECT`                                    | `http://localhost:8080/invitations/accept` | Frontend URL for invitation tokens                                  |
+| `ATOM_OAUTH_SUCCESS_REDIRECT`                                 | `http://localhost:8080/auth/callback`      | Frontend URL that receives the OAuth exchange code                  |
+| `ATOM_OAUTH_ERROR_REDIRECT`                                   | `http://localhost:8080/auth/callback`      | Frontend URL that receives OAuth errors                             |
+| `ATOM_OIDC_PROVIDERS`                                         | `[]`                                       | JSON array of OIDC providers, for example Google                    |
+| `ATOM_EMAIL_VERIFICATION_EXPIRY_SECS`                         | `86400`                                    | Email verification token lifetime                                   |
+| `ATOM_INVITATION_EXPIRY_SECS`                                 | `604800`                                   | Invitation token lifetime                                           |
+| `ATOM_OAUTH_STATE_EXPIRY_SECS`                                | `600`                                      | OAuth state token lifetime                                          |
+| `ATOM_AUTH_EXCHANGE_CODE_EXPIRY_SECS`                         | `300`                                      | OAuth exchange code lifetime                                        |
+| `ATOM_SMTP_HOST` / `ATOM_SMTP_FROM`                           | *(optional)*                               | Required pair for signup and password reset email delivery          |
+| `ATOM_SMTP_PORT` / `ATOM_SMTP_TLS`                            | `587` / `starttls`                         | SMTP port and TLS mode                                              |
+| `ATOM_SMTP_USERNAME` / `ATOM_SMTP_PASSWORD`                   | *(optional)*                               | SMTP credentials                                                    |
+| `ATOM_CERTS_ENABLED`                                          | `true`                                     | Enables certificate lifecycle support                               |
+| `ATOM_CERTS_CA_MODE`                                          | `file_intermediate_issuer`                 | CA mode: `file_intermediate_issuer` or `file_root_issuer`           |
+| `ATOM_CERTS_ROOT_CA_CERT_PATH`                                | *(optional)*                               | Mounted root CA certificate path                                    |
+| `ATOM_CERTS_INTERMEDIATE_CA_CERT_PATH`                        | *(optional)*                               | Mounted intermediate CA certificate path                            |
+| `ATOM_CERTS_INTERMEDIATE_CA_KEY_PATH`                         | *(optional)*                               | Mounted intermediate CA private key path                            |
+| `ATOM_CERTS_ROOT_CA_KEY_PATH`                                 | *(optional)*                               | Mounted root CA private key path for `file_root_issuer`             |
+| `ATOM_CERTS_LEAF_DEFAULT_TTL_SECS`                            | `2592000`                                  | Default issued certificate lifetime                                 |
+| `ATOM_CERTS_LEAF_MAX_TTL_SECS`                                | `2592000`                                  | Maximum issued certificate lifetime                                 |
+| `ATOM_CERTS_CA_DIR`                                           | `./certs`                                  | Docker Compose host directory mounted at `/certs:ro`                |
+| `POSTGRES_HOST_PORT` / `ATOM_HTTP_PORT` / `ATOM_UI_HTTP_PORT` | `5432` / `8080` / `3005`                   | Docker Compose host ports                                           |
+| `ATOM_GRAPHQL_URL`                                            | `http://atom:8080/graphql`                 | GraphQL endpoint used by the Dockerized Next UI                     |
+| `RUST_LOG`                                                    | `info`                                     | Log level filter                                                    |
 
 ---
 
 ## Authentication
 
-The examples below use `http://localhost:8080`, which is the default direct
-`cargo run` address. If you started Atom with `make up`, use
-`http://localhost:18080` instead.
+The examples below use `http://localhost:8080`, the default address for both
+the `make up` Compose backend and a direct `cargo run`.
 
 Authenticated REST, GraphQL, and custom endpoint requests use:
 
@@ -490,7 +532,7 @@ curl -s -X POST http://localhost:8080/auth/email/resend \
   -d '{"email": "alice@example.com"}'
 ```
 
-For local development only, `ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN=true`
+For local development only, `ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=true`
 allows password login before verification while still rejecting inactive or
 suspended entities.
 
@@ -701,17 +743,17 @@ active | inactive | frozen | deleted
 
 ### Magistrala Domain -> Atom Tenant
 
-| Magistrala field | Atom field |
-|---|---|
-| domain `id` | `tenants.id` |
-| domain `name` | `tenants.name` |
-| `route` | `tenants.route` |
-| `metadata` | `tenants.attributes` |
-| `tags` | `tenants.tags` |
-| `enabled` | `status = active` |
-| `disabled` | `status = inactive` |
-| `freezed` | `status = frozen` |
-| `deleted` | `status = deleted` |
+| Magistrala field | Atom field           |
+| ---------------- | -------------------- |
+| domain `id`      | `tenants.id`         |
+| domain `name`    | `tenants.name`       |
+| `route`          | `tenants.route`      |
+| `metadata`       | `tenants.attributes` |
+| `tags`           | `tenants.tags`       |
+| `enabled`        | `status = active`    |
+| `disabled`       | `status = inactive`  |
+| `freezed`        | `status = frozen`    |
+| `deleted`        | `status = deleted`   |
 
 Reuse the Magistrala domain UUID as the Atom `tenants.id`. Objects in that domain carry the same UUID in their `tenant_id` column.
 
@@ -858,17 +900,17 @@ pnpm run deploy
 
 Cloudflare build settings:
 
-| Setting         | Value                         |
-|-----------------|-------------------------------|
-| Build command   | `pnpm run build`              |
-| Deploy command  | `npx wrangler deploy`         |
+| Setting         | Value                          |
+| --------------- | ------------------------------ |
+| Build command   | `pnpm run build`               |
+| Deploy command  | `npx wrangler deploy`          |
 | Version command | `npx wrangler versions upload` |
-| Root directory  | `/docs`                       |
+| Root directory  | `/docs`                        |
 
 Set Cloudflare Workers **Build watch paths** for the `atom-docs` Worker to:
 
 | Setting       | Value    |
-|---------------|----------|
+| ------------- | -------- |
 | Include paths | `docs/*` |
 | Exclude paths | empty    |
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ make dev       # cargo run (:8090) + pnpm dev (:3000), Postgres shared
 | `make up` (Compose) | `:8080` | `:3005` | `:5432`           |
 | `make dev` (host)   | `:8090` | `:3000` | `:5432` (same DB) |
 
+Log in to either with the same admin credentials (`admin` / `12345678`); both
+read `ADMIN_SECRET` from `.env` and share one database.
+
 Run both at once to compare a code change against the released image — they
 share the one Postgres volume. Override ports with `DEV_HTTP_PORT` and
 `DEV_UI_PORT` if needed.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ There is one config file. Copy the example and start the stack:
 # 1. Create your local config
 cp .env.example .env
 
-# 2. Build and start Postgres, Atom, and the Atom Next UI
+# 2. Start Postgres, Atom, and the Atom Next UI
+#    (builds the images the first time; reuses them after)
 make up
 
 # 3. Follow backend and UI logs
@@ -180,11 +181,15 @@ curl -s -X POST http://localhost:8080/auth/login \
   -d '{"identifier": "admin", "secret": "12345678"}'
 ```
 
-Stop or rebuild the stack with:
+`make up` reuses the existing images and does not rebuild. After changing
+backend or UI code, rebuild explicitly:
 
 ```bash
-make down
-make restart
+make build      # or: make atom-build / make ui-build
+make up
+
+make down       # stop the stack
+make restart    # stop and start again (no rebuild)
 ```
 
 GraphQL is available at `POST http://localhost:8080/graphql`. Migrations apply
@@ -292,8 +297,8 @@ Run `make help` to print the current target list from the Makefile.
 | `make build`                | Builds and tags the Atom backend and Atom UI images for local Compose use.             |
 | `make atom-build`           | Builds and tags only the Atom backend image.                                           |
 | `make ui-build`             | Builds and tags only the Atom UI image.                                                |
-| `make up`                   | Builds and starts Postgres, Atom, and Atom UI with `.env`.                             |
-| `make restart`              | Stops the local Compose stack, then rebuilds and starts it again.                      |
+| `make up`                   | Starts Postgres, Atom, and Atom UI with `.env` (builds images only if missing).        |
+| `make restart`              | Stops and starts the Compose stack again (no rebuild; run `make build` first).         |
 | `make logs`                 | Follows Atom backend and Atom UI logs.                                                 |
 | `make down`                 | Stops the local Compose stack.                                                         |
 | `make docker-build`         | Builds the raw Atom Docker image using `BUILD_TARGET`, `IMAGE_NAME`, and `IMAGE_TAG`.  |

--- a/README.md
+++ b/README.md
@@ -201,34 +201,42 @@ make db        # start only Postgres
 cargo run      # Atom on http://localhost:8080
 ```
 
-Do not run `make up` and `cargo run` at the same time — both bind `8080`. Use
-`make db` for the Cargo flow, or override `ATOM_HTTP_PORT` for the Compose
-backend.
+Plain `cargo run` uses `LISTEN_ADDR` from `.env` (`8080`), so it collides with
+`make up`. To run both together, use `make dev` (below), which moves the host
+backend to a separate port.
 
-### UI development
+### UI development and running everything at once
 
-For frontend work, run the Next UI from source against a running backend
-instead of the `atom-ui` container (which would also bind `3005`).
-
-The shortcut runs Postgres (Docker) plus Atom and the UI on the host in one
-command (Ctrl-C stops both; needs host `cargo` and `pnpm`):
+The host dev flow uses its own ports so it can run **alongside** `make up` on
+the same Postgres. `make dev` starts Postgres (Docker) plus Atom and the Next
+UI on the host (Ctrl-C stops both; needs host `cargo` and `pnpm`):
 
 ```bash
-make dev                 # Postgres + cargo run (:8080) + pnpm dev (:3000)
+make dev       # cargo run (:8090) + pnpm dev (:3000), Postgres shared
 ```
 
-Or run the pieces yourself:
+| Flow                | Backend | UI      | Postgres          |
+| ------------------- | ------- | ------- | ----------------- |
+| `make up` (Compose) | `:8080` | `:3005` | `:5432`           |
+| `make dev` (host)   | `:8090` | `:3000` | `:5432` (same DB) |
+
+Run both at once to compare a code change against the released image — they
+share the one Postgres volume. Override ports with `DEV_HTTP_PORT` and
+`DEV_UI_PORT` if needed.
+
+To run the UI pieces yourself instead:
 
 ```bash
-make db && cargo run     # or: make up   (backend on :8080)
+make db && cargo run     # backend on :8080
 
 cd app
 pnpm install
-pnpm dev                 # Next UI on http://localhost:3000
+ATOM_GRAPHQL_URL=http://localhost:8080/graphql pnpm dev   # UI on :3000
 ```
 
-The dev UI calls `http://localhost:8080/graphql` (already allowed by the
-default `ATOM_CORS_ALLOWED_ORIGINS`).
+The dev UI reads the backend GraphQL endpoint from `ATOM_GRAPHQL_URL`
+(server-side). Browser origins `:3000` and `:3005` are already allowed by the
+default `ATOM_CORS_ALLOWED_ORIGINS`.
 
 ### Certificates (optional)
 
@@ -274,19 +282,19 @@ Shared Magistrala/Cube deployments may consume `ghcr.io/absmach/atom:latest` and
 
 Run `make help` to print the current target list from the Makefile.
 
-| Command                     | What it does                                                                          |
-| --------------------------- | ------------------------------------------------------------------------------------- |
-| `make db`                   | Starts only Postgres (for a host `cargo run`).                                        |
-| `make dev`                  | Postgres (Docker) + host `cargo run` + host UI dev server; Ctrl-C stops both.         |
-| `make build`                | Builds and tags the Atom backend and Atom UI images for local Compose use.            |
-| `make atom-build`           | Builds and tags only the Atom backend image.                                          |
-| `make ui-build`             | Builds and tags only the Atom UI image.                                               |
-| `make up`                   | Builds and starts Postgres, Atom, and Atom UI with `.env`.                            |
-| `make restart`              | Stops the local Compose stack, then rebuilds and starts it again.                     |
-| `make logs`                 | Follows Atom backend and Atom UI logs.                                                |
-| `make down`                 | Stops the local Compose stack.                                                        |
-| `make docker-build`         | Builds the raw Atom Docker image using `BUILD_TARGET`, `IMAGE_NAME`, and `IMAGE_TAG`. |
-| `make docker-build-release` | Builds the raw release Docker image.                                                  |
+| Command                     | What it does                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `make db`                   | Starts only Postgres (for a host `cargo run`).                                         |
+| `make dev`                  | Host `cargo run` (:8090) + UI dev (:3000) on the shared Postgres; runs with `make up`. |
+| `make build`                | Builds and tags the Atom backend and Atom UI images for local Compose use.             |
+| `make atom-build`           | Builds and tags only the Atom backend image.                                           |
+| `make ui-build`             | Builds and tags only the Atom UI image.                                                |
+| `make up`                   | Builds and starts Postgres, Atom, and Atom UI with `.env`.                             |
+| `make restart`              | Stops the local Compose stack, then rebuilds and starts it again.                      |
+| `make logs`                 | Follows Atom backend and Atom UI logs.                                                 |
+| `make down`                 | Stops the local Compose stack.                                                         |
+| `make docker-build`         | Builds the raw Atom Docker image using `BUILD_TARGET`, `IMAGE_NAME`, and `IMAGE_TAG`.  |
+| `make docker-build-release` | Builds the raw release Docker image.                                                   |
 
 Common overrides:
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -12,4 +12,4 @@ ATOM_ADMIN_SECRET=change-me
 ATOM_MIN_PASSWORD_CHARS=12
 
 # Must match the backend value — skips the "check your email" step after signup.
-# ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN=false
+# ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=false

--- a/app/.env.example
+++ b/app/.env.example
@@ -2,14 +2,15 @@
 # cp .env.example .env
 
 # GraphQL endpoint exposed by the Atom backend (server-side only).
-ATOM_GRAPHQL_URL=http://127.0.0.1:8081/graphql
+# 8080 = the `make up` backend. Use 8090 for the host `make dev` backend.
+ATOM_GRAPHQL_URL=http://localhost:8080/graphql
 
 # Credentials for the bootstrap admin entity created by migrations.
-ATOM_ADMIN_IDENTIFIER=atom-admin
-ATOM_ADMIN_SECRET=change-me
+ATOM_ADMIN_IDENTIFIER=admin
+ATOM_ADMIN_SECRET=12345678
 
 # Minimum password length — must match the backend ATOM_MIN_PASSWORD_CHARS value.
-ATOM_MIN_PASSWORD_CHARS=12
+ATOM_MIN_PASSWORD_CHARS=8
 
 # Must match the backend value — skips the "check your email" step after signup.
-# ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=false
+ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
       ATOM_PASSWORD_RESET_REDIRECT: ${ATOM_PASSWORD_RESET_REDIRECT:-http://localhost:3005/reset-password}
       ATOM_INVITATION_REDIRECT: ${ATOM_INVITATION_REDIRECT:-http://localhost:3005/invitations/accept}
       ATOM_SELF_REGISTRATION_ENABLED: ${ATOM_SELF_REGISTRATION_ENABLED:-${ATOM_SIGNUP_ENABLED:-true}}
+      ATOM_PUBLIC_BASE_URL: ${ATOM_PUBLIC_BASE_URL:-http://localhost:8080}
+      ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN: "${ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN:-false}"
+      ATOM_OIDC_PROVIDERS: ${ATOM_OIDC_PROVIDERS:-}
       RUST_LOG: info
     volumes:
       - ${ATOM_CERTS_CA_DIR:-./certs}:/certs:ro
@@ -52,47 +55,6 @@ services:
       - "${ATOM_HTTP_PORT:-8080}:8080"
     profiles:
       - default
-
-  atom-dev:
-    image: ${ATOM_DEV_IMAGE:-ghcr.io/absmach/atom:dev}
-    build:
-      context: .
-      target: dev
-    depends_on:
-      postgres:
-        condition: service_healthy
-    environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-atom}:${POSTGRES_PASSWORD:-atom-dev-only}@postgres:5432/${POSTGRES_DB:-atom}
-      LISTEN_ADDR: 0.0.0.0:8080
-      GRPC_ADDR: 0.0.0.0:8081
-      JWT_EXPIRY_SECS: 3600
-      ADMIN_SECRET: ${ADMIN_SECRET:-atom-dev-admin-password}
-      ATOM_CERTS_ENABLED: ${ATOM_CERTS_ENABLED:-true}
-      ATOM_CERTS_CA_MODE: ${ATOM_CERTS_CA_MODE:-file_intermediate_issuer}
-      ATOM_CERTS_ROOT_CA_CERT_PATH: ${ATOM_CERTS_ROOT_CA_CERT_PATH:-/certs/root-ca.crt}
-      ATOM_CERTS_INTERMEDIATE_CA_CERT_PATH: ${ATOM_CERTS_INTERMEDIATE_CA_CERT_PATH:-/certs/intermediate-ca.crt}
-      ATOM_CERTS_INTERMEDIATE_CA_KEY_PATH: ${ATOM_CERTS_INTERMEDIATE_CA_KEY_PATH:-/certs/intermediate-ca.key}
-      ATOM_CERTS_ROOT_CA_KEY_PATH: ${ATOM_CERTS_ROOT_CA_KEY_PATH:-}
-      ATOM_CERTS_LEAF_DEFAULT_TTL_SECS: ${ATOM_CERTS_LEAF_DEFAULT_TTL_SECS:-2592000}
-      ATOM_CERTS_LEAF_MAX_TTL_SECS: ${ATOM_CERTS_LEAF_MAX_TTL_SECS:-2592000}
-      ATOM_MIN_PASSWORD_CHARS: ${ATOM_MIN_PASSWORD_CHARS:-12}
-      ATOM_CORS_ALLOWED_ORIGINS: ${ATOM_CORS_ALLOWED_ORIGINS:-http://localhost:8080,http://localhost:3005}
-      ATOM_PUBLIC_BASE_URL: ${ATOM_PUBLIC_BASE_URL:-http://localhost:8081}
-      ATOM_EMAIL_VERIFICATION_REDIRECT: ${ATOM_EMAIL_VERIFICATION_REDIRECT:-http://localhost:8081/auth/email/verify}
-      ATOM_OAUTH_SUCCESS_REDIRECT: ${ATOM_OAUTH_SUCCESS_REDIRECT:-http://localhost:3005/auth/callback}
-      ATOM_OAUTH_ERROR_REDIRECT: ${ATOM_OAUTH_ERROR_REDIRECT:-http://localhost:3005/auth/callback}
-      ATOM_PASSWORD_RESET_REDIRECT: ${ATOM_PASSWORD_RESET_REDIRECT:-http://localhost:3005/reset-password}
-      ATOM_INVITATION_REDIRECT: ${ATOM_INVITATION_REDIRECT:-http://localhost:3005/invitations/accept}
-      ATOM_SELF_REGISTRATION_ENABLED: ${ATOM_SELF_REGISTRATION_ENABLED:-${ATOM_SIGNUP_ENABLED:-true}}
-      ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN: "${ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN:-false}"
-      ATOM_OIDC_PROVIDERS: ${ATOM_OIDC_PROVIDERS:-}
-      RUST_LOG: info
-    volumes:
-      - ${ATOM_CERTS_CA_DIR:-./certs}:/certs:ro
-    ports:
-      - "${ATOM_DEV_HTTP_PORT:-8081}:8080"
-    profiles:
-      - dev
 
   atom-ui:
     image: ${ATOM_UI_IMAGE:-ghcr.io/absmach/atom-ui:latest}

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,19 +23,19 @@ This site follows the same Cloudflare Workers static-assets pattern used by the 
 
 ### Cloudflare Build Settings
 
-| Setting         | Value                         |
-|-----------------|-------------------------------|
-| Build command   | `pnpm run build`              |
-| Deploy command  | `npx wrangler deploy`         |
+| Setting         | Value                          |
+| --------------- | ------------------------------ |
+| Build command   | `pnpm run build`               |
+| Deploy command  | `npx wrangler deploy`          |
 | Version command | `npx wrangler versions upload` |
-| Root directory  | `/docs`                       |
+| Root directory  | `/docs`                        |
 
 ### Cloudflare Build Watch Paths
 
 Configure this in the Cloudflare dashboard for the `atom-docs` Worker:
 
 | Setting       | Value    |
-|---------------|----------|
+| ------------- | -------- |
 | Include paths | `docs/*` |
 | Exclude paths | empty    |
 
@@ -73,10 +73,10 @@ NEXT_PUBLIC_BASE_URL=https://www.absmach.eu/docs/atom
 
 ## Project Structure
 
-| Path                              | Description                                |
-|-----------------------------------|--------------------------------------------|
-| `app/[[...slug]]/page.tsx`        | Docs page renderer                         |
-| `content/docs`                    | MDX source files                           |
-| `lib/source.ts`                   | Fumadocs source adapter                    |
-| `scripts/nest-static-export.mjs`  | Moves static export under `/docs/atom`     |
-| `wrangler.jsonc`                  | Cloudflare Workers static-assets config    |
+| Path                             | Description                             |
+| -------------------------------- | --------------------------------------- |
+| `app/[[...slug]]/page.tsx`       | Docs page renderer                      |
+| `content/docs`                   | MDX source files                        |
+| `lib/source.ts`                  | Fumadocs source adapter                 |
+| `scripts/nest-static-export.mjs` | Moves static export under `/docs/atom`  |
+| `wrangler.jsonc`                 | Cloudflare Workers static-assets config |

--- a/docs/content/docs/authentication/credentials.mdx
+++ b/docs/content/docs/authentication/credentials.mdx
@@ -63,7 +63,7 @@ curl -X POST http://localhost:8080/auth/email/resend \
   -d '{"email": "alice@example.com"}'
 ```
 
-`ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN=true` allows local development login
+`ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN=true` allows local development login
 before email verification, but inactive and suspended entities are still
 rejected.
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -7,8 +7,8 @@ description: Get Atom running and make your first authorization check.
 
 - Docker and Docker Compose
 - `make`
-- `openssl` for local dev certificate files
 - `jq` for command examples
+- `openssl` only if you enable certificates (off by default in dev env)
 
 ## Steps
 
@@ -18,11 +18,13 @@ description: Get Atom running and make your first authorization check.
 ### Create Local Dev Config
 
 ```bash
-make dev-env
+cp .env.example .env
 ```
 
-This creates `.env.dev` with local defaults and generates local root CA files
-under `certs/` if they do not already exist.
+There is one config file. `.env.example` ships working local defaults — admin
+login `admin` / `12345678`, password login allowed before email verification,
+and certificates disabled — so a fresh copy boots with no SMTP, OAuth, or CA
+setup. Edit `ADMIN_SECRET` before first boot to change the admin password.
 
 </Step>
 <Step>
@@ -35,12 +37,9 @@ make up
 
 This builds and starts:
 
-- Atom REST and GraphQL at `http://localhost:18080`
+- Atom REST and GraphQL at `http://localhost:8080`
 - Atom Next UI at `http://localhost:3005`
 - Postgres at `127.0.0.1:5432`
-
-The default local admin password in `.env.dev` is `12345678`. Edit
-`ADMIN_SECRET` in `.env.dev` before first boot if you want a different password.
 
 </Step>
 <Step>
@@ -59,9 +58,9 @@ Atom applies migrations automatically on startup.
 ### Log In
 
 ```bash
-TOKEN=$(curl -s -X POST http://localhost:18080/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:8080/auth/login \
   -H 'Content-Type: application/json' \
-  -d '{"identifier": "atom-admin", "secret": "12345678"}' \
+  -d '{"identifier": "admin", "secret": "12345678"}' \
   | jq -r .token)
 ```
 
@@ -70,10 +69,10 @@ TOKEN=$(curl -s -X POST http://localhost:18080/auth/login \
 
 ### Create A Tenant, Device, And Channel
 
-Use GraphQL at `POST http://localhost:18080/graphql`.
+Use GraphQL at `POST http://localhost:8080/graphql`.
 
 ```bash
-curl -s http://localhost:18080/graphql \
+curl -s http://localhost:8080/graphql \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{
@@ -221,7 +220,8 @@ Run `make help` for the current target list.
 
 | Command | What it does |
 |---|---|
-| `make dev-env` | Creates `.env.dev` with local defaults and local dev CA files. |
+| `make db` | Starts only Postgres (for a host `cargo run`). |
+| `make dev` | Postgres (Docker) + host `cargo run` + host UI dev server; Ctrl-C stops both. |
 | `make up` | Builds and starts Postgres, Atom, and Atom UI. |
 | `make logs` | Follows Atom backend and Atom UI logs. |
 | `make down` | Stops the local Compose stack. |
@@ -231,7 +231,6 @@ Run `make help` for the current target list.
 | `make ui-build` | Builds only the Atom UI image. |
 | `make docker-build` | Builds the raw Atom Docker image using Makefile variables. |
 | `make docker-build-release` | Builds the raw release Docker image. |
-| `make docker-build-dev` | Builds the raw dev Docker image. |
 
 Common overrides:
 
@@ -248,20 +247,43 @@ COMPOSE_PROFILES="--profile default" make up
 
 ## Direct Cargo Development
 
-Use this path when you want to run the Rust service directly on your host
-instead of inside the Compose backend:
+Run the Rust service on your host and keep only Postgres in Docker. Postgres is
+published on `127.0.0.1:5432` and `.env` points `DATABASE_URL` at
+`localhost:5432`, so this works with no extra setup:
 
 ```bash
-cp .env.example .env
-# set ADMIN_SECRET on first boot
-# set ATOM_CERTS_ENABLED=false for a minimal local run, or configure cert paths
-
-docker compose --env-file .env up -d postgres
-cargo run
+make db        # start only Postgres
+cargo run      # Atom on http://localhost:8080
 ```
 
-The direct Cargo backend listens on `http://localhost:8080` by default. The
-Makefile Compose backend listens on `http://localhost:18080`.
+Both the Cargo backend and the `make up` Compose backend bind
+`http://localhost:8080`, so run only one at a time (`make db` for Cargo, or
+override `ATOM_HTTP_PORT` for the Compose flow).
+
+## UI Development
+
+For frontend work, run the Next UI from source against a running backend
+instead of the `atom-ui` container (which also binds `3005`).
+
+The shortcut runs Postgres (Docker) plus Atom and the UI on the host in one
+command (Ctrl-C stops both; needs host `cargo` and `pnpm`):
+
+```bash
+make dev                 # Postgres + cargo run (:8080) + pnpm dev (:3000)
+```
+
+Or run the pieces yourself:
+
+```bash
+make db && cargo run     # or: make up   (backend on :8080)
+
+cd app
+pnpm install
+pnpm dev                 # Next UI on http://localhost:3000
+```
+
+The dev UI calls `http://localhost:8080/graphql`, already allowed by the
+default `ATOM_CORS_ALLOWED_ORIGINS` in `.env`.
 
 ## What Just Happened
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -35,11 +35,14 @@ setup. Edit `ADMIN_SECRET` before first boot to change the admin password.
 make up
 ```
 
-This builds and starts:
+This starts (building the images the first time, then reusing them):
 
 - Atom REST and GraphQL at `http://localhost:8080`
 - Atom Next UI at `http://localhost:3005`
 - Postgres at `127.0.0.1:5432`
+
+After changing backend or UI code, rebuild with `make build` (or
+`make atom-build` / `make ui-build`) before `make up`.
 
 </Step>
 <Step>
@@ -218,19 +221,19 @@ Expected result:
 
 Run `make help` for the current target list.
 
-| Command | What it does |
-|---|---|
-| `make db` | Starts only Postgres (for a host `cargo run`). |
-| `make dev` | Host `cargo run` (:8090) + UI dev (:3000) on the shared Postgres; runs with `make up`. |
-| `make up` | Builds and starts Postgres, Atom, and Atom UI. |
-| `make logs` | Follows Atom backend and Atom UI logs. |
-| `make down` | Stops the local Compose stack. |
-| `make restart` | Stops, rebuilds, and starts the local Compose stack again. |
-| `make build` | Builds Atom backend and Atom UI images. |
-| `make atom-build` | Builds only the Atom backend image. |
-| `make ui-build` | Builds only the Atom UI image. |
-| `make docker-build` | Builds the raw Atom Docker image using Makefile variables. |
-| `make docker-build-release` | Builds the raw release Docker image. |
+| Command                     | What it does                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `make db`                   | Starts only Postgres (for a host `cargo run`).                                         |
+| `make dev`                  | Host `cargo run` (:8090) + UI dev (:3000) on the shared Postgres; runs with `make up`. |
+| `make up`                   | Starts Postgres, Atom, and Atom UI (builds images only if missing).                    |
+| `make logs`                 | Follows Atom backend and Atom UI logs.                                                 |
+| `make down`                 | Stops the local Compose stack.                                                         |
+| `make restart`              | Stops and starts the Compose stack again (no rebuild).                                 |
+| `make build`                | Builds Atom backend and Atom UI images.                                                |
+| `make atom-build`           | Builds only the Atom backend image.                                                    |
+| `make ui-build`             | Builds only the Atom UI image.                                                         |
+| `make docker-build`         | Builds the raw Atom Docker image using Makefile variables.                             |
+| `make docker-build-release` | Builds the raw release Docker image.                                                   |
 
 Common overrides:
 
@@ -270,10 +273,10 @@ UI on the host (Ctrl-C stops both; needs host `cargo` and `pnpm`):
 make dev                 # cargo run (:8090) + pnpm dev (:3000), Postgres shared
 ```
 
-| Flow | Backend | UI | Postgres |
-| --- | --- | --- | --- |
-| `make up` (Compose) | `:8080` | `:3005` | `:5432` |
-| `make dev` (host) | `:8090` | `:3000` | `:5432` (same DB) |
+| Flow                | Backend | UI      | Postgres          |
+| ------------------- | ------- | ------- | ----------------- |
+| `make up` (Compose) | `:8080` | `:3005` | `:5432`           |
+| `make dev` (host)   | `:8090` | `:3000` | `:5432` (same DB) |
 
 Log in to either with the same admin credentials (`admin` / `12345678`); both
 read `ADMIN_SECRET` from `.env` and share one database.

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -221,7 +221,7 @@ Run `make help` for the current target list.
 | Command | What it does |
 |---|---|
 | `make db` | Starts only Postgres (for a host `cargo run`). |
-| `make dev` | Postgres (Docker) + host `cargo run` + host UI dev server; Ctrl-C stops both. |
+| `make dev` | Host `cargo run` (:8090) + UI dev (:3000) on the shared Postgres; runs with `make up`. |
 | `make up` | Builds and starts Postgres, Atom, and Atom UI. |
 | `make logs` | Follows Atom backend and Atom UI logs. |
 | `make down` | Stops the local Compose stack. |
@@ -256,34 +256,41 @@ make db        # start only Postgres
 cargo run      # Atom on http://localhost:8080
 ```
 
-Both the Cargo backend and the `make up` Compose backend bind
-`http://localhost:8080`, so run only one at a time (`make db` for Cargo, or
-override `ATOM_HTTP_PORT` for the Compose flow).
+Plain `cargo run` uses `LISTEN_ADDR` from `.env` (`8080`), so it collides with
+`make up`. To run both at once, use `make dev` (below), which moves the host
+backend to a separate port.
 
-## UI Development
+## UI Development And Running Everything At Once
 
-For frontend work, run the Next UI from source against a running backend
-instead of the `atom-ui` container (which also binds `3005`).
-
-The shortcut runs Postgres (Docker) plus Atom and the UI on the host in one
-command (Ctrl-C stops both; needs host `cargo` and `pnpm`):
+The host dev flow uses its own ports so it can run **alongside** `make up` on
+the same Postgres. `make dev` starts Postgres (Docker) plus Atom and the Next
+UI on the host (Ctrl-C stops both; needs host `cargo` and `pnpm`):
 
 ```bash
-make dev                 # Postgres + cargo run (:8080) + pnpm dev (:3000)
+make dev                 # cargo run (:8090) + pnpm dev (:3000), Postgres shared
 ```
 
-Or run the pieces yourself:
+| Flow | Backend | UI | Postgres |
+| --- | --- | --- | --- |
+| `make up` (Compose) | `:8080` | `:3005` | `:5432` |
+| `make dev` (host) | `:8090` | `:3000` | `:5432` (same DB) |
+
+Run both together to compare a code change against the released image — they
+share one Postgres volume. Override with `DEV_HTTP_PORT` / `DEV_UI_PORT`.
+
+To run the UI pieces yourself instead:
 
 ```bash
-make db && cargo run     # or: make up   (backend on :8080)
+make db && cargo run     # backend on :8080
 
 cd app
 pnpm install
-pnpm dev                 # Next UI on http://localhost:3000
+ATOM_GRAPHQL_URL=http://localhost:8080/graphql pnpm dev   # UI on :3000
 ```
 
-The dev UI calls `http://localhost:8080/graphql`, already allowed by the
-default `ATOM_CORS_ALLOWED_ORIGINS` in `.env`.
+The dev UI reads the backend GraphQL endpoint from `ATOM_GRAPHQL_URL`
+(server-side). Origins `:3000` and `:3005` are already allowed by the default
+`ATOM_CORS_ALLOWED_ORIGINS` in `.env`.
 
 ## What Just Happened
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -275,6 +275,9 @@ make dev                 # cargo run (:8090) + pnpm dev (:3000), Postgres shared
 | `make up` (Compose) | `:8080` | `:3005` | `:5432` |
 | `make dev` (host) | `:8090` | `:3000` | `:5432` (same DB) |
 
+Log in to either with the same admin credentials (`admin` / `12345678`); both
+read `ADMIN_SECRET` from `.env` and share one database.
+
 Run both together to compare a code change against the released image — they
 share one Postgres volume. Override with `DEV_HTTP_PORT` / `DEV_UI_PORT`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,7 +110,7 @@ impl Config {
                 "ATOM_SIGNUP_ENABLED",
                 true,
             ),
-            dev_allow_unverified_email_login: env_bool("ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN"),
+            dev_allow_unverified_email_login: env_bool("ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN"),
             cors_allowed_origins: parse_cors_allowed_origins(&public_base_url),
             auth_cookie_secure: std::env::var("ATOM_AUTH_COOKIE_SECURE")
                 .map(|_| env_bool("ATOM_AUTH_COOKIE_SECURE"))


### PR DESCRIPTION
- Collapse to a single .env (cp .env.example .env); remove make dev-env
- Ship working local defaults in .env.example: admin login, unverified email login, certificates disabled, so a fresh copy boots with no SMTP/OAuth/CA setup
- Remove the dev Docker image and atom-dev service; keep one release image and fold the dev-only env knobs into the atom service
- Unify the Cargo and Compose flows on one Postgres volume and port 8080
- Add `make db` (Postgres only) and `make dev` (Postgres + cargo run + UI)
- Rename ATOM_DEV_ALLOW_UNVERIFIED_EMAIL_LOGIN to ATOM_ALLOW_UNVERIFIED_EMAIL_LOGIN
- Fix the admin login identifier in docs (admin, not atom-admin)
- Document the local run flows in README and quickstart

<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is an enhancement.
<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
This simplifies running Atom locally.

## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->
There is no such issue.
## Have you included tests for your changes?
N/A
But I did test locally.

## Did you document any new/modified features?
Yes.

### Notes
N/A
