### PR TITLE
Fix docs navigation and font

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,11 +1,14 @@
 import type { ReactNode } from 'react';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { Metadata } from 'next';
+import { Rubik } from 'next/font/google';
 import { baseOptions } from '@/app/layout.config';
 import { source } from '@/lib/source';
 import { Provider } from '@/components/provider';
 import 'fumadocs-ui/style.css';
 import './global.css';
+
+const rubik = Rubik({ subsets: ['latin'], variable: '--font-rubik' });
 
 export const metadata: Metadata = {
   title: {
@@ -17,10 +20,10 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body>
+    <html lang="en" className={rubik.variable} suppressHydrationWarning>
+      <body className={rubik.className}>
         <Provider>
-          <DocsLayout tree={source.pageTree} {...baseOptions}>
+          <DocsLayout tree={source.getPageTree()} {...baseOptions}>
             {children}
           </DocsLayout>
         </Provider>

--- a/docs/content/docs/access-control/meta.json
+++ b/docs/content/docs/access-control/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Access Control",
-  "pages": ["index", "rbac", "abac", "policies", "assignment-guardrails", "evaluation"]
+  "pages": ["rbac", "abac", "policies", "assignment-guardrails", "evaluation"]
 }

--- a/docs/content/docs/architecture/meta.json
+++ b/docs/content/docs/architecture/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Architecture",
-  "pages": ["index", "data-model"]
+  "pages": ["data-model"]
 }

--- a/docs/content/docs/authentication/meta.json
+++ b/docs/content/docs/authentication/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Authentication",
-  "pages": ["index", "credentials", "certificates", "jwt", "jwks"]
+  "pages": ["credentials", "certificates", "jwt", "jwks"]
 }

--- a/docs/content/docs/queries/meta.json
+++ b/docs/content/docs/queries/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Queries & Search",
   "pages": [
-    "index",
     "authz-explain",
     "entity-access",
     "resource-access",

--- a/docs/content/docs/user-guide/meta.json
+++ b/docs/content/docs/user-guide/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "User Guide",
   "pages": [
-    "index",
     "quick-start",
     "dashboard",
     "tenants",


### PR DESCRIPTION
## Summary

- Apply the Rubik font to Atom docs via `next/font/google`, matching Magistrala docs.
- Remove folder-level `index` entries from docs `meta.json` files so Fumadocs does not render duplicate folder index pages in footer navigation.
- Keep the default Fumadocs page/footer behavior instead of adding custom pagination logic.

## Root cause

Atom listed `index` inside folder `pages` arrays. Fumadocs already treats `index.mdx` as the folder index, so those entries appeared twice in the page tree and caused footer navigation on folder index pages to point back to the same page.

## Validation

- `pnpm build` from `docs/`
- Spot-checked generated footer links for root, User Guide, Architecture, and Access Control pages.