### PR TITLE
Add encrypted CA key provider abstraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@ ATOM_KEY_ENCRYPTION_KEY_ID=local:v1
 # Local/dev only. Production should leave this false.
 ATOM_ALLOW_PLAINTEXT_SIGNING_KEYS=false
 
+# Managed CA keys use a separate KEK. It is required only after an authority
+# uses key_backend=encrypted_database; public-only roots do not need it.
+# Generate a different value from ATOM_KEY_ENCRYPTION_KEY:
+#   openssl rand -base64 32
+# ATOM_PKI_CA_KEY_ENCRYPTION_KEY=
+ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID=local-ca:v1
+
 # --- Postgres pool controls --------------------------------------------
 ATOM_DB_MAX_CONNECTIONS=20
 ATOM_DB_MIN_CONNECTIONS=0

--- a/product-docs/development/pki/pr-002-key-provider.md
+++ b/product-docs/development/pki/pr-002-key-provider.md
@@ -1,5 +1,9 @@
 # PR-002 — CA Key Provider Abstraction
 
+## Status
+
+Implemented by the PR-002 delivery branch.
+
 ## Objective
 
 Introduce an Atom-owned signing/key-provider interface and an encrypted-database implementation without changing certificate issuance routing.
@@ -38,6 +42,19 @@ Encrypt/decrypt round trip, AAD mismatch, wrong KEK, ciphertext corruption, key-
 ## Rollback
 
 No encrypted authority may be activated until this PR is deployed everywhere. Rollback is safe while no production rows use the new backend.
+
+## Operator configuration
+
+- `ATOM_PKI_CA_KEY_ENCRYPTION_KEY` is the dedicated, base64-encoded 32-byte CA
+  KEK. It must not reuse `ATOM_KEY_ENCRYPTION_KEY`.
+- `ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID` is the operator-visible key identifier
+  written with encrypted authority material. Its default is `local-ca:v1`.
+- The CA KEK may be omitted while no `encrypted_database` authority exists.
+  Startup fails closed when an encrypted authority references a missing key,
+  another key ID, or an unsupported encryption algorithm.
+- Changing the configured key ID does not silently decrypt old rows. Operators
+  must retain/reconfigure the matching KEK until a reviewed rewrap procedure is
+  available; a mismatch stops startup and signing.
 
 ## AI execution prompt
 

