### PR TITLE
[PKI PR-005] Implement tenant-aware CSR signing

### DIFF
--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -111,6 +111,59 @@ completeAuthorityRetirement
 `pki.provision_automated` capability. Scoped access tokens cannot invoke CA
 lifecycle mutations.
 
+## Managed CSR signing (v2)
+
+`issueCertificateFromCsrV2` is the first managed leaf-issuance path. The
+existing `issueCertificateFromCsr` mutation remains the legacy file-issuer API;
+the explicit `V2` suffix prevents an authority migration from silently changing
+existing clients.
+
+The v2 input accepts only:
+
+- the target `entityId`;
+- the device-generated `csrPem`;
+- an optional requested `ttlSecs`; and
+- a required, caller-generated `idempotencyKey` (1–256 non-control UTF-8 bytes).
+
+Tenant, profile, issuer, CA path, and key reference are deliberately absent.
+Atom authorizes and locks the stored entity, derives its tenant, selects and
+locks that scope's active issuer, and resolves the stored `client` profile. The
+response includes the leaf, immutable issuing chain, issuer/profile IDs, and
+canonical identity URI. `privateKeyPem` is always null on this path because the
+device key never enters Atom.
+
+```graphql
+mutation SignDeviceCsr($input: IssueCertificateFromCsrV2Input!) {
+  issueCertificateFromCsrV2(input: $input) {
+    idempotentReplay
+    chainPem
+    certificate {
+      credentialId
+      issuerId
+      serialNumber
+      certificatePem
+      profileId
+      identityUri
+    }
+  }
+}
+```
+
+Reuse the same idempotency key only for an exact retry. Atom stores a digest of
+the key and request—not the token or CSR—and returns the original credential
+with `idempotentReplay: true`. Reusing it with different CSR or TTL content is a
+conflict. A replay does not enqueue a second `certificate.issue` domain event.
+
+Serial conflicts are retried in nested savepoints on the caller's transaction.
+The credential, issuer link, completion ledger, and outbox event commit
+together. If CA signing succeeds but any database write or final commit fails,
+the certificate is neither returned nor registered as a runtime credential;
+the uncommitted ledger row disappears too. Retrying the same key therefore
+either returns the prior committed credential or performs a clean replacement
+attempt. Operators reconcile an uncertain client response by retrying the same
+request and checking the credential ID, issuance ledger, audit log, and outbox;
+there is no separately usable orphan artifact to import.
+
 ## Legacy CA files
 
 The original v1 issuer remains available for backward compatibility and loads
@@ -148,8 +201,9 @@ offline-root flow above.
 | Production root private key | Offline; never accepted by Atom |
 | Legacy v1 CA certificate/key | Mounted files, loaded at startup |
 | Issued leaf certificate | `credentials` row with `kind = certificate` |
-| Issued leaf private key | Returned once, never stored |
+| Generated-path leaf private key | Returned once by legacy/generated issuance, never stored |
 | CSR private key | Never enters Atom |
+| Managed CSR idempotency state | Request/key digests and committed credential ID only |
 | CRL cache | `certificate_crl_state` |
 
 ## Public PKI Endpoints

--- a/migrations/008_pki_csr_issuance.sql
+++ b/migrations/008_pki_csr_issuance.sql
@@ -1,0 +1,65 @@
+-- Idempotency ledger for managed, CSR-based leaf issuance.
+--
+-- The public idempotency token and CSR are never stored.  Only keyed request
+-- identity and payload digests are retained, and the row commits atomically
+-- with the issuer-bound certificate credential.
+
+CREATE TABLE certificate_issuance_requests (
+    id                          UUID        PRIMARY KEY,
+    entity_id                   UUID        NOT NULL
+                                             REFERENCES entities(id) ON DELETE CASCADE,
+    request_key_hash            TEXT        NOT NULL
+                                             CHECK (request_key_hash ~ '^[0-9a-f]{64}$'),
+    request_fingerprint_sha256  TEXT        NOT NULL
+                                             CHECK (request_fingerprint_sha256 ~ '^[0-9a-f]{64}$'),
+    credential_id               UUID        UNIQUE
+                                             REFERENCES credentials(id) ON DELETE CASCADE,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at                TIMESTAMPTZ,
+
+    CONSTRAINT uq_certificate_issuance_request_key
+        UNIQUE (entity_id, request_key_hash),
+    CONSTRAINT chk_certificate_issuance_request_state
+        CHECK ((credential_id IS NULL AND completed_at IS NULL)
+            OR (credential_id IS NOT NULL AND completed_at IS NOT NULL))
+);
+
+CREATE INDEX idx_certificate_issuance_requests_credential
+    ON certificate_issuance_requests(credential_id)
+    WHERE credential_id IS NOT NULL;
+
+-- A retry ledger may only resolve to the managed certificate created for the
+-- same entity.  This repeats the service invariant at the database boundary.
+CREATE OR REPLACE FUNCTION enforce_certificate_issuance_request_credential()
+RETURNS trigger AS $$
+DECLARE
+    credential_entity_id UUID;
+    credential_kind      TEXT;
+    credential_issuer_id UUID;
+BEGIN
+    IF NEW.credential_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT entity_id, kind, issuer_id
+      INTO credential_entity_id, credential_kind, credential_issuer_id
+      FROM credentials
+     WHERE id = NEW.credential_id;
+
+    IF NOT FOUND THEN
+        RETURN NEW;
+    END IF;
+    IF credential_entity_id <> NEW.entity_id
+       OR credential_kind <> 'certificate'
+       OR credential_issuer_id IS NULL THEN
+        RAISE EXCEPTION 'issuance request must reference its issuer-bound entity certificate'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_certificate_issuance_request_credential
+    BEFORE INSERT OR UPDATE OF entity_id, credential_id
+    ON certificate_issuance_requests
+    FOR EACH ROW EXECUTE FUNCTION enforce_certificate_issuance_request_credential();

--- a/product-docs/development/pki/pr-005-csr-import.md
+++ b/product-docs/development/pki/pr-005-csr-import.md
@@ -1,5 +1,9 @@
 # PR-005 — Tenant-Aware CSR Signing
 
+## Status
+
+Implemented by the PR-005 delivery branch.
+
 ## Objective
 
 Add the first production tenant-aware leaf path using device-generated CSRs.

--- a/src/certs/authority/repo.rs
+++ b/src/certs/authority/repo.rs
@@ -116,6 +116,43 @@ where
         .map_err(db_err)
 }
 
