### PR TITLE
Run CI for certificate staging PRs

### DIFF
--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -10,7 +10,7 @@ on:
       - "buf.gen.yaml"
       - ".github/workflows/apidocs.yml"
   pull_request:
-    branches: [main]
+    branches: [main, certificates]
 
 jobs:
   proto:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, certificates]
   # Pushes to main and release tags run this through the image workflow, which
   # gates publishing on it. Keeping a separate push trigger here would just run
   # the same job twice for every one of those events.


### PR DESCRIPTION
## What changed

Allows the existing Rust and API documentation pull-request workflows to run when a PR targets the `certificates` staging branch.

## Why

The numbered PKI PRs intentionally target `certificates`, but both workflows were filtered to `main`, leaving those PRs without format, clippy, compilation, database-test, API-doc, or OpenAPI checks.

## Scope

Workflow branch filters only. No application, schema, migration, or runtime behavior changes.