--- a/src/certs/authority/key_provider.rs
+++ b/src/certs/authority/key_provider.rs
@@ -1,0 +1,792 @@
+//! Atom-owned CA signing boundary.
+//!
+//! The encrypted-database provider implemented here is deliberately independent
+//! of certificate issuance. Later providers (PKCS#11, KMS, or the legacy file
+//! bridge) can implement [`AuthorityKeyProvider`] without changing public APIs.
+
+use std::fmt;
+
+use p256::{
+    ecdsa::{signature::Signer, Signature, SigningKey},
+    pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey},
+};
+use rand::{rngs::OsRng, RngCore};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::{
+    config::PkiCaKeyConfig,
+    crypto,
+    error::AppError,
+    metrics,
+};
+
+use super::{repo, AuthorityKeyBackend, AuthorityRecord};
+
+const PROVIDER_NAME: &str = "encrypted_database";
+const ENCRYPTION_ALGORITHM: &str = crypto::AEAD_ALG;
+const DEK_LEN: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityKeyAlgorithm {
+    EcdsaP256Sha256,
+}
+
+impl AuthorityKeyAlgorithm {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EcdsaP256Sha256 => "ecdsa_p256_sha256",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthoritySignatureAlgorithm {
+    EcdsaP256Sha256,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthorityKeyContext {
+    pub authority_id: Uuid,
+    pub tenant_id: Option<Uuid>,
+    pub version: i32,
+}
+
+impl AuthorityKeyContext {
+    fn aad(self, purpose: &'static str) -> Vec<u8> {
+        let tenant = self
+            .tenant_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "global".to_string());
+        format!(
+            "atom:pki:authority-key:v1:{purpose}:{}:{tenant}:{}",
+            self.authority_id, self.version
+        )
+        .into_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityKeyProviderStatus {
+    Ready,
+    Unconfigured,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthorityKeyProviderHealth {
+    pub backend: AuthorityKeyBackend,
+    pub status: AuthorityKeyProviderStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthorityKeyMetadata {
+    pub backend: AuthorityKeyBackend,
+    pub key_algorithm: AuthorityKeyAlgorithm,
+    pub key_encryption_key_id: String,
+    pub encryption_algorithm: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorityPublicKey {
+    pub algorithm: AuthorityKeyAlgorithm,
+    /// SubjectPublicKeyInfo DER. This is public material.
+    pub subject_public_key_info_der: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthoritySignature {
+    pub algorithm: AuthoritySignatureAlgorithm,
+    /// ASN.1 DER encoded ECDSA signature. This is not private-key material.
+    pub bytes: Vec<u8>,
+}
+
+/// Opaque database representation of one encrypted CA key.
+///
+/// It intentionally does not implement `Serialize`. Its custom `Debug` omits
+/// ciphertext, nonces, wrapped DEKs, and external key references.
+pub struct EncryptedAuthorityKey {
+    pub(crate) encrypted_private_key: Vec<u8>,
+    pub(crate) private_key_nonce: Vec<u8>,
+    pub(crate) wrapped_dek: Vec<u8>,
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    pub(crate) key_encryption_key_id: String,
+    pub(crate) encryption_algorithm: String,
+    key_algorithm: AuthorityKeyAlgorithm,
+    destroyed: bool,
+}
+
+impl fmt::Debug for EncryptedAuthorityKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedAuthorityKey")
+            .field("backend", &AuthorityKeyBackend::EncryptedDatabase)
+            .field("key_algorithm", &self.key_algorithm)
+            .field("key_encryption_key_id", &self.key_encryption_key_id)
+            .field("encryption_algorithm", &self.encryption_algorithm)
+            .field("destroyed", &self.destroyed)
+            .field("key_material", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl Drop for EncryptedAuthorityKey {
+    fn drop(&mut self) {
+        self.encrypted_private_key.zeroize();
+        self.private_key_nonce.zeroize();
+        self.wrapped_dek.zeroize();
+        self.wrapped_dek_nonce.zeroize();
+    }
+}
+
+impl EncryptedAuthorityKey {
+    pub fn from_authority(authority: &AuthorityRecord) -> Result<Self, AuthorityKeyProviderError> {
+        if authority.key_backend != AuthorityKeyBackend::EncryptedDatabase {
+            return Err(AuthorityKeyProviderError::WrongBackend);
+        }
+        Self::from_columns(
+            authority.encrypted_private_key.clone(),
+            authority.private_key_nonce.clone(),
+            authority.wrapped_dek.clone(),
+            authority.wrapped_dek_nonce.clone(),
+            authority.key_encryption_key_id.clone(),
+            authority.encryption_algorithm.clone(),
+        )
+    }
+
+    fn from_columns(
+        encrypted_private_key: Option<Vec<u8>>,
+        private_key_nonce: Option<Vec<u8>>,
+        wrapped_dek: Option<Vec<u8>>,
+        wrapped_dek_nonce: Option<Vec<u8>>,
+        key_encryption_key_id: Option<String>,
+        encryption_algorithm: Option<String>,
+    ) -> Result<Self, AuthorityKeyProviderError> {
+        Ok(Self {
+            encrypted_private_key: required(encrypted_private_key, "encrypted_private_key")?,
+            private_key_nonce: required(private_key_nonce, "private_key_nonce")?,
+            wrapped_dek: required(wrapped_dek, "wrapped_dek")?,
+            wrapped_dek_nonce: required(wrapped_dek_nonce, "wrapped_dek_nonce")?,
+            key_encryption_key_id: required(
+                key_encryption_key_id,
+                "key_encryption_key_id",
+            )?,
+            encryption_algorithm: required(encryption_algorithm, "encryption_algorithm")?,
+            key_algorithm: AuthorityKeyAlgorithm::EcdsaP256Sha256,
+            destroyed: false,
+        })
+    }
+
+    pub fn metadata(&self) -> AuthorityKeyMetadata {
+        AuthorityKeyMetadata {
+            backend: AuthorityKeyBackend::EncryptedDatabase,
+            key_algorithm: self.key_algorithm,
+            key_encryption_key_id: self.key_encryption_key_id.clone(),
+            encryption_algorithm: self.encryption_algorithm.clone(),
+        }
+    }
+
+    fn ensure_usable(&self) -> Result<(), AuthorityKeyProviderError> {
+        if self.destroyed {
+            return Err(AuthorityKeyProviderError::Destroyed);
+        }
+        if self.encryption_algorithm != ENCRYPTION_ALGORITHM {
+            return Err(AuthorityKeyProviderError::UnsupportedEncryptionAlgorithm);
+        }
+        Ok(())
+    }
+
+    fn destroy(&mut self) {
+        self.encrypted_private_key.zeroize();
+        self.encrypted_private_key.clear();
+        self.private_key_nonce.zeroize();
+        self.private_key_nonce.clear();
+        self.wrapped_dek.zeroize();
+        self.wrapped_dek.clear();
+        self.wrapped_dek_nonce.zeroize();
+        self.wrapped_dek_nonce.clear();
+        self.destroyed = true;
+    }
+}
+
+fn required<T>(value: Option<T>, field: &'static str) -> Result<T, AuthorityKeyProviderError> {
+    value.ok_or(AuthorityKeyProviderError::MissingField(field))
+}
+
+#[derive(Debug)]
+pub struct GeneratedAuthorityKey<K> {
+    pub public_key: AuthorityPublicKey,
+    pub key: K,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AuthorityKeyProviderError {
+    #[error("CA key provider is not configured")]
+    Unconfigured,
+    #[error("authority key belongs to a different provider backend")]
+    WrongBackend,
+    #[error("encrypted authority key is missing {0}")]
+    MissingField(&'static str),
+    #[error("encrypted authority key uses an unavailable CA KEK id")]
+    KeyEncryptionKeyIdMismatch,
+    #[error("encrypted authority key uses an unsupported encryption algorithm")]
+    UnsupportedEncryptionAlgorithm,
+    #[error("authority key uses an unsupported signing algorithm")]
+    UnsupportedKeyAlgorithm,
+    #[error("authority key cryptographic operation failed")]
+    CryptographicFailure,
+    #[error("authority key has been destroyed")]
+    Destroyed,
+}
+
+/// Provider-neutral CA key operations. Certificate services depend on this
+/// interface rather than database encryption, PKCS#11, KMS, or file details.
+pub trait AuthorityKeyProvider: Send + Sync {
+    /// Provider-owned opaque handle. File, PKCS#11, and KMS implementations can
+    /// use their own handle without exposing it to certificate services.
+    type Key;
+
+    fn backend(&self) -> AuthorityKeyBackend;
+    fn health(&self) -> AuthorityKeyProviderHealth;
+    fn generate(
+        &self,
+        context: AuthorityKeyContext,
+        algorithm: AuthorityKeyAlgorithm,
+    ) -> Result<GeneratedAuthorityKey<Self::Key>, AuthorityKeyProviderError>;
+    fn public_key(
+        &self,
+        context: AuthorityKeyContext,
+        key: &Self::Key,
+    ) -> Result<AuthorityPublicKey, AuthorityKeyProviderError>;
+    fn sign(
+        &self,
+        context: AuthorityKeyContext,
+        key: &Self::Key,
+        message: &[u8],
+    ) -> Result<AuthoritySignature, AuthorityKeyProviderError>;
+    fn retire(&self, key: &Self::Key) -> Result<(), AuthorityKeyProviderError>;
+    fn destroy(&self, key: &mut Self::Key) -> Result<(), AuthorityKeyProviderError>;
+}
+
+#[derive(Clone)]
+pub struct EncryptedDatabaseKeyProvider {
+    config: PkiCaKeyConfig,
+}
+
+impl fmt::Debug for EncryptedDatabaseKeyProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedDatabaseKeyProvider")
+            .field("backend", &AuthorityKeyBackend::EncryptedDatabase)
+            .field("configured", &self.config.key_encryption_key.is_some())
+            .field("key_encryption_key_id", &self.config.key_encryption_key_id)
+            .finish()
+    }
+}
+
+impl EncryptedDatabaseKeyProvider {
+    pub fn new(config: PkiCaKeyConfig) -> Self {
+        Self { config }
+    }
+
+    fn kek(&self, key_id: &str) -> Result<&[u8], AuthorityKeyProviderError> {
+        if key_id != self.config.key_encryption_key_id {
+            return Err(AuthorityKeyProviderError::KeyEncryptionKeyIdMismatch);
+        }
+        self.config
+            .key_encryption_key
+            .as_ref()
+            .map(|key| key.expose())
+            .ok_or(AuthorityKeyProviderError::Unconfigured)
+    }
+
+    fn encrypt_generated_key(
+        &self,
+        context: AuthorityKeyContext,
+        key_algorithm: AuthorityKeyAlgorithm,
+        private_key: &[u8],
+    ) -> Result<EncryptedAuthorityKey, AuthorityKeyProviderError> {
+        let kek = self.kek(&self.config.key_encryption_key_id)?;
+        let mut dek = Zeroizing::new(vec![0_u8; DEK_LEN]);
+        OsRng.fill_bytes(dek.as_mut_slice());
+
+        let private = crypto::encrypt(
+            dek.as_slice(),
+            &context.aad("private-key"),
+            private_key,
+        )
+        .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
+        let wrapped = crypto::encrypt(kek, &context.aad("wrapped-dek"), dek.as_slice())
+            .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
+
+        Ok(EncryptedAuthorityKey {
+            encrypted_private_key: private.ciphertext,
+            private_key_nonce: private.nonce,
+            wrapped_dek: wrapped.ciphertext,
+            wrapped_dek_nonce: wrapped.nonce,
+            key_encryption_key_id: self.config.key_encryption_key_id.clone(),
+            encryption_algorithm: ENCRYPTION_ALGORITHM.to_string(),
+            key_algorithm,
+            destroyed: false,
+        })
+    }
+
+    fn decrypt_signing_key(
+        &self,
+        context: AuthorityKeyContext,
+        key: &EncryptedAuthorityKey,
+    ) -> Result<SigningKey, AuthorityKeyProviderError> {
+        key.ensure_usable()?;
+        if key.key_algorithm != AuthorityKeyAlgorithm::EcdsaP256Sha256 {
+            return Err(AuthorityKeyProviderError::UnsupportedKeyAlgorithm);
+        }
+        let kek = self.kek(&key.key_encryption_key_id)?;
+        let dek = Zeroizing::new(
+            crypto::decrypt(
+                kek,
+                &context.aad("wrapped-dek"),
+                &key.wrapped_dek,
+                &key.wrapped_dek_nonce,
+            )
+            .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?,
+        );
+        if dek.len() != DEK_LEN {
+            return Err(AuthorityKeyProviderError::CryptographicFailure);
+        }
+        let private_key = Zeroizing::new(
+            crypto::decrypt(
+                dek.as_slice(),
+                &context.aad("private-key"),
+                &key.encrypted_private_key,
+                &key.private_key_nonce,
+            )
+            .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?,
+        );
+        SigningKey::from_pkcs8_der(private_key.as_slice())
+            .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)
+    }
+
+    fn observe<T>(
+        operation: &'static str,
+        result: Result<T, AuthorityKeyProviderError>,
+    ) -> Result<T, AuthorityKeyProviderError> {
+        let outcome = if result.is_ok() { "success" } else { "error" };
+        metrics::record_pki_key_provider_operation(PROVIDER_NAME, operation, outcome);
+        result
+    }
+
+    fn validate_requirement(
+        &self,
+        requirement: &repo::EncryptedKeyRequirement,
+    ) -> Result<(), AuthorityKeyProviderError> {
+        if requirement.encryption_algorithm != ENCRYPTION_ALGORITHM {
+            return Err(AuthorityKeyProviderError::UnsupportedEncryptionAlgorithm);
+        }
+        self.kek(&requirement.key_encryption_key_id).map(|_| ())
+    }
+}
+
+impl AuthorityKeyProvider for EncryptedDatabaseKeyProvider {
+    type Key = EncryptedAuthorityKey;
+
+    fn backend(&self) -> AuthorityKeyBackend {
+        AuthorityKeyBackend::EncryptedDatabase
+    }
+
+    fn health(&self) -> AuthorityKeyProviderHealth {
+        AuthorityKeyProviderHealth {
+            backend: self.backend(),
+            status: if self.config.key_encryption_key.is_some() {
+                AuthorityKeyProviderStatus::Ready
+            } else {
+                AuthorityKeyProviderStatus::Unconfigured
+            },
+        }
+    }
+
+    fn generate(
+        &self,
+        context: AuthorityKeyContext,
+        algorithm: AuthorityKeyAlgorithm,
+    ) -> Result<GeneratedAuthorityKey<Self::Key>, AuthorityKeyProviderError> {
+        let result = (|| {
+            if algorithm != AuthorityKeyAlgorithm::EcdsaP256Sha256 {
+                return Err(AuthorityKeyProviderError::UnsupportedKeyAlgorithm);
+            }
+            let signing_key = SigningKey::random(&mut OsRng);
+            let private_key = signing_key
+                .to_pkcs8_der()
+                .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
+            let public_key = signing_key
+                .verifying_key()
+                .to_public_key_der()
+                .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
+            let private_key = Zeroizing::new(private_key.as_bytes().to_vec());
+            let encrypted_key =
+                self.encrypt_generated_key(context, algorithm, private_key.as_slice())?;
+            Ok(GeneratedAuthorityKey {
+                public_key: AuthorityPublicKey {
+                    algorithm,
+                    subject_public_key_info_der: public_key.as_bytes().to_vec(),
+                },
+                key: encrypted_key,
+            })
+        })();
+        Self::observe("generate", result)
+    }
+
+    fn public_key(
+        &self,
+        context: AuthorityKeyContext,
+        key: &EncryptedAuthorityKey,
+    ) -> Result<AuthorityPublicKey, AuthorityKeyProviderError> {
+        let result = (|| {
+            let signing_key = self.decrypt_signing_key(context, key)?;
+            let public_key = signing_key
+                .verifying_key()
+                .to_public_key_der()
+                .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
+            Ok(AuthorityPublicKey {
+                algorithm: key.key_algorithm,
+                subject_public_key_info_der: public_key.as_bytes().to_vec(),
+            })
+        })();
+        Self::observe("public_key", result)
+    }
+
+    fn sign(
+        &self,
+        context: AuthorityKeyContext,
+        key: &EncryptedAuthorityKey,
+        message: &[u8],
+    ) -> Result<AuthoritySignature, AuthorityKeyProviderError> {
+        let result = (|| {
+            let signing_key = self.decrypt_signing_key(context, key)?;
+            let signature: Signature = signing_key.sign(message);
+            Ok(AuthoritySignature {
+                algorithm: AuthoritySignatureAlgorithm::EcdsaP256Sha256,
+                bytes: signature.to_der().as_bytes().to_vec(),
+            })
+        })();
+        Self::observe("sign", result)
+    }
+
+    fn retire(&self, key: &EncryptedAuthorityKey) -> Result<(), AuthorityKeyProviderError> {
+        // Retired issuer keys must remain usable for CRL/OCSP until retention
+        // ends. Lifecycle state lives on the authority; the encrypted provider
+        // therefore validates but intentionally retains the key material.
+        let result = key.ensure_usable();
+        Self::observe("retire", result)
+    }
+
+    fn destroy(
+        &self,
+        key: &mut EncryptedAuthorityKey,
+    ) -> Result<(), AuthorityKeyProviderError> {
+        let result = (|| {
+            key.ensure_usable()?;
+            key.destroy();
+            Ok(())
+        })();
+        Self::observe("destroy", result)
+    }
+}
+
+/// Validate provider metadata without loading or decrypting any CA private key.
+/// A CA KEK is optional while every authority is `public_only`, but startup
+/// fails closed as soon as an encrypted authority requires it.
+pub async fn validate_startup(pool: &PgPool, config: &PkiCaKeyConfig) -> Result<(), AppError> {
+    let requirements = repo::encrypted_key_requirements(pool).await?;
+    if requirements.is_empty() {
+        return Ok(());
+    }
+
+    let provider = EncryptedDatabaseKeyProvider::new(config.clone());
+    requirements
+        .iter()
+        .try_for_each(|requirement| provider.validate_requirement(requirement))
+        .map_err(|error| AppError::Internal(anyhow::anyhow!(error)))?;
+
+    tracing::info!(
+        provider = PROVIDER_NAME,
+        configurations = requirements.len(),
+        "PKI CA key provider metadata validated"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use p256::{
+        ecdsa::{signature::Verifier, Signature, VerifyingKey},
+        pkcs8::DecodePublicKey,
+    };
+
+    use crate::config::SecretBytes;
+
+    use super::*;
+
+    fn config(byte: u8, id: &str) -> PkiCaKeyConfig {
+        PkiCaKeyConfig {
+            key_encryption_key: Some(
+                SecretBytes::new(vec![byte; DEK_LEN]).expect("test CA KEK"),
+            ),
+            key_encryption_key_id: id.to_string(),
+        }
+    }
+
+    fn context() -> AuthorityKeyContext {
+        AuthorityKeyContext {
+            authority_id: Uuid::new_v4(),
+            tenant_id: Some(Uuid::new_v4()),
+            version: 1,
+        }
+    }
+
+    fn generated(
+        provider: &EncryptedDatabaseKeyProvider,
+        context: AuthorityKeyContext,
+    ) -> GeneratedAuthorityKey<EncryptedAuthorityKey> {
+        provider
+            .generate(context, AuthorityKeyAlgorithm::EcdsaP256Sha256)
+            .expect("generate")
+    }
+
+    fn public_only_root() -> AuthorityRecord {
+        let now = chrono::Utc::now();
+        AuthorityRecord {
+            id: Uuid::new_v4(),
+            tenant_id: None,
+            parent_id: None,
+            kind: super::super::AuthorityKind::Root,
+            version: 1,
+            status: super::super::AuthorityStatus::Active,
+            issuance_enabled: false,
+            subject: "CN=offline root".to_string(),
+            serial_number: "01".to_string(),
+            fingerprint_sha256: "00".repeat(32),
+            subject_key_id: None,
+            authority_key_id: None,
+            certificate_pem: "public certificate".to_string(),
+            chain_pem: "public chain".to_string(),
+            not_before: now,
+            not_after: now + chrono::Duration::days(1),
+            key_backend: AuthorityKeyBackend::PublicOnly,
+            key_reference: None,
+            encrypted_private_key: None,
+            private_key_nonce: None,
+            wrapped_dek: None,
+            wrapped_dek_nonce: None,
+            key_encryption_key_id: None,
+            encryption_algorithm: None,
+            created_at: now,
+            updated_at: now,
+            activated_at: Some(now),
+            retiring_at: None,
+            retired_at: None,
+        }
+    }
+
+    #[test]
+    fn generated_key_signs_and_public_key_verifies() {
+        let provider = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let context = context();
+        let generated = generated(&provider, context);
+        let message = b"certificate-tbs";
+
+        let signature = provider
+            .sign(context, &generated.key, message)
+            .expect("sign");
+        let public = provider
+            .public_key(context, &generated.key)
+            .expect("public key");
+        assert_eq!(public, generated.public_key);
+
+        let verifying_key =
+            VerifyingKey::from_public_key_der(&public.subject_public_key_info_der)
+                .expect("public key DER");
+        let signature = Signature::from_der(&signature.bytes).expect("signature DER");
+        verifying_key
+            .verify(message, &signature)
+            .expect("independent verification");
+    }
+
+    #[test]
+    fn aad_binds_authority_tenant_and_version() {
+        let provider = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let context = context();
+        let generated = generated(&provider, context);
+
+        for wrong_context in [
+            AuthorityKeyContext {
+                authority_id: Uuid::new_v4(),
+                ..context
+            },
+            AuthorityKeyContext {
+                tenant_id: Some(Uuid::new_v4()),
+                ..context
+            },
+            AuthorityKeyContext {
+                version: context.version + 1,
+                ..context
+            },
+        ] {
+            assert_eq!(
+                provider
+                    .sign(wrong_context, &generated.key, b"message")
+                    .expect_err("AAD mismatch"),
+                AuthorityKeyProviderError::CryptographicFailure
+            );
+        }
+    }
+
+    #[test]
+    fn wrong_kek_and_key_id_fail_closed() {
+        let context = context();
+        let original = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let generated = generated(&original, context);
+
+        let wrong_key = EncryptedDatabaseKeyProvider::new(config(8, "ca:v1"));
+        assert_eq!(
+            wrong_key
+                .sign(context, &generated.key, b"message")
+                .expect_err("wrong key"),
+            AuthorityKeyProviderError::CryptographicFailure
+        );
+
+        let rotated_id = EncryptedDatabaseKeyProvider::new(config(7, "ca:v2"));
+        assert_eq!(
+            rotated_id
+                .sign(context, &generated.key, b"message")
+                .expect_err("unavailable old key id"),
+            AuthorityKeyProviderError::KeyEncryptionKeyIdMismatch
+        );
+    }
+
+    #[test]
+    fn corrupted_ciphertext_and_unsupported_algorithm_fail_closed() {
+        let provider = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let context = context();
+        let mut generated = generated(&provider, context);
+        generated.key.encrypted_private_key[0] ^= 0xff;
+        assert_eq!(
+            provider
+                .sign(context, &generated.key, b"message")
+                .expect_err("corruption"),
+            AuthorityKeyProviderError::CryptographicFailure
+        );
+
+        generated.key.encryption_algorithm = "unsupported".to_string();
+        assert_eq!(
+            provider
+                .sign(context, &generated.key, b"message")
+                .expect_err("algorithm"),
+            AuthorityKeyProviderError::UnsupportedEncryptionAlgorithm
+        );
+    }
+
+    #[test]
+    fn missing_fields_and_public_only_backend_fail_closed() {
+        assert_eq!(
+            EncryptedAuthorityKey::from_columns(
+                None,
+                Some(vec![0; 12]),
+                Some(vec![1]),
+                Some(vec![0; 12]),
+                Some("ca:v1".to_string()),
+                Some(ENCRYPTION_ALGORITHM.to_string()),
+            )
+            .expect_err("missing field"),
+            AuthorityKeyProviderError::MissingField("encrypted_private_key")
+        );
+
+        assert!(!AuthorityKeyBackend::PublicOnly.can_sign());
+        assert_eq!(
+            EncryptedAuthorityKey::from_authority(&public_only_root())
+                .expect_err("public-only root cannot produce a signing handle"),
+            AuthorityKeyProviderError::WrongBackend
+        );
+    }
+
+    #[test]
+    fn restart_loading_uses_only_persisted_encrypted_columns() {
+        let context = context();
+        let first_process = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let generated = generated(&first_process, context);
+        let persisted = &generated.key;
+
+        let loaded = EncryptedAuthorityKey::from_columns(
+            Some(persisted.encrypted_private_key.clone()),
+            Some(persisted.private_key_nonce.clone()),
+            Some(persisted.wrapped_dek.clone()),
+            Some(persisted.wrapped_dek_nonce.clone()),
+            Some(persisted.key_encryption_key_id.clone()),
+            Some(persisted.encryption_algorithm.clone()),
+        )
+        .expect("load persisted key");
+        let restarted_process = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        restarted_process
+            .sign(context, &loaded, b"after restart")
+            .expect("sign after restart");
+    }
+
+    #[test]
+    fn secret_material_is_not_debugged_or_serialized() {
+        let provider = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let generated = generated(&provider, context());
+        let ciphertext = hex::encode(&generated.key.encrypted_private_key);
+        let wrapped_dek = hex::encode(&generated.key.wrapped_dek);
+        let debug = format!("{:?}", generated.key);
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains(&ciphertext));
+        assert!(!debug.contains(&wrapped_dek));
+
+        let serialized = serde_json::to_string(&generated.key.metadata())
+            .expect("safe metadata serialization");
+        assert!(!serialized.contains(&ciphertext));
+        assert!(!serialized.contains(&wrapped_dek));
+    }
+
+    #[test]
+    fn retirement_retains_key_but_destruction_zeroizes_handle() {
+        let provider = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
+        let context = context();
+        let mut generated = generated(&provider, context);
+        provider
+            .retire(&generated.key)
+            .expect("retire retains key");
+        provider
+            .sign(context, &generated.key, b"crl")
+            .expect("retired key remains usable for artifacts");
+
+        provider
+            .destroy(&mut generated.key)
+            .expect("destroy");
+        assert_eq!(
+            provider
+                .sign(context, &generated.key, b"message")
+                .expect_err("destroyed key"),
+            AuthorityKeyProviderError::Destroyed
+        );
+    }
+
+    #[test]
+    fn missing_ca_kek_is_healthy_only_for_unused_provider() {
+        let provider = EncryptedDatabaseKeyProvider::new(PkiCaKeyConfig::default());
+        assert_eq!(
+            provider.health().status,
+            AuthorityKeyProviderStatus::Unconfigured
+        );
+        assert_eq!(
+            provider
+                .validate_requirement(&repo::EncryptedKeyRequirement {
+                    key_encryption_key_id: "local-ca:v1".to_string(),
+                    encryption_algorithm: ENCRYPTION_ALGORITHM.to_string(),
+                })
+                .expect_err("encrypted row requires CA KEK"),
+            AuthorityKeyProviderError::Unconfigured
+        );
+    }
+}

--- a/src/certs/authority/key_provider.rs
+++ b/src/certs/authority/key_provider.rs
@@ -16,12 +16,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 use zeroize::{Zeroize, Zeroizing};
 
-use crate::{
-    config::PkiCaKeyConfig,
-    crypto,
-    error::AppError,
-    metrics,
-};
+use crate::{config::PkiCaKeyConfig, crypto, error::AppError, metrics};
 
 use super::{repo, AuthorityKeyBackend, AuthorityRecord};
 
@@ -170,10 +165,7 @@ impl EncryptedAuthorityKey {
             private_key_nonce: required(private_key_nonce, "private_key_nonce")?,
             wrapped_dek: required(wrapped_dek, "wrapped_dek")?,
             wrapped_dek_nonce: required(wrapped_dek_nonce, "wrapped_dek_nonce")?,
-            key_encryption_key_id: required(
-                key_encryption_key_id,
-                "key_encryption_key_id",
-            )?,
+            key_encryption_key_id: required(key_encryption_key_id, "key_encryption_key_id")?,
             encryption_algorithm: required(encryption_algorithm, "encryption_algorithm")?,
             key_algorithm: AuthorityKeyAlgorithm::EcdsaP256Sha256,
             destroyed: false,
@@ -312,12 +304,8 @@ impl EncryptedDatabaseKeyProvider {
         let mut dek = Zeroizing::new(vec![0_u8; DEK_LEN]);
         OsRng.fill_bytes(dek.as_mut_slice());
 
-        let private = crypto::encrypt(
-            dek.as_slice(),
-            &context.aad("private-key"),
-            private_key,
-        )
-        .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
+        let private = crypto::encrypt(dek.as_slice(), &context.aad("private-key"), private_key)
+            .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
         let wrapped = crypto::encrypt(kek, &context.aad("wrapped-dek"), dek.as_slice())
             .map_err(|_| AuthorityKeyProviderError::CryptographicFailure)?;
 
@@ -481,10 +469,7 @@ impl AuthorityKeyProvider for EncryptedDatabaseKeyProvider {
         Self::observe("retire", result)
     }
 
-    fn destroy(
-        &self,
-        key: &mut EncryptedAuthorityKey,
-    ) -> Result<(), AuthorityKeyProviderError> {
+    fn destroy(&self, key: &mut EncryptedAuthorityKey) -> Result<(), AuthorityKeyProviderError> {
         let result = (|| {
             key.ensure_usable()?;
             key.destroy();
@@ -530,9 +515,7 @@ mod tests {
 
     fn config(byte: u8, id: &str) -> PkiCaKeyConfig {
         PkiCaKeyConfig {
-            key_encryption_key: Some(
-                SecretBytes::new(vec![byte; DEK_LEN]).expect("test CA KEK"),
-            ),
+            key_encryption_key: Some(SecretBytes::new(vec![byte; DEK_LEN]).expect("test CA KEK")),
             key_encryption_key_id: id.to_string(),
         }
     }
@@ -604,9 +587,8 @@ mod tests {
             .expect("public key");
         assert_eq!(public, generated.public_key);
 
-        let verifying_key =
-            VerifyingKey::from_public_key_der(&public.subject_public_key_info_der)
-                .expect("public key DER");
+        let verifying_key = VerifyingKey::from_public_key_der(&public.subject_public_key_info_der)
+            .expect("public key DER");
         let signature = Signature::from_der(&signature.bytes).expect("signature DER");
         verifying_key
             .verify(message, &signature)
@@ -743,8 +725,8 @@ mod tests {
         assert!(!debug.contains(&ciphertext));
         assert!(!debug.contains(&wrapped_dek));
 
-        let serialized = serde_json::to_string(&generated.key.metadata())
-            .expect("safe metadata serialization");
+        let serialized =
+            serde_json::to_string(&generated.key.metadata()).expect("safe metadata serialization");
         assert!(!serialized.contains(&ciphertext));
         assert!(!serialized.contains(&wrapped_dek));
     }
@@ -754,16 +736,12 @@ mod tests {
         let provider = EncryptedDatabaseKeyProvider::new(config(7, "ca:v1"));
         let context = context();
         let mut generated = generated(&provider, context);
-        provider
-            .retire(&generated.key)
-            .expect("retire retains key");
+        provider.retire(&generated.key).expect("retire retains key");
         provider
             .sign(context, &generated.key, b"crl")
             .expect("retired key remains usable for artifacts");
 
-        provider
-            .destroy(&mut generated.key)
-            .expect("destroy");
+        provider.destroy(&mut generated.key).expect("destroy");
         assert_eq!(
             provider
                 .sign(context, &generated.key, b"message")

--- a/src/certs/authority/mod.rs
+++ b/src/certs/authority/mod.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub mod repo;
 pub mod key_provider;
+pub mod repo;
 
 /// Position of a CA in Atom's managed trust hierarchy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]

--- a/src/certs/authority/mod.rs
+++ b/src/certs/authority/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub mod repo;
+pub mod key_provider;
 
 /// Position of a CA in Atom's managed trust hierarchy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]

--- a/src/certs/authority/repo.rs
+++ b/src/certs/authority/repo.rs
@@ -5,6 +5,12 @@ use crate::error::{db_err, AppError};
 
 use super::AuthorityRecord;
 
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct EncryptedKeyRequirement {
+    pub key_encryption_key_id: String,
+    pub encryption_algorithm: String,
+}
+
 const AUTHORITY_COLUMNS: &str = r#"
     id,
     tenant_id,
@@ -136,4 +142,21 @@ pub async fn list_tenant_authorities(
         .fetch_all(pool)
         .await
         .map_err(AppError::Database)
+}
+
+/// Return only non-secret metadata needed to validate the encrypted CA provider
+/// before the process starts serving. Private-key columns are deliberately not
+/// selected, so startup validation cannot preload tenant keys.
+pub async fn encrypted_key_requirements(
+    pool: &PgPool,
+) -> Result<Vec<EncryptedKeyRequirement>, AppError> {
+    sqlx::query_as::<_, EncryptedKeyRequirement>(
+        r#"SELECT DISTINCT key_encryption_key_id, encryption_algorithm
+           FROM pki_authorities
+           WHERE key_backend = 'encrypted_database'
+           ORDER BY key_encryption_key_id, encryption_algorithm"#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(db_err)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use ipnet::IpNet;
 use serde::Deserialize;
 use std::{fmt, str::FromStr};
 use uuid::Uuid;
+use zeroize::Zeroize;
 
 // 00000000-0000-0000-0000-000000000001
 pub const ADMIN_ENTITY_ID: Uuid =
@@ -22,6 +23,7 @@ pub struct Config {
     /// must then be secured by the deployment: private network / service mesh).
     pub grpc_tls: Option<GrpcTlsConfig>,
     pub signing_keys: SigningKeyConfig,
+    pub pki_ca_keys: PkiCaKeyConfig,
     pub audit_policy: AuditPolicyConfig,
     pub audit_retention: AuditRetentionConfig,
     pub purge: PurgeConfig,
@@ -122,6 +124,12 @@ impl fmt::Debug for SecretBytes {
     }
 }
 
+impl Drop for SecretBytes {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SigningKeyConfig {
     pub key_encryption_key: Option<SecretBytes>,
@@ -135,6 +143,25 @@ impl Default for SigningKeyConfig {
             key_encryption_key: None,
             key_encryption_key_id: "local:v1".to_string(),
             allow_plaintext_signing_keys: false,
+        }
+    }
+}
+
+/// Dedicated key-encryption-key configuration for managed CA private keys.
+///
+/// This is intentionally separate from [`SigningKeyConfig`]: compromise or
+/// rotation of JWT/credential encryption must not grant access to CA keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PkiCaKeyConfig {
+    pub key_encryption_key: Option<SecretBytes>,
+    pub key_encryption_key_id: String,
+}
+
+impl Default for PkiCaKeyConfig {
+    fn default() -> Self {
+        Self {
+            key_encryption_key: None,
+            key_encryption_key_id: "local-ca:v1".to_string(),
         }
     }
 }
@@ -465,6 +492,7 @@ impl Config {
             grpc_addr: std::env::var("GRPC_ADDR").unwrap_or_else(|_| "0.0.0.0:8081".to_string()),
             grpc_tls: grpc_tls_from_env()?,
             signing_keys: signing_keys_from_env()?,
+            pki_ca_keys: pki_ca_keys_from_env()?,
             audit_policy: AuditPolicyConfig {
                 hot_path_allow_db_enabled: env_bool_default(
                     "ATOM_AUDIT_HOT_PATH_ALLOW_DB_ENABLED",
@@ -559,6 +587,10 @@ impl Config {
                 // for recoverable secrets (shared keys).
                 key_encryption_key: SecretBytes::new(vec![7u8; 32]).ok(),
                 ..SigningKeyConfig::default()
+            },
+            pki_ca_keys: PkiCaKeyConfig {
+                key_encryption_key: SecretBytes::new(vec![8u8; 32]).ok(),
+                ..PkiCaKeyConfig::default()
             },
             audit_policy: AuditPolicyConfig::default(),
             audit_retention: AuditRetentionConfig::default(),
@@ -739,6 +771,33 @@ fn parse_key_encryption_key() -> Result<Option<SecretBytes>> {
     SecretBytes::new(bytes)
         .map(Some)
         .context("ATOM_KEY_ENCRYPTION_KEY must decode to exactly 32 bytes")
+}
+
+fn pki_ca_keys_from_env() -> Result<PkiCaKeyConfig> {
+    let default = PkiCaKeyConfig::default();
+    let key_encryption_key = parse_secret_key_env("ATOM_PKI_CA_KEY_ENCRYPTION_KEY")?;
+    let key_encryption_key_id = std::env::var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID")
+        .unwrap_or(default.key_encryption_key_id);
+    if key_encryption_key.is_some() && key_encryption_key_id.trim().is_empty() {
+        anyhow::bail!("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID must not be blank when the CA KEK is set");
+    }
+    Ok(PkiCaKeyConfig {
+        key_encryption_key,
+        key_encryption_key_id,
+    })
+}
+
+fn parse_secret_key_env(name: &str) -> Result<Option<SecretBytes>> {
+    let value = match std::env::var(name) {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return Ok(None),
+    };
+    let bytes = STANDARD
+        .decode(value.trim())
+        .with_context(|| format!("{name} must be base64 encoded"))?;
+    SecretBytes::new(bytes)
+        .map(Some)
+        .with_context(|| format!("{name} must decode to exactly 32 bytes"))
 }
 
 fn audit_retention_from_env() -> Result<AuditRetentionConfig> {
@@ -1065,6 +1124,7 @@ mod tests {
         assert_eq!(cfg.db_pool.acquire_timeout_secs, 30);
         assert!(!cfg.signing_keys.allow_plaintext_signing_keys);
         assert!(cfg.signing_keys.key_encryption_key.is_none());
+        assert!(cfg.pki_ca_keys.key_encryption_key.is_none());
         assert!(!cfg.audit_policy.hot_path_allow_db_enabled);
         assert_eq!(cfg.audit_retention.days, 365);
         assert_eq!(cfg.login_failure_limit, 5);
@@ -1213,6 +1273,39 @@ mod tests {
     }
 
     #[test]
+    fn pki_ca_key_is_separate_and_must_be_base64_32_bytes() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_hardening_env();
+        let _db_guard = DatabaseUrlGuard::set();
+        std::env::set_var(
+            "ATOM_KEY_ENCRYPTION_KEY",
+            "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+        );
+
+        let cfg = Config::from_env().expect("config");
+        assert!(cfg.signing_keys.key_encryption_key.is_some());
+        assert!(cfg.pki_ca_keys.key_encryption_key.is_none());
+
+        std::env::set_var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY", "too-short");
+        let err = Config::from_env().expect_err("invalid CA key");
+        assert!(err
+            .to_string()
+            .contains("ATOM_PKI_CA_KEY_ENCRYPTION_KEY"));
+
+        std::env::set_var(
+            "ATOM_PKI_CA_KEY_ENCRYPTION_KEY",
+            "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+        );
+        std::env::set_var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID", " ");
+        let err = Config::from_env().expect_err("blank CA key id");
+        assert!(err
+            .to_string()
+            .contains("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID"));
+
+        clear_hardening_env();
+    }
+
+    #[test]
     fn trusted_proxy_cidrs_must_be_valid() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         clear_hardening_env();
@@ -1288,6 +1381,8 @@ mod tests {
             "ATOM_KEY_ENCRYPTION_KEY",
             "ATOM_KEY_ENCRYPTION_KEY_ID",
             "ATOM_ALLOW_PLAINTEXT_SIGNING_KEYS",
+            "ATOM_PKI_CA_KEY_ENCRYPTION_KEY",
+            "ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID",
             "ATOM_AUDIT_HOT_PATH_ALLOW_DB_ENABLED",
             "ATOM_AUDIT_RETENTION_DAYS",
             "ATOM_AUDIT_RETENTION_ENABLED",

--- a/src/config.rs
+++ b/src/config.rs
@@ -776,8 +776,8 @@ fn parse_key_encryption_key() -> Result<Option<SecretBytes>> {
 fn pki_ca_keys_from_env() -> Result<PkiCaKeyConfig> {
     let default = PkiCaKeyConfig::default();
     let key_encryption_key = parse_secret_key_env("ATOM_PKI_CA_KEY_ENCRYPTION_KEY")?;
-    let key_encryption_key_id = std::env::var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID")
-        .unwrap_or(default.key_encryption_key_id);
+    let key_encryption_key_id =
+        std::env::var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID").unwrap_or(default.key_encryption_key_id);
     if key_encryption_key.is_some() && key_encryption_key_id.trim().is_empty() {
         anyhow::bail!("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID must not be blank when the CA KEK is set");
     }
@@ -1288,9 +1288,7 @@ mod tests {
 
         std::env::set_var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY", "too-short");
         let err = Config::from_env().expect_err("invalid CA key");
-        assert!(err
-            .to_string()
-            .contains("ATOM_PKI_CA_KEY_ENCRYPTION_KEY"));
+        assert!(err.to_string().contains("ATOM_PKI_CA_KEY_ENCRYPTION_KEY"));
 
         std::env::set_var(
             "ATOM_PKI_CA_KEY_ENCRYPTION_KEY",

--- a/src/config.rs
+++ b/src/config.rs
@@ -483,6 +483,18 @@ impl Config {
         let public_base_url = std::env::var("ATOM_PUBLIC_BASE_URL")
             .unwrap_or_else(|_| "http://localhost:8080".into());
         let ui_auth_callback = public_url(&public_base_url, "/auth/callback");
+        let signing_keys = signing_keys_from_env()?;
+        let pki_ca_keys = pki_ca_keys_from_env()?;
+        if let (Some(signing_kek), Some(ca_kek)) = (
+            signing_keys.key_encryption_key.as_ref(),
+            pki_ca_keys.key_encryption_key.as_ref(),
+        ) {
+            if signing_kek.expose() == ca_kek.expose() {
+                anyhow::bail!(
+                    "ATOM_PKI_CA_KEY_ENCRYPTION_KEY must not reuse ATOM_KEY_ENCRYPTION_KEY"
+                );
+            }
+        }
         Ok(Config {
             database_url: std::env::var("DATABASE_URL").context("DATABASE_URL must be set")?,
             db_pool: db_pool_from_env()?,
@@ -491,8 +503,8 @@ impl Config {
                 .unwrap_or_else(|_| "0.0.0.0:8080".to_string()),
             grpc_addr: std::env::var("GRPC_ADDR").unwrap_or_else(|_| "0.0.0.0:8081".to_string()),
             grpc_tls: grpc_tls_from_env()?,
-            signing_keys: signing_keys_from_env()?,
-            pki_ca_keys: pki_ca_keys_from_env()?,
+            signing_keys,
+            pki_ca_keys,
             audit_policy: AuditPolicyConfig {
                 hot_path_allow_db_enabled: env_bool_default(
                     "ATOM_AUDIT_HOT_PATH_ALLOW_DB_ENABLED",
@@ -1294,11 +1306,35 @@ mod tests {
             "ATOM_PKI_CA_KEY_ENCRYPTION_KEY",
             "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
         );
+        let err = Config::from_env().expect_err("reused signing and CA KEK");
+        assert!(err
+            .to_string()
+            .contains("must not reuse ATOM_KEY_ENCRYPTION_KEY"));
+
+        std::env::set_var(
+            "ATOM_PKI_CA_KEY_ENCRYPTION_KEY",
+            "ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=",
+        );
         std::env::set_var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID", " ");
         let err = Config::from_env().expect_err("blank CA key id");
         assert!(err
             .to_string()
             .contains("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID"));
+
+        std::env::set_var("ATOM_PKI_CA_KEY_ENCRYPTION_KEY_ID", "local-ca:v1");
+        let cfg = Config::from_env().expect("distinct CA KEK");
+        assert_ne!(
+            cfg.signing_keys
+                .key_encryption_key
+                .as_ref()
+                .expect("signing KEK")
+                .expose(),
+            cfg.pki_ca_keys
+                .key_encryption_key
+                .as_ref()
+                .expect("CA KEK")
+                .expose(),
+        );
 
         clear_hardening_env();
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -59,12 +59,15 @@ pub fn decrypt(
     let mut nonce_bytes = [0_u8; NONCE_LEN];
     nonce_bytes.copy_from_slice(nonce);
     let opening = aead_key(key)?;
-    let mut buf = ciphertext.to_vec();
+    // The AEAD implementation decrypts in place. Keep that backing allocation
+    // zeroizing so the original plaintext buffer is wiped after copying the
+    // returned value to its caller-owned result.
+    let mut buf = zeroize::Zeroizing::new(ciphertext.to_vec());
     let plaintext = opening
         .open_in_place(
             Nonce::assume_unique_for_key(nonce_bytes),
             Aad::from(aad),
-            &mut buf,
+            buf.as_mut_slice(),
         )
         .map_err(|_| AppError::Internal(anyhow::anyhow!("aead decrypt")))?;
     Ok(plaintext.to_vec())

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ async fn main() -> anyhow::Result<()> {
     sqlx::migrate!("./migrations").run(&pool).await?;
     tracing::info!("migrations applied");
 
+    certs::authority::key_provider::validate_startup(&pool, &cfg.pki_ca_keys).await?;
+
     if let Some(ref secret) = cfg.admin_secret {
         bootstrap_admin_credentials(&pool, cfg.admin_entity_id, secret).await?;
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -36,6 +36,9 @@ pub const EVENT_OUTBOX_PUBLISH_FAILURES: &str = "atom_event_outbox_publish_failu
 pub const EVENT_OUTBOX_EXHAUSTED: &str = "atom_event_outbox_exhausted_total";
 /// Gauge of DB pool connections, labelled by `state` (total|idle).
 pub const DB_POOL_CONNECTIONS: &str = "atom_db_pool_connections";
+/// Counter of CA key-provider operations. Labels are bounded to provider,
+/// operation, and outcome; authority and tenant identifiers are never labels.
+pub const PKI_KEY_PROVIDER_OPERATIONS: &str = "atom_pki_key_provider_operations_total";
 
 #[cfg(feature = "metrics")]
 mod backend {
@@ -102,6 +105,20 @@ mod backend {
     pub fn record_outbox_exhausted() {
         metrics::counter!(EVENT_OUTBOX_EXHAUSTED).increment(1);
     }
+
+    pub fn record_pki_key_provider_operation(
+        provider: &'static str,
+        operation: &'static str,
+        outcome: &'static str,
+    ) {
+        metrics::counter!(
+            PKI_KEY_PROVIDER_OPERATIONS,
+            "provider" => provider,
+            "operation" => operation,
+            "outcome" => outcome
+        )
+        .increment(1);
+    }
 }
 
 #[cfg(not(feature = "metrics"))]
@@ -130,9 +147,17 @@ mod backend {
     pub fn record_outbox_publish_failure(_rows: u64) {}
     #[inline]
     pub fn record_outbox_exhausted() {}
+    #[inline]
+    pub fn record_pki_key_provider_operation(
+        _provider: &'static str,
+        _operation: &'static str,
+        _outcome: &'static str,
+    ) {
+    }
 }
 
 pub use backend::{
     enabled, init, record_audit_db_suppressed, record_audit_failure, record_decision,
-    record_outbox_exhausted, record_outbox_publish_failure, record_rate_limit_rejection, render,
+    record_outbox_exhausted, record_outbox_publish_failure, record_pki_key_provider_operation,
+    record_rate_limit_rejection, render,
 };


### PR DESCRIPTION
## What changed

Implements PR-002 from `product-docs/development/pki/pr-002-key-provider.md`:

- adds an Atom-owned CA key-provider interface with provider-specific opaque key handles;
- adds the encrypted-database provider using a random per-authority DEK and a dedicated CA KEK;
- binds wrapped DEKs and encrypted PKCS#8 keys to authority ID, tenant scope, and authority version with AEAD associated data;
- adds generation, public-key retrieval, signing, retirement, destruction, and health operations;
- adds separate `ATOM_PKI_CA_KEY_ENCRYPTION_KEY[_ID]` configuration;
- validates encrypted-authority provider metadata at startup without loading private keys;
- adds bounded, non-secret provider operation metrics;
- redacts encrypted and wrapped key material and zeroizes plaintext/private buffers where supported;
- documents operator configuration and rollback behavior.

## Security decisions

- The production root remains `public_only`; a public-only authority cannot produce an encrypted signing handle.
- The CA KEK is independent of `ATOM_KEY_ENCRYPTION_KEY`.
- No CA key is decrypted at startup or preloaded across tenants.
- Wrong KEKs, mismatched KEK IDs, AAD mismatch, corrupted ciphertext, missing fields, destroyed handles, and unsupported encryption algorithms fail closed.
- Existing v1 file issuer routing is unchanged.

## Validation

Local validation:
- `git diff --check` — passed.
- Rust commands were not available in the local workspace; GitHub Actions is the authoritative format, clippy, compile, unit, and database-test run for this PR.

Added unit coverage for:
- envelope-encryption/signing round trip and independent ECDSA verification;
- authority/tenant/version AAD mismatch;
- wrong KEK and KEK-ID rotation mismatch;
- corrupted ciphertext and unsupported algorithm;
- missing encrypted fields and public-only roots;
- restart loading from encrypted columns;
- secret-free Debug/serialization;
- retirement and destruction;
- optional CA KEK until encrypted authority rows exist.

## Migration and compatibility

- No database migration is added or changed.
- Existing v1 certificate issuance, storage, authorization, CRL, and OCSP behavior remains unchanged.
- Rollback is safe while no production authority uses `encrypted_database`.

## Roadmap

Merging this PR unlocks PR-003 (CA provisioning) and PR-004 (certificate profiles).