+/// Select and lock the active issuer used by one issuance transaction.
+///
+/// The share lock prevents a lifecycle transition from retiring the authority
+/// after policy validation but before the issuer-bound credential commits.
+pub async fn lock_active_leaf_issuer_for_scope(
+    tx: &mut Transaction<'_, Postgres>,
+    tenant_id: Option<Uuid>,
+) -> Result<AuthorityRecord, AppError> {
+    let query = format!(
+        r#"
+        SELECT {AUTHORITY_COLUMNS}
+        FROM pki_authorities
+        WHERE (($1::uuid IS NULL
+                AND tenant_id IS NULL
+                AND kind = 'platform_leaf_issuer')
+            OR ($1::uuid IS NOT NULL
+                AND tenant_id = $1
+                AND kind = 'tenant_intermediate'))
+          AND status = 'active'
+          AND issuance_enabled = true
+          AND not_before <= now()
+          AND not_after > now()
+        FOR SHARE
+        "#
+    );
+    sqlx::query_as::<_, AuthorityRecord>(&query)
+        .bind(tenant_id)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|error| match error {
+            sqlx::Error::RowNotFound => {
+                AppError::not_found("no active issuing authority is available for the entity scope")
+            }
+            other => AppError::Database(other),
+        })
+}
+
 /// Backward-compatible tenant-only selector for current call sites.
 pub async fn active_tenant_leaf_issuer(
     pool: &PgPool,

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -189,6 +189,83 @@ impl CertificateMutation {
         Ok(issued.into())
     }
 
+    /// Explicitly versioned managed-issuer path.  The v1 mutation above keeps
+    /// its file-issuer behavior for compatibility.
+    async fn issue_certificate_from_csr_v2(
+        &self,
+        ctx: &Context<'_>,
+        input: IssueCertificateFromCsrV2Input,
+    ) -> Result<IssuedCertificate> {
+        let auth = require_auth(ctx)?;
+        let state = ctx.data::<AppState>()?;
+        let entity_id = parse_id(input.entity_id, "entityId")?;
+        let tenant_id = require_credential_management(state, &auth, entity_id).await?;
+        let mut tx = state
+            .pool
+            .begin()
+            .await
+            .map_err(|error| gql_error(db_err(error)))?;
+        let issued = service::issue_certificate_from_csr_v2_in_tx(
+            &mut tx,
+            &state.config,
+            tenant_id,
+            service::IssueCertificateFromCsrV2 {
+                entity_id,
+                ttl_secs: input.ttl_secs,
+                csr_pem: input.csr_pem,
+                idempotency_key: input.idempotency_key,
+            },
+        )
+        .await
+        .map_err(gql_error)?;
+        let details = serde_json::json!({
+            "credential_id": issued.certificate.credential_id,
+            "serial_number": issued.certificate.serial_number,
+            "issuer_id": issued.certificate.issuer_id,
+            "profile_id": issued.certificate.profile_id,
+            "csr": true,
+            "managed": true,
+            "replay": issued.idempotent_replay,
+        });
+        if issued.idempotent_replay {
+            tx.commit()
+                .await
+                .map_err(|error| gql_error(db_err(error)))?;
+            audit::write(
+                &state.pool,
+                false,
+                audit::AuditEvent {
+                    actor_entity_id: Some(auth.entity_id),
+                    tenant_id,
+                    target_kind: Some("entity"),
+                    target_id: Some(entity_id),
+                    event: "certificate.issue_replayed",
+                    outcome: AuditOutcome::Allow,
+                    details,
+                },
+            )
+            .await;
+        } else {
+            audit::commit_with_audit(
+                &state.pool,
+                tx,
+                state.config.events.enabled(),
+                &audit::AuditEvent {
+                    actor_entity_id: Some(auth.entity_id),
+                    tenant_id,
+                    target_kind: Some("entity"),
+                    target_id: Some(entity_id),
+                    event: "certificate.issue",
+                    outcome: AuditOutcome::Allow,
+                    details,
+                },
+            )
+            .await
+            .map_err(gql_error)?;
+        }
+        Ok(issued.into())
+    }
+
     async fn renew_certificate(
         &self,
         ctx: &Context<'_>,
@@ -326,6 +403,14 @@ pub struct IssueCertificateFromCsrInput {
 }
 
 #[derive(InputObject)]
+pub struct IssueCertificateFromCsrV2Input {
+    pub entity_id: ID,
+    pub ttl_secs: Option<u64>,
+    pub csr_pem: String,
+    pub idempotency_key: String,
+}
+
+#[derive(InputObject)]
 pub struct RenewCertificateInput {
     pub serial_number: String,
     pub ttl_secs: Option<u64>,
@@ -357,6 +442,8 @@ impl CertificateList {
 pub struct IssuedCertificate {
     pub certificate: Certificate,
     pub private_key_pem: Option<String>,
+    pub chain_pem: Option<String>,
+    pub idempotent_replay: bool,
 }
 
 #[Object]
@@ -367,6 +454,14 @@ impl IssuedCertificate {
 
     async fn private_key_pem(&self) -> Option<&str> {
         self.private_key_pem.as_deref()
+    }
+
+    async fn chain_pem(&self) -> Option<&str> {
+        self.chain_pem.as_deref()
+    }
+
+    async fn idempotent_replay(&self) -> bool {
+        self.idempotent_replay
     }
 }
 
@@ -380,6 +475,10 @@ impl Certificate {
 
     async fn entity_id(&self) -> ID {
         ID(self.0.entity_id.to_string())
+    }
+
+    async fn issuer_id(&self) -> Option<ID> {
+        self.0.issuer_id.map(|id| ID(id.to_string()))
     }
 
     async fn tenant_id(&self) -> Option<ID> {
@@ -414,6 +513,18 @@ impl Certificate {
         &self.0.fingerprint_sha256
     }
 
+    async fn profile_id(&self) -> Option<ID> {
+        self.0.profile_id.map(|id| ID(id.to_string()))
+    }
+
+    async fn profile_name(&self) -> Option<&str> {
+        self.0.profile_name.as_deref()
+    }
+
+    async fn identity_uri(&self) -> Option<&str> {
+        self.0.identity_uri.as_deref()
+    }
+
     async fn expires_at(&self) -> Option<String> {
         self.0.expires_at.map(|ts| ts.to_rfc3339())
     }
@@ -436,6 +547,8 @@ impl From<service::IssuedCertificate> for IssuedCertificate {
         IssuedCertificate {
             certificate: Certificate(value.certificate),
             private_key_pem: value.private_key_pem,
+            chain_pem: value.chain_pem,
+            idempotent_replay: value.idempotent_replay,
         }
     }
 }

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -7,9 +7,11 @@ use std::{collections::HashSet, fmt, net::IpAddr};
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
+use p256::{elliptic_curve::sec1::ToEncodedPoint, pkcs8::DecodePublicKey, PublicKey};
 use rcgen::{
     CertificateParams, CertificateSigningRequestParams, CrlDistributionPoint, CustomExtension,
-    DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, SerialNumber,
+    DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, PublicKeyData,
+    SanType, SerialNumber, SignatureAlgorithm, SigningKey, PKCS_ECDSA_P256_SHA256,
 };
 use ring::{digest, rand, rand::SecureRandom};
 use time::{Duration, OffsetDateTime};
@@ -21,8 +23,15 @@ use x509_parser::{
 };
 use yasna::{models::ObjectIdentifier, Tag};
 
-use crate::error::AppError;
+use crate::{config::PkiCaKeyConfig, error::AppError};
 
+use super::authority::{
+    key_provider::{
+        AuthorityKeyContext, AuthorityKeyProvider, AuthorityKeyProviderError,
+        EncryptedAuthorityKey, EncryptedDatabaseKeyProvider,
+    },
+    AuthorityKeyBackend, AuthorityRecord,
+};
 use super::profile::{
     CertificateProfile, ExtendedKeyUsage, KeyAlgorithm, KeyUsage, SanRule, SanRuleMode,
     StoredSubject,
@@ -33,10 +42,53 @@ const AIA_OID: &[u64] = &[1, 3, 6, 1, 5, 5, 7, 1, 1];
 const OCSP_ACCESS_METHOD_OID: &[u64] = &[1, 3, 6, 1, 5, 5, 7, 48, 1];
 const CA_ISSUERS_ACCESS_METHOD_OID: &[u64] = &[1, 3, 6, 1, 5, 5, 7, 48, 2];
 
+enum PkiSigningKey {
+    Local(KeyPair),
+    EncryptedDatabase {
+        provider: EncryptedDatabaseKeyProvider,
+        context: AuthorityKeyContext,
+        key: EncryptedAuthorityKey,
+        raw_public_key: Vec<u8>,
+    },
+}
+
+impl PublicKeyData for PkiSigningKey {
+    fn der_bytes(&self) -> &[u8] {
+        match self {
+            Self::Local(key) => key.der_bytes(),
+            Self::EncryptedDatabase { raw_public_key, .. } => raw_public_key,
+        }
+    }
+
+    fn algorithm(&self) -> &'static SignatureAlgorithm {
+        match self {
+            Self::Local(key) => key.algorithm(),
+            Self::EncryptedDatabase { .. } => &PKCS_ECDSA_P256_SHA256,
+        }
+    }
+}
+
+impl SigningKey for PkiSigningKey {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rcgen::Error> {
+        match self {
+            Self::Local(key) => key.sign(message),
+            Self::EncryptedDatabase {
+                provider,
+                context,
+                key,
+                ..
+            } => provider
+                .sign(*context, key, message)
+                .map(|signature| signature.bytes)
+                .map_err(|_| rcgen::Error::RemoteKeyError),
+        }
+    }
+}
+
 pub struct PkiIssuer {
     certificate_pem: String,
     chain_pem: String,
-    key_pair: KeyPair,
+    signing_key: PkiSigningKey,
     not_before: OffsetDateTime,
     not_after: OffsetDateTime,
     ocsp_url: String,
@@ -99,7 +151,97 @@ impl PkiIssuer {
         Ok(Self {
             certificate_pem: pem_encode_certificate(&certificate_der),
             chain_pem: chain_pem.to_string(),
-            key_pair,
+            signing_key: PkiSigningKey::Local(key_pair),
+            not_before,
+            not_after,
+            ocsp_url: ocsp_url.to_string(),
+            ca_issuers_url: ca_issuers_url.to_string(),
+            crl_distribution_point_url: crl_distribution_point_url.to_string(),
+        })
+    }
+
+    /// Load an active managed issuer without materializing a plaintext CA key.
+    /// The provider decrypts only inside each signing operation and immediately
+    /// drops its ephemeral signing-key value afterwards.
+    pub fn from_managed_authority(
+        authority: &AuthorityRecord,
+        ca_keys: &PkiCaKeyConfig,
+    ) -> Result<Self, AppError> {
+        if !authority.can_issue_leaves_at(Utc::now()) {
+            return Err(AppError::bad_request(
+                "issuing authority is not active and valid for leaf issuance",
+            ));
+        }
+        if authority.key_backend != AuthorityKeyBackend::EncryptedDatabase {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "managed authority key backend is not available for leaf issuance"
+            )));
+        }
+        let certificate_pem =
+            required_authority_field(authority.certificate_pem.as_deref(), "certificate")?;
+        let chain_pem = required_authority_field(authority.chain_pem.as_deref(), "chain")?;
+        let ocsp_url = required_authority_field(authority.ocsp_url.as_deref(), "OCSP URL")?;
+        let ca_issuers_url =
+            required_authority_field(authority.ca_issuers_url.as_deref(), "CA issuers URL")?;
+        let crl_distribution_point_url = required_authority_field(
+            authority.crl_distribution_point_url.as_deref(),
+            "CRL distribution point URL",
+        )?;
+        validate_route(ocsp_url, "OCSP")?;
+        validate_route(ca_issuers_url, "CA issuers")?;
+        validate_route(crl_distribution_point_url, "CRL distribution point")?;
+
+        let certificate_der = one_certificate_der(certificate_pem, "issuer certificate")?;
+        let (_, certificate) =
+            x509_parser::parse_x509_certificate(&certificate_der).map_err(|_| {
+                AppError::Internal(anyhow::anyhow!("stored invalid issuer certificate"))
+            })?;
+        validate_issuer_certificate(&certificate)?;
+        validate_chain(&certificate_der, chain_pem)?;
+
+        let fingerprint = hex::encode(digest::digest(&digest::SHA256, &certificate_der));
+        if authority.fingerprint_sha256.as_deref() != Some(&fingerprint)
+            || authority.not_before.map(|value| value.timestamp())
+                != Some(certificate.validity().not_before.timestamp())
+            || authority.not_after.map(|value| value.timestamp())
+                != Some(certificate.validity().not_after.timestamp())
+        {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "stored issuer metadata does not match its certificate"
+            )));
+        }
+
+        let context = AuthorityKeyContext {
+            authority_id: authority.id,
+            tenant_id: authority.tenant_id,
+            version: authority.version,
+        };
+        let provider = EncryptedDatabaseKeyProvider::new(ca_keys.clone());
+        let key =
+            EncryptedAuthorityKey::from_authority(authority).map_err(managed_key_provider_error)?;
+        let public = provider
+            .public_key(context, &key)
+            .map_err(managed_key_provider_error)?;
+        if public.subject_public_key_info_der != certificate.public_key().raw {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "managed authority key does not match its certificate"
+            )));
+        }
+        let public_key = PublicKey::from_public_key_der(&public.subject_public_key_info_der)
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid managed authority key")))?;
+        let raw_public_key = public_key.to_encoded_point(false).as_bytes().to_vec();
+        let not_before = certificate.validity().not_before.to_datetime();
+        let not_after = certificate.validity().not_after.to_datetime();
+
+        Ok(Self {
+            certificate_pem: pem_encode_certificate(&certificate_der),
+            chain_pem: chain_pem.to_string(),
+            signing_key: PkiSigningKey::EncryptedDatabase {
+                provider,
+                context,
+                key,
+                raw_public_key,
+            },
             not_before,
             not_after,
             ocsp_url: ocsp_url.to_string(),
@@ -228,7 +370,7 @@ pub fn issue_from_csr_at(
         params,
         public_key: parsed.params.public_key,
     };
-    let signer = Issuer::from_ca_cert_pem(&issuer.certificate_pem, &issuer.key_pair)
+    let signer = Issuer::from_ca_cert_pem(&issuer.certificate_pem, &issuer.signing_key)
         .map_err(core_encoding_error)?;
     let certificate = signing_request
         .signed_by(&signer)
@@ -736,6 +878,18 @@ fn validate_route(value: &str, label: &str) -> Result<(), AppError> {
         return Err(AppError::bad_request(format!("invalid {label} URL")));
     }
     Ok(())
+}
+
+fn required_authority_field<'a>(value: Option<&'a str>, label: &str) -> Result<&'a str, AppError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("managed authority {label} is missing")))
+}
+
+fn managed_key_provider_error(error: AuthorityKeyProviderError) -> AppError {
+    AppError::Internal(anyhow::anyhow!(
+        "managed authority key provider failed: {error}"
+    ))
 }
 
 fn rcgen_key_usage(usage: KeyUsage) -> KeyUsagePurpose {

--- a/src/certs/profile.rs
+++ b/src/certs/profile.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::{FromRow, PgPool, Postgres};
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::error::{db_err, AppError};
@@ -242,6 +242,38 @@ pub async fn resolve_for_subject(
 
     if let Some(base_profile_id) = profile.base_profile_id {
         let base = profile_by_id(pool, base_profile_id).await?;
+        validate_override(&profile, &base)?;
+    }
+    Ok(profile)
+}
+
+/// Transaction-scoped profile resolution for issuance paths.  Both the
+/// override and its platform ceiling are read through the caller's existing
+/// connection, so a constrained pool cannot deadlock on a nested acquire.
+pub async fn resolve_for_subject_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    subject: &StoredSubject,
+    name: &str,
+) -> Result<CertificateProfile, AppError> {
+    let query = format!(
+        r#"
+        SELECT {PROFILE_COLUMNS}
+        FROM certificate_profiles
+        WHERE name = $1
+          AND (tenant_id IS NULL OR tenant_id = $2)
+        ORDER BY (tenant_id IS NULL) ASC
+        LIMIT 1
+        "#
+    );
+    let row = sqlx::query_as::<_, ProfileRow>(&query)
+        .bind(name)
+        .bind(subject.tenant_id)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(db_err)?;
+    let profile = CertificateProfile::try_from(row)?;
+    if let Some(base_profile_id) = profile.base_profile_id {
+        let base = profile_by_id(&mut **tx, base_profile_id).await?;
         validate_override(&profile, &base)?;
     }
     Ok(profile)

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -8,6 +8,7 @@ use crate::error::{db_err, AppError};
 #[derive(Debug, Clone, FromRow)]
 pub struct CertificateCredential {
     pub id: Uuid,
+    pub issuer_id: Option<Uuid>,
     pub entity_id: Uuid,
     pub tenant_id: Option<Uuid>,
     pub identifier: String,
@@ -15,6 +16,12 @@ pub struct CertificateCredential {
     pub metadata: Value,
     pub expires_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CertificateIssuanceRequestClaim {
+    New { request_id: Uuid },
+    Replay { credential_id: Uuid },
 }
 
 #[derive(Debug, Clone, FromRow)]
@@ -72,6 +79,116 @@ pub async fn insert_certificate_credential(
     .map_err(AppError::Database)
 }
 
+pub async fn insert_managed_certificate_credential(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_id: Uuid,
+    issuer_id: Uuid,
+    serial_number: &str,
+    metadata: Value,
+    expires_at: DateTime<Utc>,
+) -> Result<Uuid, AppError> {
+    sqlx::query_scalar(
+        r#"
+        INSERT INTO credentials (
+            id, entity_id, kind, identifier, metadata, expires_at, issuer_id
+        )
+        VALUES ($1, $2, 'certificate', $3, $4, $5, $6)
+        RETURNING id
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(entity_id)
+    .bind(serial_number)
+    .bind(metadata)
+    .bind(expires_at)
+    .bind(issuer_id)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(AppError::Database)
+}
+
+pub async fn claim_certificate_issuance_request(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_id: Uuid,
+    request_key_hash: &str,
+    request_fingerprint_sha256: &str,
+) -> Result<CertificateIssuanceRequestClaim, AppError> {
+    let request_id = Uuid::new_v4();
+    let inserted = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO certificate_issuance_requests (
+            id, entity_id, request_key_hash, request_fingerprint_sha256
+        )
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (entity_id, request_key_hash) DO NOTHING
+        RETURNING id
+        "#,
+    )
+    .bind(request_id)
+    .bind(entity_id)
+    .bind(request_key_hash)
+    .bind(request_fingerprint_sha256)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    if inserted.is_some() {
+        return Ok(CertificateIssuanceRequestClaim::New { request_id });
+    }
+
+    let existing = sqlx::query_as::<_, (String, Option<Uuid>)>(
+        r#"
+        SELECT request_fingerprint_sha256, credential_id
+        FROM certificate_issuance_requests
+        WHERE entity_id = $1 AND request_key_hash = $2
+        FOR UPDATE
+        "#,
+    )
+    .bind(entity_id)
+    .bind(request_key_hash)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    if existing.0 != request_fingerprint_sha256 {
+        return Err(AppError::conflict(
+            "idempotency key was already used for a different certificate request",
+        ));
+    }
+    existing
+        .1
+        .map(|credential_id| CertificateIssuanceRequestClaim::Replay { credential_id })
+        .ok_or_else(|| {
+            AppError::Internal(anyhow::anyhow!(
+                "stored certificate issuance request is incomplete"
+            ))
+        })
+}
+
+pub async fn complete_certificate_issuance_request(
+    tx: &mut Transaction<'_, Postgres>,
+    request_id: Uuid,
+    credential_id: Uuid,
+) -> Result<(), AppError> {
+    let completed = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        UPDATE certificate_issuance_requests
+        SET credential_id = $2, completed_at = now()
+        WHERE id = $1 AND credential_id IS NULL
+        RETURNING id
+        "#,
+    )
+    .bind(request_id)
+    .bind(credential_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    if completed.is_none() {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "certificate issuance request could not be completed"
+        )));
+    }
+    Ok(())
+}
+
 pub async fn certificate_by_serial<'e, E>(
     executor: E,
     serial_number: &str,
