### PR TITLE
add sitemap generation

### DIFF
--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { source } from '@/lib/source';
+
+type Sitemap = {
+  url: string;
+  changeFrequency: 'weekly';
+  priority: number;
+}[];
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_BASE_URL || 'https://www.absmach.eu/docs/atom';
+const normalizedBaseUrl = baseUrl.replace(/\/$/, '');
+
+export const dynamic = 'force-static';
+
+function toSiteUrl(path: string): string {
+  const url = `${normalizedBaseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+export default function sitemap(): Sitemap {
+  return source.getPages().map((page) => ({
+    url: toSiteUrl(page.url),
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }));
+}


### PR DESCRIPTION
Adds a static App Router sitemap route for Atom docs. Generated URLs are based on NEXT_PUBLIC_BASE_URL and normalized with trailing slashes to match the deployed docs routes.

Verification:
- npx tsc --noEmit
- pnpm build
- Confirmed generated sitemap loc entries end with trailing slashes