@@ -81,7 +198,7 @@ where
 {
     sqlx::query_as::<_, CertificateCredential>(
         r#"
-        SELECT c.id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
                c.expires_at, c.created_at
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id
@@ -112,7 +229,7 @@ where
 {
     sqlx::query_as::<_, CertificateCredential>(
         r#"
-        SELECT c.id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
                c.expires_at, c.created_at
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id
@@ -135,7 +252,7 @@ pub async fn list_certificates(
 ) -> Result<Vec<CertificateCredential>, AppError> {
     let mut query = QueryBuilder::<Postgres>::new(
         r#"
-        SELECT c.id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
                c.expires_at, c.created_at
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id
@@ -198,7 +315,7 @@ where
 {
     sqlx::query_as::<_, CertificateCredential>(
         r#"
-        SELECT c.id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
                c.expires_at, c.created_at
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id
@@ -222,7 +339,7 @@ pub async fn revoked_certificates(
 ) -> Result<Vec<CertificateCredential>, AppError> {
     sqlx::query_as::<_, CertificateCredential>(
         r#"
-        SELECT c.id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
                c.expires_at, c.created_at
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -29,7 +29,10 @@ use crate::{
     identity,
 };
 
-use super::repo;
+use super::{
+    authority::{repo as authority_repo, AuthorityKind, AuthorityRecord},
+    pki_core, profile, repo,
+};
 
 const CRL_REGEN_LOCK_ID: i64 = 0x0041_544f_4d43_524c;
 const LEAF_CLOCK_SKEW_SECS: i64 = 300;
@@ -53,6 +56,14 @@ pub struct IssueCertificateFromCsr {
 }
 
 #[derive(Debug, Clone)]
+pub struct IssueCertificateFromCsrV2 {
+    pub entity_id: Uuid,
+    pub ttl_secs: Option<u64>,
+    pub csr_pem: String,
+    pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct RenewCertificate {
     pub serial_number: String,
     pub ttl_secs: Option<u64>,
@@ -62,6 +73,8 @@ pub struct RenewCertificate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CertificateMetadata {
     pub certificate_pem: String,
+    #[serde(default)]
+    pub chain_pem: Option<String>,
     pub subject: Value,
     pub dns_names: Vec<String>,
     pub ip_addresses: Vec<String>,
@@ -70,6 +83,12 @@ pub struct CertificateMetadata {
     pub issuer_serial_number: String,
     pub issuer_fingerprint_sha256: String,
     pub fingerprint_sha256: String,
+    #[serde(default)]
+    pub profile_id: Option<Uuid>,
+    #[serde(default)]
+    pub profile_name: Option<String>,
+    #[serde(default)]
+    pub identity_uri: Option<String>,
     pub not_before: DateTime<Utc>,
     pub not_after: DateTime<Utc>,
     pub issued_from_csr: bool,
@@ -80,15 +99,20 @@ pub struct CertificateMetadata {
 #[derive(Debug, Clone)]
 pub struct CertificateRecord {
     pub credential_id: Uuid,
+    pub issuer_id: Option<Uuid>,
     pub entity_id: Uuid,
     pub tenant_id: Option<Uuid>,
     pub serial_number: String,
     pub status: String,
     pub certificate_pem: String,
+    pub chain_pem: Option<String>,
     pub subject: Value,
     pub dns_names: Vec<String>,
     pub ip_addresses: Vec<String>,
     pub fingerprint_sha256: String,
+    pub profile_id: Option<Uuid>,
+    pub profile_name: Option<String>,
+    pub identity_uri: Option<String>,
     pub expires_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub revoked_at: Option<DateTime<Utc>>,
@@ -99,6 +123,8 @@ pub struct CertificateRecord {
 pub struct IssuedCertificate {
     pub certificate: CertificateRecord,
     pub private_key_pem: Option<String>,
+    pub chain_pem: Option<String>,
+    pub idempotent_replay: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -414,6 +440,8 @@ pub async fn issue_certificate_in_tx(
                 return Ok(IssuedCertificate {
                     certificate: record,
                     private_key_pem: Some(private_key_pem),
+                    chain_pem: Some(loaded.chain_pem.clone()),
+                    idempotent_replay: false,
                 });
             }
             Err(err) if is_unique_violation(&err) && attempt + 1 < SERIAL_INSERT_ATTEMPTS => {
@@ -499,12 +527,133 @@ pub async fn issue_certificate_from_csr_in_tx(
                 return Ok(IssuedCertificate {
                     certificate: record,
                     private_key_pem: None,
+                    chain_pem: Some(loaded.chain_pem.clone()),
+                    idempotent_replay: false,
                 });
             }
             Err(err) if is_unique_violation(&err) && attempt + 1 < SERIAL_INSERT_ATTEMPTS => {
                 attempt_tx.rollback().await.map_err(AppError::Database)?;
             }
             Err(err) => return Err(err),
+        }
+    }
+
+    Err(AppError::conflict(
+        "failed to allocate a unique certificate serial number",
+    ))
+}
+
+/// Explicitly versioned, managed-issuer CSR path introduced by PR-005.
+///
+/// `authorized_tenant_id` is produced by the transport authorization layer;
+/// it is not a public request field.  Rechecking it after locking the entity
+/// closes the authorization-to-issuance race without accepting caller scope.
+pub async fn issue_certificate_from_csr_v2(
+    pool: &sqlx::PgPool,
+    config: &Config,
+    authorized_tenant_id: Option<Uuid>,
+    input: IssueCertificateFromCsrV2,
+) -> Result<IssuedCertificate, AppError> {
+    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let issued =
+        issue_certificate_from_csr_v2_in_tx(&mut tx, config, authorized_tenant_id, input).await?;
+    tx.commit().await.map_err(AppError::Database)?;
+    Ok(issued)
+}
+
+/// Managed CSR issuance using only the caller's existing transaction and
+/// nested savepoints for serial retries.
+pub async fn issue_certificate_from_csr_v2_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    config: &Config,
+    authorized_tenant_id: Option<Uuid>,
+    input: IssueCertificateFromCsrV2,
+) -> Result<IssuedCertificate, AppError> {
+    validate_idempotency_key(&input.idempotency_key)?;
+    let (_, stored_tenant_id) = identity::repo::lock_active_entity(tx, input.entity_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("entity not found"))?;
+    if stored_tenant_id != authorized_tenant_id {
+        return Err(AppError::Forbidden);
+    }
+    let subject = profile::load_subject(&mut **tx, input.entity_id).await?;
+    if subject.tenant_id() != stored_tenant_id {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "locked entity scope changed during certificate issuance"
+        )));
+    }
+
+    let request_key_hash = issuance_request_key_hash(&input.idempotency_key);
+    let request_fingerprint =
+        issuance_request_fingerprint(input.entity_id, input.ttl_secs, input.csr_pem.as_bytes());
+    let request_id = match repo::claim_certificate_issuance_request(
+        tx,
+        input.entity_id,
+        &request_key_hash,
+        &request_fingerprint,
+    )
+    .await?
+    {
+        repo::CertificateIssuanceRequestClaim::New { request_id } => request_id,
+        repo::CertificateIssuanceRequestClaim::Replay { credential_id } => {
+            let certificate =
+                record_from_row(repo::fetch_certificate_by_id(&mut **tx, credential_id).await?)?;
+            return Ok(IssuedCertificate {
+                chain_pem: certificate.chain_pem.clone(),
+                certificate,
+                private_key_pem: None,
+                idempotent_replay: true,
+            });
+        }
+    };
+
+    let certificate_profile = profile::resolve_for_subject_in_tx(tx, &subject, "client").await?;
+    let authority = authority_repo::lock_active_leaf_issuer_for_scope(tx, stored_tenant_id).await?;
+    validate_issuer_scope(&authority, stored_tenant_id)?;
+    let issuer = pki_core::PkiIssuer::from_managed_authority(&authority, &config.pki_ca_keys)?;
+
+    for attempt in 0..SERIAL_INSERT_ATTEMPTS {
+        let issued = pki_core::issue_from_csr(
+            &certificate_profile,
+            &subject,
+            &issuer,
+            pki_core::IssueFromCsr {
+                csr_pem: &input.csr_pem,
+                requested_ttl_seconds: input.ttl_secs,
+            },
+        )?;
+        let chain_pem = issued.chain_pem.clone();
+        let mut attempt_tx = tx.begin().await.map_err(AppError::Database)?;
+        let outcome =
+            persist_managed_certificate(&mut attempt_tx, input.entity_id, &authority, issued).await;
+        match outcome {
+            Ok(certificate) => {
+                repo::complete_certificate_issuance_request(
+                    &mut attempt_tx,
+                    request_id,
+                    certificate.credential_id,
+                )
+                .await?;
+                attempt_tx.commit().await.map_err(AppError::Database)?;
+                return Ok(IssuedCertificate {
+                    certificate,
+                    private_key_pem: None,
+                    chain_pem: Some(chain_pem),
+                    idempotent_replay: false,
+                });
+            }
+            Err(error) if is_unique_violation(&error) => {
+                attempt_tx.rollback().await.map_err(AppError::Database)?;
+                if attempt + 1 == SERIAL_INSERT_ATTEMPTS {
+                    return Err(AppError::conflict(
+                        "failed to allocate a unique certificate serial number",
+                    ));
+                }
+            }
+            Err(error) => {
+                attempt_tx.rollback().await.map_err(AppError::Database)?;
+                return Err(error);
+            }
         }
     }
 
@@ -905,6 +1054,7 @@ async fn persist_certificate(
     let fingerprint_sha256 = certificate_fingerprint_sha256(&input.certificate_pem)?;
     let metadata = CertificateMetadata {
         certificate_pem: input.certificate_pem,
+        chain_pem: Some(issuer.chain_pem.clone()),
         subject: input.subject,
         dns_names: input.dns_names,
         ip_addresses: input.ip_addresses,
@@ -913,6 +1063,9 @@ async fn persist_certificate(
         issuer_serial_number: issuer.issuer_serial_number.clone(),
         issuer_fingerprint_sha256: issuer.issuer_fingerprint_sha256.clone(),
         fingerprint_sha256,
+        profile_id: None,
+        profile_name: None,
+        identity_uri: None,
         not_before: input.not_before,
         not_after: input.not_after,
         issued_from_csr: input.issued_from_csr,
@@ -938,24 +1091,146 @@ async fn persist_certificate(
     record_from_row(repo::fetch_certificate_by_id(&mut **tx, id).await?)
 }
 
+async fn persist_managed_certificate(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    entity_id: Uuid,
+    authority: &AuthorityRecord,
+    issued: pki_core::IssuedCertificate,
+) -> Result<CertificateRecord, AppError> {
+    let issuer_serial_number = authority.serial_number.clone().ok_or_else(|| {
+        AppError::Internal(anyhow::anyhow!("managed issuer serial number is missing"))
+    })?;
+    let issuer_fingerprint_sha256 = authority.fingerprint_sha256.clone().ok_or_else(|| {
+        AppError::Internal(anyhow::anyhow!("managed issuer fingerprint is missing"))
+    })?;
+    let metadata = CertificateMetadata {
+        certificate_pem: issued.certificate_pem,
+        chain_pem: Some(issued.chain_pem),
+        subject: json!({
+            "common_name": entity_id,
+            "identity_uri": issued.identity_uri.clone(),
+        }),
+        dns_names: issued.dns_names,
+        ip_addresses: issued
+            .ip_addresses
+            .into_iter()
+            .map(|address| address.to_string())
+            .collect(),
+        issuer_kind: authority_kind_name(authority.kind).to_string(),
+        issuer_subject: authority.subject.clone(),
+        issuer_serial_number,
+        issuer_fingerprint_sha256,
+        fingerprint_sha256: issued.fingerprint_sha256,
+        profile_id: Some(issued.profile_id),
+        profile_name: Some(issued.profile_name),
+        identity_uri: Some(issued.identity_uri),
+        not_before: issued.not_before,
+        not_after: issued.not_after,
+        issued_from_csr: true,
+        revoked_at: None,
+        revocation_reason: None,
+    };
+    let id = repo::insert_managed_certificate_credential(
+        tx,
+        entity_id,
+        authority.id,
+        &issued.serial_number,
+        serde_json::to_value(metadata).map_err(|error| {
+            AppError::Internal(anyhow::anyhow!(
+                "failed to encode certificate metadata: {error}"
+            ))
+        })?,
+        issued.not_after,
+    )
+    .await?;
+    record_from_row(repo::fetch_certificate_by_id(&mut **tx, id).await?)
+}
+
 fn record_from_row(row: repo::CertificateCredential) -> Result<CertificateRecord, AppError> {
     let metadata = metadata_from_value(&row.metadata)?;
     Ok(CertificateRecord {
         credential_id: row.id,
+        issuer_id: row.issuer_id,
         entity_id: row.entity_id,
         tenant_id: row.tenant_id,
         serial_number: row.identifier,
         status: row.status,
         certificate_pem: metadata.certificate_pem,
+        chain_pem: metadata.chain_pem,
         subject: metadata.subject,
         dns_names: metadata.dns_names,
         ip_addresses: metadata.ip_addresses,
         fingerprint_sha256: metadata.fingerprint_sha256,
+        profile_id: metadata.profile_id,
+        profile_name: metadata.profile_name,
+        identity_uri: metadata.identity_uri,
         expires_at: row.expires_at,
         created_at: row.created_at,
         revoked_at: metadata.revoked_at,
         revocation_reason: metadata.revocation_reason,
     })
+}
+
+fn validate_issuer_scope(
+    authority: &AuthorityRecord,
+    tenant_id: Option<Uuid>,
+) -> Result<(), AppError> {
+    let matches = match tenant_id {
+        Some(tenant_id) => {
+            authority.kind == AuthorityKind::TenantIntermediate
+                && authority.tenant_id == Some(tenant_id)
+        }
+        None => {
+            authority.kind == AuthorityKind::PlatformLeafIssuer && authority.tenant_id.is_none()
+        }
+    };
+    if matches {
+        Ok(())
+    } else {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "selected issuing authority does not match the locked entity scope"
+        )))
+    }
+}
+
+fn authority_kind_name(kind: AuthorityKind) -> &'static str {
+    match kind {
+        AuthorityKind::Root => "root",
+        AuthorityKind::PlatformIntermediate => "platform_intermediate",
+        AuthorityKind::PlatformLeafIssuer => "platform_leaf_issuer",
+        AuthorityKind::TenantIntermediate => "tenant_intermediate",
+    }
+}
+
+fn validate_idempotency_key(value: &str) -> Result<(), AppError> {
+    if value.is_empty() || value.len() > 256 || value.chars().any(char::is_control) {
+        return Err(AppError::bad_request(
+            "idempotency key must contain 1 to 256 non-control UTF-8 bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn issuance_request_key_hash(value: &str) -> String {
+    let mut context = digest::Context::new(&digest::SHA256);
+    context.update(b"atom:pki:csr-issuance-key:v1\0");
+    context.update(value.as_bytes());
+    hex::encode(context.finish())
+}
+
+fn issuance_request_fingerprint(entity_id: Uuid, ttl_secs: Option<u64>, csr_pem: &[u8]) -> String {
+    let mut context = digest::Context::new(&digest::SHA256);
+    context.update(b"atom:pki:csr-issuance-request:v1\0");
+    context.update(entity_id.as_bytes());
+    match ttl_secs {
+        Some(ttl) => {
+            context.update(&[1]);
+            context.update(&ttl.to_be_bytes());
+        }
+        None => context.update(&[0]),
+    }
+    context.update(csr_pem);
+    hex::encode(context.finish())
 }
 
 fn metadata_from_value(value: &Value) -> Result<CertificateMetadata, AppError> {

--- a/tests/m32_pki_csr_issuance.rs
+++ b/tests/m32_pki_csr_issuance.rs
@@ -1,0 +1,760 @@
+//! PR-005 managed CSR issuance coverage.
+//!
+//! Requires PostgreSQL and OpenSSL. The CI fresh-database matrix executes this
+//! ignored test binary single-threaded.
+
+mod common;
+
+use std::{fs, process::Command};
+
+use async_graphql::{Request, Variables};
+use atom::{
+    auth::AuthContext,
+    certs::authority::{provisioning, repo as authority_repo, AuthorityRecord},
+    config::{Config, PkiCaKeyConfig},
+    graphql::build_schema,
+    keys::{ActiveKeys, LoadedKey},
+    state::AppState,
+};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use rcgen::{
+    BasicConstraints, CertificateParams, CertificateSigningRequestParams, DnType,
+    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyIdMethod, KeyPair, KeyUsagePurpose, SanType,
+};
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
+use uuid::Uuid;
+use x509_parser::pem::parse_x509_pem;
+
+const OCSP_URL: &str = "https://pki.example.test/tenant/ocsp";
+const CA_ISSUERS_URL: &str = "https://pki.example.test/tenant/ca.der";
+const CRL_URL: &str = "https://pki.example.test/tenant/crl.der";
+
+struct TestRoot {
+    params: CertificateParams,
+    key: KeyPair,
+    pem: String,
+}
+
+#[tokio::test]
+#[ignore]
+async fn managed_csr_issuance_enforces_the_pr005_contract() {
+    let pool = common::pool().await;
+    let config = managed_config();
+    let tenant_a = create_tenant(&pool, "pki-csr-a").await;
+    let tenant_b = create_tenant(&pool, "pki-csr-b").await;
+    let tenant_without_issuer = create_tenant(&pool, "pki-csr-none").await;
+    let entity_a = create_entity(&pool, tenant_a, "pki-csr-actor-a").await;
+    let entity_b = create_entity(&pool, tenant_b, "pki-csr-target-b").await;
+    let entity_without_issuer =
+        create_entity(&pool, tenant_without_issuer, "pki-csr-no-issuer").await;
+
+    let root = test_root();
+    let issuer = provision_tenant_issuer(&pool, &config.pki_ca_keys, &root, tenant_a).await;
+    let schema = build_schema(graphql_state(pool.clone(), config.clone()));
+
+    // The public v2 contract has no tenant, issuer, CA path, key reference, or
+    // profile selector. Scope and signer selection remain internal.
+    let introspection = schema
+        .execute(Request::new(
+            r#"{
+              __type(name: "IssueCertificateFromCsrV2Input") {
+                inputFields { name }
+              }
+            }"#,
+        ))
+        .await;
+    assert!(
+        introspection.errors.is_empty(),
+        "{:?}",
+        introspection.errors
+    );
+    let mut input_fields = introspection.data.into_json().unwrap()["__type"]["inputFields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|field| field["name"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    input_fields.sort();
+    assert_eq!(
+        input_fields,
+        vec![
+            "csrPem".to_string(),
+            "entityId".to_string(),
+            "idempotencyKey".to_string(),
+            "ttlSecs".to_string(),
+        ]
+    );
+
+    let plain_csr = csr(|_| {});
+    let first = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &plain_csr,
+            "request-one",
+            Some(3600),
+        ))
+        .await;
+    assert!(first.errors.is_empty(), "{:?}", first.errors);
+    let first = first.data.into_json().unwrap()["issueCertificateFromCsrV2"].clone();
+    assert_eq!(first["privateKeyPem"], Value::Null);
+    assert_eq!(first["idempotentReplay"], false);
+    assert_eq!(first["certificate"]["issuerId"], issuer.id.to_string());
+    assert_eq!(first["certificate"]["entityId"], entity_a.to_string());
+    assert_eq!(first["certificate"]["tenantId"], tenant_a.to_string());
+    assert_eq!(first["certificate"]["profileName"], "client");
+    assert_eq!(
+        first["certificate"]["identityUri"],
+        format!("urn:atom:tenant:{tenant_a}:entity:{entity_a}")
+    );
+    let credential_id: Uuid = first["certificate"]["credentialId"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let serial_number = first["certificate"]["serialNumber"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let leaf_pem = first["certificate"]["certificatePem"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let chain_pem = first["chainPem"].as_str().unwrap().to_string();
+    assert_eq!(chain_pem.matches("BEGIN CERTIFICATE").count(), 3);
+    assert_chain_with_openssl(&leaf_pem, &chain_pem, &root.pem);
+
+    let persisted: (Option<Uuid>, Uuid, Value, Option<String>, Option<Vec<u8>>) = sqlx::query_as(
+        r#"SELECT issuer_id, entity_id, metadata, secret_hash, secret_ciphertext
+               FROM credentials WHERE id = $1"#,
+    )
+    .bind(credential_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(persisted.0, Some(issuer.id));
+    assert_eq!(persisted.1, entity_a);
+    assert!(persisted.3.is_none() && persisted.4.is_none());
+    let persisted_text = persisted.2.to_string();
+    assert!(!persisted_text.contains("PRIVATE KEY"));
+    assert_eq!(persisted.2["profile_name"], "client");
+    assert_eq!(
+        persisted.2["identity_uri"],
+        first["certificate"]["identityUri"]
+    );
+
+    // An exact retry resolves to the original credential and creates neither a
+    // second certificate nor a second domain event.
+    let replay = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &plain_csr,
+            "request-one",
+            Some(3600),
+        ))
+        .await;
+    assert!(replay.errors.is_empty(), "{:?}", replay.errors);
+    let replay = replay.data.into_json().unwrap()["issueCertificateFromCsrV2"].clone();
+    assert_eq!(replay["idempotentReplay"], true);
+    assert_eq!(
+        replay["certificate"]["credentialId"],
+        credential_id.to_string()
+    );
+    assert_eq!(replay["certificate"]["serialNumber"], serial_number);
+    assert_eq!(certificate_count(&pool, entity_a).await, 1);
+
+    let mismatched_retry = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &csr(|_| {}),
+            "request-one",
+            Some(3600),
+        ))
+        .await;
+    assert!(errors_contain(&mismatched_retry.errors, "idempotency key"));
+    assert_eq!(certificate_count(&pool, entity_a).await, 1);
+
+    let ledger: (String, String, Option<Uuid>) = sqlx::query_as(
+        r#"SELECT request_key_hash, request_fingerprint_sha256, credential_id
+           FROM certificate_issuance_requests WHERE entity_id = $1"#,
+    )
+    .bind(entity_a)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_ne!(ledger.0, "request-one");
+    assert_eq!(ledger.0.len(), 64);
+    assert_eq!(ledger.1.len(), 64);
+    assert_eq!(ledger.2, Some(credential_id));
+    assert_eq!(
+        event_count(&pool, "audit_logs", "certificate.issue", entity_a).await,
+        1
+    );
+    assert_eq!(
+        event_count(&pool, "event_outbox", "certificate.issue", entity_a).await,
+        1
+    );
+    assert_eq!(
+        event_count(&pool, "audit_logs", "certificate.issue_replayed", entity_a,).await,
+        1
+    );
+
+    // A tenant-A principal can manage itself but cannot use that identity to
+    // sign a certificate for a tenant-B entity.
+    let cross_tenant = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_b,
+            &plain_csr,
+            "cross-tenant",
+            Some(3600),
+        ))
+        .await;
+    assert!(errors_contain(&cross_tenant.errors, "forbidden"));
+    assert_eq!(certificate_count(&pool, entity_b).await, 0);
+
+    // The same issuer mismatch is rejected if an internal/import path attempts
+    // to bypass the service boundary.
+    let db_scope_error = sqlx::query(
+        r#"INSERT INTO credentials (
+               id, entity_id, kind, identifier, issuer_id, metadata
+           ) VALUES ($1, $2, 'certificate', $3, $4, '{}')"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(entity_b)
+    .bind(format!("deadbeef{}", Uuid::new_v4().simple()))
+    .bind(issuer.id)
+    .execute(&pool)
+    .await
+    .expect_err("cross-tenant issuer insert must fail");
+    assert!(matches!(
+        db_scope_error,
+        sqlx::Error::Database(ref database) if database.code().as_deref() == Some("23514")
+    ));
+
+    let no_issuer = schema
+        .execute(issue_request(
+            entity_without_issuer,
+            Some(tenant_without_issuer),
+            entity_without_issuer,
+            &plain_csr,
+            "no-issuer",
+            Some(3600),
+        ))
+        .await;
+    assert!(errors_contain(
+        &no_issuer.errors,
+        "no active issuing authority"
+    ));
+    assert_eq!(certificate_count(&pool, entity_without_issuer).await, 0);
+
+    // The production route reaches the PR-004 CSR policy boundary rather than
+    // copying privileged request extensions.
+    let attacks = [
+        ("malformed", "not a CSR".to_string()),
+        ("invalid-signature", corrupt_csr_signature(&plain_csr)),
+        (
+            "ca-request",
+            csr(|params| {
+                params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+                params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+            }),
+        ),
+        (
+            "identity-substitution",
+            csr(|params| {
+                params.subject_alt_names = vec![SanType::URI(
+                    "urn:atom:tenant:attacker:entity:attacker"
+                        .try_into()
+                        .unwrap(),
+                )];
+            }),
+        ),
+        (
+            "arbitrary-eku",
+            csr(|params| params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth]),
+        ),
+    ];
+    for (key, attack) in attacks {
+        let response = schema
+            .execute(issue_request(
+                entity_a,
+                Some(tenant_a),
+                entity_a,
+                &attack,
+                key,
+                Some(3600),
+            ))
+            .await;
+        assert!(
+            !response.errors.is_empty(),
+            "attack {key} unexpectedly passed"
+        );
+    }
+    assert_eq!(certificate_count(&pool, entity_a).await, 1);
+
+    // A synthetic first-attempt unique violation proves the service rolls back
+    // the poisoned savepoint and retries on the same outer connection.
+    install_serial_collision_trigger(&pool, entity_a).await;
+    let collision = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &plain_csr,
+            "serial-collision",
+            Some(3600),
+        ))
+        .await;
+    assert!(collision.errors.is_empty(), "{:?}", collision.errors);
+    let collision_attempts: i64 =
+        sqlx::query_scalar("SELECT last_value FROM pki_test_serial_collision_seq")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(collision_attempts, 2);
+    remove_serial_collision_trigger(&pool).await;
+    assert_eq!(certificate_count(&pool, entity_a).await, 2);
+
+    // Signing occurs before credential persistence. A forced database failure
+    // returns no artifact and rolls back the credential, retry ledger, audit,
+    // and outbox state together.
+    install_persistence_failure_trigger(&pool, entity_a).await;
+    let before_credentials = certificate_count(&pool, entity_a).await;
+    let before_requests = issuance_request_count(&pool, entity_a).await;
+    let before_events = event_count(&pool, "event_outbox", "certificate.issue", entity_a).await;
+    let rollback = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &plain_csr,
+            "forced-rollback",
+            Some(3600),
+        ))
+        .await;
+    assert!(!rollback.errors.is_empty());
+    remove_persistence_failure_trigger(&pool).await;
+    assert_eq!(certificate_count(&pool, entity_a).await, before_credentials);
+    assert_eq!(
+        issuance_request_count(&pool, entity_a).await,
+        before_requests
+    );
+    assert_eq!(
+        event_count(&pool, "event_outbox", "certificate.issue", entity_a).await,
+        before_events
+    );
+
+    // Both expired and retiring issuers are excluded by the internal selector.
+    let original_not_before = issuer.not_before.unwrap();
+    let original_not_after = issuer.not_after.unwrap();
+    sqlx::query(
+        r#"UPDATE pki_authorities
+           SET not_before = $2, not_after = now() - interval '1 second'
+           WHERE id = $1"#,
+    )
+    .bind(issuer.id)
+    .bind(original_not_before)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let expired = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &plain_csr,
+            "expired-issuer",
+            Some(3600),
+        ))
+        .await;
+    assert!(errors_contain(
+        &expired.errors,
+        "no active issuing authority"
+    ));
+    sqlx::query("UPDATE pki_authorities SET not_before = $2, not_after = $3 WHERE id = $1")
+        .bind(issuer.id)
+        .bind(original_not_before)
+        .bind(original_not_after)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"UPDATE pki_authorities
+           SET status = 'retiring', issuance_enabled = false, retiring_at = now()
+           WHERE id = $1"#,
+    )
+    .bind(issuer.id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let retiring = schema
+        .execute(issue_request(
+            entity_a,
+            Some(tenant_a),
+            entity_a,
+            &plain_csr,
+            "retiring-issuer",
+            Some(3600),
+        ))
+        .await;
+    assert!(errors_contain(
+        &retiring.errors,
+        "no active issuing authority"
+    ));
+}
+
+fn managed_config() -> Config {
+    let mut config = Config::for_tests();
+    config.events.amqp_url = Some("amqp://unused-in-pr005-test".to_string());
+    config
+}
+
+fn graphql_state(pool: PgPool, config: Config) -> AppState {
+    let primary = LoadedKey {
+        kid: "test".into(),
+        public_key_pem: String::new(),
+        private_key_pem: String::new(),
+        x_b64: String::new(),
+        y_b64: String::new(),
+    };
+    AppState::new(
+        pool,
+        config,
+        ActiveKeys {
+            primary,
+            standby: None,
+        },
+        None,
+    )
+}
+
+fn issue_request(
+    actor_id: Uuid,
+    actor_tenant_id: Option<Uuid>,
+    entity_id: Uuid,
+    csr_pem: &str,
+    idempotency_key: &str,
+    ttl_secs: Option<u64>,
+) -> Request {
+    Request::new(
+        r#"mutation Issue($input: IssueCertificateFromCsrV2Input!) {
+          issueCertificateFromCsrV2(input: $input) {
+            idempotentReplay
+            chainPem
+            privateKeyPem
+            certificate {
+              credentialId
+              issuerId
+              entityId
+              tenantId
+              serialNumber
+              certificatePem
+              fingerprintSha256
+              profileId
+              profileName
+              identityUri
+            }
+          }
+        }"#,
+    )
+    .variables(Variables::from_json(json!({
+        "input": {
+            "entityId": entity_id,
+            "ttlSecs": ttl_secs,
+            "csrPem": csr_pem,
+            "idempotencyKey": idempotency_key,
+        }
+    })))
+    .data(AuthContext {
+        entity_id: actor_id,
+        tenant_id: actor_tenant_id,
+        session_id: None,
+        ..Default::default()
+    })
+}
+
+fn errors_contain(errors: &[async_graphql::ServerError], expected: &str) -> bool {
+    errors.iter().any(|error| error.message.contains(expected))
+}
+
+fn csr(mutate: impl FnOnce(&mut CertificateParams)) -> String {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::default();
+    mutate(&mut params);
+    params.serialize_request(&key).unwrap().pem().unwrap()
+}
+
+fn corrupt_csr_signature(csr_pem: &str) -> String {
+    let (_, pem) = parse_x509_pem(csr_pem.as_bytes()).unwrap();
+    let mut der = pem.contents;
+    *der.last_mut().unwrap() ^= 0x01;
+    pem_encode("CERTIFICATE REQUEST", &der)
+}
+
+fn pem_encode(label: &str, der: &[u8]) -> String {
+    let encoded = STANDARD.encode(der);
+    let mut pem = format!("-----BEGIN {label}-----\n");
+    for chunk in encoded.as_bytes().chunks(64) {
+        pem.extend(chunk.iter().map(|byte| char::from(*byte)));
+        pem.push('\n');
+    }
+    pem.push_str(&format!("-----END {label}-----\n"));
+    pem
+}
+
+fn test_root() -> TestRoot {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "PR-005 Offline Root");
+    params.is_ca = IsCa::Ca(BasicConstraints::Constrained(2));
+    params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    params.key_identifier_method = KeyIdMethod::Sha256;
+    params.not_before = OffsetDateTime::now_utc() - Duration::days(1);
+    params.not_after = OffsetDateTime::now_utc() + Duration::days(365);
+    let pem = params.self_signed(&key).unwrap().pem();
+    TestRoot { params, key, pem }
+}
+
+async fn provision_tenant_issuer(
+    pool: &PgPool,
+    ca_keys: &PkiCaKeyConfig,
+    root: &TestRoot,
+    tenant_id: Uuid,
+) -> AuthorityRecord {
+    let mut tx = pool.begin().await.unwrap();
+    provisioning::import_root_in_tx(&mut tx, &root.pem)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    let signed = sign_authority_csr(&pending, root);
+    let mut tx = pool.begin().await.unwrap();
+    let imported =
+        provisioning::import_signed_authority_in_tx(&mut tx, ca_keys, pending.id, &signed)
+            .await
+            .unwrap();
+    assert!(imported.succeeded(), "{:?}", imported.validation_error);
+    tx.commit().await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let provisioned =
+        provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
+            .await
+            .unwrap();
+    assert!(
+        provisioned.succeeded(),
+        "{:?}",
+        provisioned.validation_error
+    );
+    tx.commit().await.unwrap();
+    sqlx::query(
+        r#"UPDATE pki_authorities
+           SET ocsp_url = $2, ca_issuers_url = $3,
+               crl_distribution_point_url = $4
+           WHERE id = $1"#,
+    )
+    .bind(provisioned.authority.id)
+    .bind(OCSP_URL)
+    .bind(CA_ISSUERS_URL)
+    .bind(CRL_URL)
+    .execute(pool)
+    .await
+    .unwrap();
+    authority_repo::authority_by_id(pool, provisioned.authority.id)
+        .await
+        .unwrap()
+}
+
+fn sign_authority_csr(pending: &AuthorityRecord, root: &TestRoot) -> String {
+    let mut csr =
+        CertificateSigningRequestParams::from_pem(pending.csr_pem.as_deref().unwrap()).unwrap();
+    csr.params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
+    csr.params.not_after = OffsetDateTime::now_utc() + Duration::days(180);
+    csr.params.use_authority_key_identifier_extension = true;
+    csr.signed_by(&Issuer::from_params(&root.params, &root.key))
+        .unwrap()
+        .pem()
+}
+
+async fn create_tenant(pool: &PgPool, prefix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO tenants (id, name) VALUES ($1, $2)")
+        .bind(id)
+        .bind(format!("{prefix}-{id}"))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn create_entity(pool: &PgPool, tenant_id: Uuid, prefix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO entities (id, kind, name, tenant_id, status) VALUES ($1, 'device', $2, $3, 'active')",
+    )
+    .bind(id)
+    .bind(format!("{prefix}-{id}"))
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn certificate_count(pool: &PgPool, entity_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM credentials WHERE entity_id = $1 AND kind = 'certificate'",
+    )
+    .bind(entity_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn issuance_request_count(pool: &PgPool, entity_id: Uuid) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM certificate_issuance_requests WHERE entity_id = $1")
+        .bind(entity_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn event_count(pool: &PgPool, table: &str, event: &str, target_id: Uuid) -> i64 {
+    let query = format!("SELECT COUNT(*) FROM {table} WHERE event = $1 AND target_id = $2");
+    sqlx::query_scalar(&query)
+        .bind(event)
+        .bind(target_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn install_serial_collision_trigger(pool: &PgPool, entity_id: Uuid) {
+    sqlx::query("CREATE SEQUENCE pki_test_serial_collision_seq")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(&format!(
+        r#"CREATE FUNCTION pki_test_serial_collision() RETURNS trigger AS $$
+        BEGIN
+            IF NEW.entity_id = '{entity_id}'::uuid
+               AND NEW.kind = 'certificate'
+               AND NEW.issuer_id IS NOT NULL
+               AND nextval('pki_test_serial_collision_seq') = 1 THEN
+                RAISE EXCEPTION 'synthetic serial collision' USING ERRCODE = '23505';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql"#,
+    ))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TRIGGER trg_pki_test_serial_collision BEFORE INSERT ON credentials FOR EACH ROW EXECUTE FUNCTION pki_test_serial_collision()",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn remove_serial_collision_trigger(pool: &PgPool) {
+    sqlx::query("DROP TRIGGER trg_pki_test_serial_collision ON credentials")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DROP FUNCTION pki_test_serial_collision()")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DROP SEQUENCE pki_test_serial_collision_seq")
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn install_persistence_failure_trigger(pool: &PgPool, entity_id: Uuid) {
+    sqlx::query(&format!(
+        r#"CREATE FUNCTION pki_test_persistence_failure() RETURNS trigger AS $$
+        BEGIN
+            IF NEW.entity_id = '{entity_id}'::uuid
+               AND NEW.kind = 'certificate'
+               AND NEW.issuer_id IS NOT NULL THEN
+                RAISE EXCEPTION 'synthetic managed credential failure' USING ERRCODE = '23514';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql"#,
+    ))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TRIGGER trg_pki_test_persistence_failure BEFORE INSERT ON credentials FOR EACH ROW EXECUTE FUNCTION pki_test_persistence_failure()",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn remove_persistence_failure_trigger(pool: &PgPool) {
+    sqlx::query("DROP TRIGGER trg_pki_test_persistence_failure ON credentials")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DROP FUNCTION pki_test_persistence_failure()")
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn assert_chain_with_openssl(leaf_pem: &str, chain_pem: &str, root_pem: &str) {
+    let directory = std::env::temp_dir().join(format!("atom-pr005-{}", Uuid::new_v4()));
+    fs::create_dir_all(&directory).unwrap();
+    let leaf_path = directory.join("leaf.pem");
+    let chain_path = directory.join("chain.pem");
+    let root_path = directory.join("root.pem");
+    fs::write(&leaf_path, leaf_pem).unwrap();
+    let root_start = chain_pem
+        .rfind("-----BEGIN CERTIFICATE-----")
+        .expect("managed chain contains its root");
+    fs::write(&chain_path, &chain_pem[..root_start]).unwrap();
+    fs::write(&root_path, root_pem).unwrap();
+    let output = Command::new("openssl")
+        .args(["verify", "-purpose", "sslclient", "-CAfile"])
+        .arg(&root_path)
+        .arg("-untrusted")
+        .arg(&chain_path)
+        .arg(&leaf_path)
+        .output()
+        .expect("OpenSSL must be installed for PR-005 chain verification");
+    assert!(
+        output.status.success(),
+        "OpenSSL chain verification failed: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fs::remove_dir_all(directory).unwrap();
+
+    let (_, leaf) = parse_x509_pem(leaf_pem.as_bytes()).unwrap();
+    let (_, issuer) = parse_x509_pem(chain_pem.as_bytes()).unwrap();
+    let (_, leaf) = x509_parser::parse_x509_certificate(&leaf.contents).unwrap();
+    let (_, issuer) = x509_parser::parse_x509_certificate(&issuer.contents).unwrap();
+    leaf.verify_signature(Some(issuer.public_key())).unwrap();
+}

--- a/tests/m32_pki_csr_issuance.rs
+++ b/tests/m32_pki_csr_issuance.rs
@@ -415,6 +415,7 @@ async fn managed_csr_issuance_enforces_the_pr005_contract() {
 fn managed_config() -> Config {
     let mut config = Config::for_tests();
     config.events.amqp_url = Some("amqp://unused-in-pr005-test".to_string());
+    config.graphql_limits.introspection_enabled = true;
     config
 }
 

--- a/tests/m32_pki_csr_issuance.rs
+++ b/tests/m32_pki_csr_issuance.rs
@@ -636,8 +636,14 @@ async fn issuance_request_count(pool: &PgPool, entity_id: Uuid) -> i64 {
 }
 
 async fn event_count(pool: &PgPool, table: &str, event: &str, target_id: Uuid) -> i64 {
-    let query = format!("SELECT COUNT(*) FROM {table} WHERE event = $1 AND target_id = $2");
-    sqlx::query_scalar(&query)
+    let query = match table {
+        "audit_logs" => "SELECT COUNT(*) FROM audit_logs WHERE event = $1 AND target_id = $2",
+        "event_outbox" => {
+            "SELECT COUNT(*) FROM event_outbox WHERE event = $1 AND (payload->>'target_id')::uuid = $2"
+        }
+        _ => panic!("unsupported event table"),
+    };
+    sqlx::query_scalar(query)
         .bind(event)
         .bind(target_id)
         .fetch_one(pool)


### PR DESCRIPTION
## Objective

Implement PR-005's first production tenant-aware leaf path for device-generated CSRs while preserving the legacy file-issuer mutation as the explicitly versioned v1 path.

## Dependencies

- PR-002 — merged into `certificates` by #46.
- PR-003 — merged into `certificates` by #48.
- PR-004 — merged into `certificates` by #49 at `790e80650d53a89e79721cbde77fe85abc9a2254`.
- This branch was created from that exact `certificates` tip.

## Changes

- Adds the explicitly versioned `issueCertificateFromCsrV2` mutation; its input contains only entity, CSR, TTL, and idempotency key.
- Locks and reloads the authorized entity scope, derives tenant scope from stored state, selects/share-locks the active managed issuer internally, and resolves the stored client profile through the same transaction.
- Adapts the encrypted-database authority provider to the PKI core without generating or materializing a leaf private key.
- Verifies CSR signatures and policy, canonicalizes leaf identity/extensions, signs through the managed provider, independently verifies the emitted certificate, and persists its immutable chain.
- Persists issuer-bound credentials and profile/identity/chain metadata with service- and database-layer scope enforcement.
- Adds a digest-only idempotency ledger and nested-savepoint serial collision retries without opening another pool connection.
- Commits the credential, retry completion, and domain-event outbox together; exact replays return the original credential without a duplicate issue event and retain a replay audit record.
- Documents the v1/v2 compatibility boundary and uncertain-response reconciliation procedure.

## Acceptance criteria validation

- [x] **Caller cannot supply tenant, issuer, CA path, key reference, or privileged extensions.** The v2 GraphQL input exposes exactly `entityId`, `ttlSecs`, `csrPem`, and `idempotencyKey`; schema introspection plus malformed/signature/CA/identity/EKU attack cases pass in `m32_pki_csr_issuance`.
- [x] **Tenant A cannot sign for Tenant B entity.** Authorization denial is exercised through the production GraphQL resolver, and no credential is written.
- [x] **No active issuer returns a clear fail-closed error.** The no-issuer, expired-issuer, and retiring-issuer scenarios all return `no active issuing authority`.
- [x] **Certificate issuer and entity tenant match at service and database layers.** The service validates the locked stored scope; the existing credential trigger rejects a cross-tenant issuer insert with SQLSTATE 23514; both are covered by the integration suite.
- [x] **Private key never enters Atom.** The v2 response always returns null for `privateKeyPem`; credential metadata/secret columns and retry storage are inspected for private material, while the CSR's private key remains device-side.
- [x] **Signing success followed by DB failure creates no runtime-usable credential.** A forced post-sign credential failure proves rollback of credential, retry ledger, and outbox. The operator retry/reconciliation strategy is documented.
- [x] **Legacy CSR endpoint remains compatible or explicitly versioned.** `issueCertificateFromCsr` remains unchanged as v1; managed issuance is exposed as `issueCertificateFromCsrV2`.

## Mandatory tests

All mandatory cases are implemented in `tests/m32_pki_csr_issuance.rs` and passed in Rust run 276:

- [x] Cross-tenant authorization.
- [x] Issuer unavailable.
- [x] Issuer expired and retiring.
- [x] CSR attacks: malformed input, invalid signature, CA request, identity substitution, and arbitrary EKU.
- [x] Synthetic first-attempt serial collision and same-transaction savepoint retry.
- [x] Forced post-sign database failure and full transaction rollback.
- [x] Exact duplicate request replay plus mismatched idempotency-key reuse.
- [x] Audit/outbox creation and duplicate-event suppression.
- [x] Independent OpenSSL client-chain validation plus x509-parser signature verification.

The PR-005 integration binary result was: `1 passed; 0 failed; 0 ignored`.

## Exact commands

- `cargo fmt --check` — passed in Rust run 276.
- `cargo clippy -- -D warnings` — passed in Rust run 276.
- `cargo test --no-run --locked` — passed in Rust run 276.
- Repository CI fresh-database runner (`run_one --lib`, then every eligible `tests/*.rs` binary with `--include-ignored --test-threads=1`) — passed in Rust run 276.
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm run build` in `docs` — passed locally.
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm audit --prod --audit-level high` in `docs` — passed locally (one pre-existing moderate advisory, none at the configured high threshold).
- API Docs run 217: `buf lint`, `buf generate` drift check, and `redocly lint apidocs/openapi.yaml` — passed.

## Additional validation

- `git diff --check certificates...HEAD` — passed.
- Full diff reviewed for transaction ownership, tenant/issuer scope, request-surface minimization, secret handling, cleanup, backward compatibility, and specification non-goals.
- No unresolved inline review threads, submitted reviews, or actionable comments were present at the final review checkpoint.

## Non-goals

No generated private keys, renewal, revocation, CRL, OCSP, resolver-v2, reveal/escrow path, or unrelated refactor was added.

## Compatibility and risks

The existing `issueCertificateFromCsr` mutation and legacy metadata remain readable through serde defaults. The managed route is explicitly v2 and never accepts tenant, issuer, CA path, key reference, or profile selection. Managed credentials now carry `issuer_id` and immutable chain/profile identity metadata. Atom's established event convention is preserved: the domain outbox is atomic with the mutation, while the compliance audit row is written post-commit and remains fire-and-forget. No deployment secret or environment-specific credential is introduced.

This PR targets `certificates`, never `main`.