### PR TITLE
[PKI PR-007] Implement issuer-aware certificate renewal

### DIFF
--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -252,18 +252,20 @@ certificate's profile threshold, never from a global renewal constant.
 
 By default the old and new credentials overlap and remain independently
 resolvable. Set `revokeOld: true` for immediate, atomic revocation of the old
-credential. The replacement, history link, optional revocation, audit record,
-and outbox event commit together.
+credential. The replacement, history link, optional revocation, and outbox
+event commit together; the compliance audit row follows the repository's
+existing post-commit, best-effort policy.
 
 The service boundary also accepts renewal authorization from the exact
 certificate being replaced so the enrollment transport in PR-014 can attach
-without changing renewal policy. Certificate-authenticated renewal is accepted
-only when the credential is active, unexpired, within its profile renewal
-window, and issued by a legacy, active, or retiring issuer. It is rejected once
-expired or revoked. A normally authorized operator may recover an expired but
-not revoked subject by renewing it with a new CSR or explicit generated-key
-request; a revoked subject must use fresh enrollment. This recovery never treats
-an expired or revoked certificate as authentication.
+without changing renewal policy. `renewalDueAt` tells clients when renewal is
+normally due, but does not block an intentional early key rotation.
+Certificate-authenticated renewal is accepted only when the credential is
+active, unexpired, and issued by a legacy, active, or retiring issuer. It is
+rejected once expired or revoked. A normally authorized operator may recover an
+expired but not revoked subject by renewing it with a new CSR or explicit
+generated-key request; a revoked subject must use fresh enrollment. This
+recovery never treats an expired or revoked certificate as authentication.
 
 The original serial-based `renewCertificate` mutation remains the explicit v1
 compatibility path until resolver-v2 migration is complete. New integrations

--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -210,6 +210,65 @@ PR-010 completes per-issuer CRL and OCSP publication. The legacy
 `issueCertificate` mutation remains available as the explicit v1 migration
 path and is not silently redirected to managed authorities.
 
+## Issuer-aware renewal (v2)
+
+Managed renewal identifies the certificate being replaced by its exact
+`credentialId`, never by serial alone. Use `renewCertificateFromCsrV2` when the
+subject keeps its key outside Atom, or the separately named
+`renewGeneratedCertificateV2` when an operator explicitly requests a new
+one-time private key. Neither input accepts an entity, tenant, issuer, profile,
+subject name, or key reference.
+
+```graphql
+mutation RenewDevice($input: RenewCertificateFromCsrV2Input!) {
+  renewCertificateFromCsrV2(input: $input) {
+    idempotentReplay
+    chainPem
+    certificate {
+      credentialId
+      renewedFromCredentialId
+      issuerId
+      renewalDueAt
+      certificatePem
+    }
+  }
+}
+```
+
+Both v2 mutations require an idempotency key. A certificate can have only one
+replacement: an exact retry returns that replacement with
+`idempotentReplay: true`, while a changed key, CSR, TTL, mode, or revocation
+policy conflicts. Generated-key retries never reveal the private key again; if
+the first response was lost, use the same unusable-key response procedure as a
+lost bootstrap response.
+
+The replacement is issued under the subject scope's current active issuer and
+current `client` profile. This moves a leaf from a retiring issuer to its
+replacement and is the only migration path for legacy `issuerId: null`
+certificates: tenant-owned entities move to their tenant intermediate, while
+global entities move to the platform leaf issuer. Atom stores an exact
+`renewedFromCredentialId` relation and derives `renewalDueAt` from the old
+certificate's profile threshold, never from a global renewal constant.
+
+By default the old and new credentials overlap and remain independently
+resolvable. Set `revokeOld: true` for immediate, atomic revocation of the old
+credential. The replacement, history link, optional revocation, audit record,
+and outbox event commit together.
+
+The service boundary also accepts renewal authorization from the exact
+certificate being replaced so the enrollment transport in PR-014 can attach
+without changing renewal policy. Certificate-authenticated renewal is accepted
+only when the credential is active, unexpired, within its profile renewal
+window, and issued by a legacy, active, or retiring issuer. It is rejected once
+expired or revoked. A normally authorized operator may recover an expired but
+not revoked subject by renewing it with a new CSR or explicit generated-key
+request; a revoked subject must use fresh enrollment. This recovery never treats
+an expired or revoked certificate as authentication.
+
+The original serial-based `renewCertificate` mutation remains the explicit v1
+compatibility path until resolver-v2 migration is complete. New integrations
+must use the exact-credential v2 mutations.
+
 ## Legacy CA files
 
 The original v1 issuer remains available for backward compatibility and loads

--- a/migrations/009_pki_certificate_renewal.sql
+++ b/migrations/009_pki_certificate_renewal.sql
@@ -1,0 +1,87 @@
+-- Exact-credential renewal history and idempotency ledger.
+--
+-- A certificate may have at most one replacement. The public idempotency
+-- token and CSR are never stored; only domain-separated digests are retained.
+-- The pending row, replacement credential, optional old-certificate
+-- revocation, and completion link are committed in one transaction.
+
+CREATE TABLE certificate_renewals (
+    id                          UUID        PRIMARY KEY,
+    previous_credential_id      UUID        NOT NULL UNIQUE
+                                             REFERENCES credentials(id) ON DELETE CASCADE,
+    request_key_hash            TEXT        NOT NULL
+                                             CHECK (request_key_hash ~ '^[0-9a-f]{64}$'),
+    request_fingerprint_sha256  TEXT        NOT NULL
+                                             CHECK (request_fingerprint_sha256 ~ '^[0-9a-f]{64}$'),
+    key_mode                    TEXT        NOT NULL CHECK (key_mode IN ('csr', 'generated')),
+    replacement_credential_id   UUID        UNIQUE
+                                             REFERENCES credentials(id) ON DELETE CASCADE,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at                TIMESTAMPTZ,
+
+    CONSTRAINT chk_certificate_renewal_state
+        CHECK ((replacement_credential_id IS NULL AND completed_at IS NULL)
+            OR (replacement_credential_id IS NOT NULL AND completed_at IS NOT NULL))
+);
+
+CREATE INDEX idx_certificate_renewals_replacement
+    ON certificate_renewals(replacement_credential_id)
+    WHERE replacement_credential_id IS NOT NULL;
+
+-- Keep the service's history invariants at the database boundary: both sides
+-- are certificate credentials for one entity, the replacement is managed by
+-- an explicit issuer, and its immutable metadata points back to the exact old
+-- credential rather than an ambiguous serial.
+CREATE OR REPLACE FUNCTION enforce_certificate_renewal_link()
+RETURNS trigger AS $$
+DECLARE
+    previous_entity_id UUID;
+    previous_kind      TEXT;
+    replacement_entity_id UUID;
+    replacement_kind      TEXT;
+    replacement_issuer_id UUID;
+    replacement_previous_id TEXT;
+BEGIN
+    SELECT entity_id, kind
+      INTO previous_entity_id, previous_kind
+      FROM credentials
+     WHERE id = NEW.previous_credential_id;
+
+    IF NOT FOUND OR previous_kind <> 'certificate' THEN
+        RAISE EXCEPTION 'renewal source must be a certificate credential'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.replacement_credential_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.replacement_credential_id = NEW.previous_credential_id THEN
+        RAISE EXCEPTION 'renewal replacement must differ from its source'
+            USING ERRCODE = '23514';
+    END IF;
+
+    SELECT entity_id, kind, issuer_id,
+           metadata->>'renewed_from_credential_id'
+      INTO replacement_entity_id, replacement_kind,
+           replacement_issuer_id, replacement_previous_id
+      FROM credentials
+     WHERE id = NEW.replacement_credential_id;
+
+    IF NOT FOUND
+       OR replacement_kind <> 'certificate'
+       OR replacement_issuer_id IS NULL
+       OR replacement_entity_id <> previous_entity_id
+       OR replacement_previous_id IS DISTINCT FROM NEW.previous_credential_id::text THEN
+        RAISE EXCEPTION 'renewal replacement must be an issuer-bound certificate for the same entity'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_certificate_renewal_link
+    BEFORE INSERT OR UPDATE OF previous_credential_id, replacement_credential_id
+    ON certificate_renewals
+    FOR EACH ROW EXECUTE FUNCTION enforce_certificate_renewal_link();

--- a/product-docs/development/pki/pr-007-renewal.md
+++ b/product-docs/development/pki/pr-007-renewal.md
@@ -1,5 +1,9 @@
 # PR-007 — Issuer-Aware Certificate Renewal
 
+## Status
+
+Implemented by the PR-007 delivery branch.
+
 ## Objective
 
 Renew existing certificates into the tenant's current active issuer while preserving history and safe rotation.

--- a/src/certs/authority/repo.rs
+++ b/src/certs/authority/repo.rs
@@ -153,6 +153,28 @@ pub async fn lock_active_leaf_issuer_for_scope(
         })
 }
 
+/// Hold a shared lock while an already-issued certificate is used as renewal
+/// authentication. Lifecycle transitions may wait, but they cannot revoke or
+/// retire the presented issuer between validation and renewal commit.
+pub async fn lock_authority_for_certificate_authentication(
+    tx: &mut Transaction<'_, Postgres>,
+    authority_id: Uuid,
+) -> Result<AuthorityRecord, AppError> {
+    let query = format!(
+        r#"
+        SELECT {AUTHORITY_COLUMNS}
+        FROM pki_authorities
+        WHERE id = $1
+        FOR SHARE
+        "#
+    );
+    sqlx::query_as::<_, AuthorityRecord>(&query)
+        .bind(authority_id)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(db_err)
+}
+
 /// Backward-compatible tenant-only selector for current call sites.
 pub async fn active_tenant_leaf_issuer(
     pool: &PgPool,

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -364,6 +364,40 @@ impl CertificateMutation {
         Ok(issued.into())
     }
 
+    /// Exact-credential managed renewal using a subject-owned CSR.
+    async fn renew_certificate_from_csr_v2(
+        &self,
+        ctx: &Context<'_>,
+        input: RenewCertificateFromCsrV2Input,
+    ) -> Result<IssuedCertificate> {
+        renew_certificate_v2(
+            ctx,
+            parse_id(input.credential_id, "credentialId")?,
+            input.ttl_secs,
+            input.revoke_old.unwrap_or(false),
+            input.idempotency_key,
+            service::RenewalKeySource::Csr(input.csr_pem),
+        )
+        .await
+    }
+
+    /// Exact-credential managed renewal with a new one-time private key.
+    async fn renew_generated_certificate_v2(
+        &self,
+        ctx: &Context<'_>,
+        input: RenewGeneratedCertificateV2Input,
+    ) -> Result<IssuedCertificate> {
+        renew_certificate_v2(
+            ctx,
+            parse_id(input.credential_id, "credentialId")?,
+            input.ttl_secs,
+            input.revoke_old.unwrap_or(false),
+            input.idempotency_key,
+            service::RenewalKeySource::Generated,
+        )
+        .await
+    }
+
     async fn revoke_certificate(
         &self,
         ctx: &Context<'_>,
@@ -436,6 +470,95 @@ impl CertificateMutation {
     }
 }
 
+async fn renew_certificate_v2(
+    ctx: &Context<'_>,
+    credential_id: Uuid,
+    ttl_secs: Option<u64>,
+    revoke_old: bool,
+    idempotency_key: String,
+    key_source: service::RenewalKeySource,
+) -> Result<IssuedCertificate> {
+    let auth = require_auth(ctx)?;
+    let state = ctx.data::<AppState>()?;
+    let old = service::certificate_by_id(&state.pool, credential_id)
+        .await
+        .map_err(gql_error)?;
+    require_certificate_rotate(state, &auth, &old).await?;
+    let key_mode = key_source.mode();
+    let mut tx = state
+        .pool
+        .begin()
+        .await
+        .map_err(|error| gql_error(db_err(error)))?;
+    let issued = service::renew_certificate_v2_in_tx(
+        &mut tx,
+        &state.config,
+        service::CertificateRenewalAuthorization::Operator {
+            expected_entity_id: old.entity_id,
+            expected_tenant_id: old.tenant_id,
+        },
+        service::RenewCertificateV2 {
+            credential_id,
+            ttl_secs,
+            key_source,
+            revoke_old,
+            idempotency_key,
+        },
+    )
+    .await
+    .map_err(gql_error)?;
+    let details = serde_json::json!({
+        "old_credential_id": old.credential_id,
+        "new_credential_id": issued.certificate.credential_id,
+        "old_serial_number": old.serial_number,
+        "new_serial_number": issued.certificate.serial_number,
+        "old_issuer_id": old.issuer_id,
+        "new_issuer_id": issued.certificate.issuer_id,
+        "profile_id": issued.certificate.profile_id,
+        "key_mode": key_mode,
+        "revoke_old": revoke_old,
+        "replay": issued.idempotent_replay,
+        "managed": true,
+    });
+    if issued.idempotent_replay {
+        tx.commit()
+            .await
+            .map_err(|error| gql_error(db_err(error)))?;
+        audit::write(
+            &state.pool,
+            false,
+            audit::AuditEvent {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id: old.tenant_id,
+                target_kind: Some("credential"),
+                target_id: Some(old.credential_id),
+                event: "certificate.renew_replayed",
+                outcome: AuditOutcome::Allow,
+                details,
+            },
+        )
+        .await;
+    } else {
+        audit::commit_with_audit(
+            &state.pool,
+            tx,
+            state.config.events.enabled(),
+            &audit::AuditEvent {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id: old.tenant_id,
+                target_kind: Some("credential"),
+                target_id: Some(old.credential_id),
+                event: "certificate.renew",
+                outcome: AuditOutcome::Allow,
+                details,
+            },
+        )
+        .await
+        .map_err(gql_error)?;
+    }
+    Ok(issued.into())
+}
+
 #[derive(InputObject)]
 pub struct IssueCertificateInput {
     pub entity_id: ID,
@@ -471,6 +594,23 @@ pub struct RenewCertificateInput {
     pub serial_number: String,
     pub ttl_secs: Option<u64>,
     pub revoke_old: Option<bool>,
+}
+
+#[derive(InputObject)]
+pub struct RenewCertificateFromCsrV2Input {
+    pub credential_id: ID,
+    pub ttl_secs: Option<u64>,
+    pub csr_pem: String,
+    pub revoke_old: Option<bool>,
+    pub idempotency_key: String,
+}
+
+#[derive(InputObject)]
+pub struct RenewGeneratedCertificateV2Input {
+    pub credential_id: ID,
+    pub ttl_secs: Option<u64>,
+    pub revoke_old: Option<bool>,
+    pub idempotency_key: String,
 }
 
 #[derive(InputObject)]
@@ -581,6 +721,25 @@ impl Certificate {
 
     async fn identity_uri(&self) -> Option<&str> {
         self.0.identity_uri.as_deref()
+    }
+
+    async fn renewed_from_credential_id(&self) -> Option<ID> {
+        self.0
+            .renewed_from_credential_id
+            .map(|id| ID(id.to_string()))
+    }
+
+    async fn renewal_due_at(&self, ctx: &Context<'_>) -> Result<String> {
+        let due_at = match self.0.renewal_due_at {
+            Some(value) => value,
+            None => {
+                let state = ctx.data::<AppState>()?;
+                service::certificate_renewal_due_at(&state.pool, self.0.credential_id)
+                    .await
+                    .map_err(gql_error)?
+            }
+        };
+        Ok(due_at.to_rfc3339())
     }
 
     async fn expires_at(&self) -> Option<String> {

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -271,6 +271,7 @@ pub struct IssuedCertificate {
     pub not_after: DateTime<Utc>,
     pub profile_id: uuid::Uuid,
     pub profile_name: String,
+    pub renewal_threshold_seconds: u64,
     pub dns_names: Vec<String>,
     pub ip_addresses: Vec<IpAddr>,
 }
@@ -475,6 +476,7 @@ pub fn issue_from_csr_at(
         not_after: to_chrono(not_after)?,
         profile_id: profile.id,
         profile_name: profile.name.clone(),
+        renewal_threshold_seconds: profile.renewal_threshold_seconds,
         dns_names: approved_sans.dns_names,
         ip_addresses: approved_sans.ip_addresses,
     })

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -24,6 +24,12 @@ pub enum CertificateIssuanceRequestClaim {
     Replay { credential_id: Uuid },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CertificateRenewalRequestClaim {
+    New { renewal_id: Uuid },
+    Replay { credential_id: Uuid },
+}
+
 #[derive(Debug, Clone, FromRow)]
 pub struct CrlState {
     pub crl_number: i64,
@@ -189,6 +195,94 @@ pub async fn complete_certificate_issuance_request(
     Ok(())
 }
 
+pub async fn claim_certificate_renewal(
+    tx: &mut Transaction<'_, Postgres>,
+    previous_credential_id: Uuid,
+    request_key_hash: &str,
+    request_fingerprint_sha256: &str,
+    key_mode: &str,
+) -> Result<CertificateRenewalRequestClaim, AppError> {
+    let renewal_id = Uuid::new_v4();
+    let inserted = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO certificate_renewals (
+            id, previous_credential_id, request_key_hash,
+            request_fingerprint_sha256, key_mode
+        )
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (previous_credential_id) DO NOTHING
+        RETURNING id
+        "#,
+    )
+    .bind(renewal_id)
+    .bind(previous_credential_id)
+    .bind(request_key_hash)
+    .bind(request_fingerprint_sha256)
+    .bind(key_mode)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    if inserted.is_some() {
+        return Ok(CertificateRenewalRequestClaim::New { renewal_id });
+    }
+
+    let existing = sqlx::query_as::<_, (String, String, String, Option<Uuid>)>(
+        r#"
+        SELECT request_key_hash, request_fingerprint_sha256, key_mode,
+               replacement_credential_id
+        FROM certificate_renewals
+        WHERE previous_credential_id = $1
+        FOR UPDATE
+        "#,
+    )
+    .bind(previous_credential_id)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    if existing.0 != request_key_hash
+        || existing.1 != request_fingerprint_sha256
+        || existing.2 != key_mode
+    {
+        return Err(AppError::conflict(
+            "certificate was already renewed by a different request",
+        ));
+    }
+    existing
+        .3
+        .map(|credential_id| CertificateRenewalRequestClaim::Replay { credential_id })
+        .ok_or_else(|| {
+            AppError::Internal(anyhow::anyhow!(
+                "stored certificate renewal request is incomplete"
+            ))
+        })
+}
+
+pub async fn complete_certificate_renewal(
+    tx: &mut Transaction<'_, Postgres>,
+    renewal_id: Uuid,
+    replacement_credential_id: Uuid,
+) -> Result<(), AppError> {
+    let completed = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        UPDATE certificate_renewals
+        SET replacement_credential_id = $2, completed_at = now()
+        WHERE id = $1 AND replacement_credential_id IS NULL
+        RETURNING id
+        "#,
+    )
+    .bind(renewal_id)
+    .bind(replacement_credential_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    if completed.is_none() {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "certificate renewal request could not be completed"
+        )));
+    }
+    Ok(())
+}
+
 pub async fn certificate_by_serial<'e, E>(
     executor: E,
     serial_number: &str,
@@ -238,6 +332,26 @@ where
     )
     .bind(credential_id)
     .fetch_one(executor)
+    .await
+    .map_err(db_err)
+}
+
+pub async fn lock_certificate_by_id(
+    tx: &mut Transaction<'_, Postgres>,
+    credential_id: Uuid,
+) -> Result<CertificateCredential, AppError> {
+    sqlx::query_as::<_, CertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+               c.expires_at, c.created_at
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        WHERE c.kind = 'certificate' AND c.id = $1
+        FOR UPDATE OF c
+        "#,
+    )
+    .bind(credential_id)
+    .fetch_one(&mut **tx)
     .await
     .map_err(db_err)
 }

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -929,28 +929,6 @@ pub async fn renew_certificate_v2_in_tx(
     let old_metadata = metadata_from_value(&old.metadata)?;
     let now = Utc::now();
     validate_renewal_source(tx, &old, &old_metadata, authorization, now).await?;
-    let threshold_seconds = renewal_threshold_for_certificate(
-        tx,
-        old.entity_id,
-        old_metadata.profile_id,
-        old_metadata.renewal_threshold_seconds,
-    )
-    .await?;
-    let renewal_due_at = renewal_due_at(
-        old_metadata.not_before,
-        old_metadata.not_after,
-        threshold_seconds,
-    )?;
-    if matches!(
-        authorization,
-        CertificateRenewalAuthorization::PresentedCertificate { .. }
-    ) && now < renewal_due_at
-    {
-        return Err(AppError::bad_request(format!(
-            "certificate renewal is not due until {}",
-            renewal_due_at.to_rfc3339()
-        )));
-    }
 
     let key_mode = input.key_source.mode();
     let request_key_hash = renewal_request_key_hash(&input.idempotency_key);
@@ -1728,26 +1706,6 @@ async fn validate_renewal_source(
         }
     }
     Ok(())
-}
-
-async fn renewal_threshold_for_certificate(
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    entity_id: Uuid,
-    profile_id: Option<Uuid>,
-    stored_threshold_seconds: Option<u64>,
-) -> Result<u64, AppError> {
-    if let Some(value) = stored_threshold_seconds {
-        return Ok(value);
-    }
-    if let Some(profile_id) = profile_id {
-        return Ok(profile::profile_by_id(&mut **tx, profile_id)
-            .await?
-            .renewal_threshold_seconds());
-    }
-    let subject = profile::load_subject(&mut **tx, entity_id).await?;
-    Ok(profile::resolve_for_subject_in_tx(tx, &subject, "client")
-        .await?
-        .renewal_threshold_seconds())
 }
 
 fn renewal_due_at(

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -928,7 +928,12 @@ pub async fn renew_certificate_v2_in_tx(
 
     let old_metadata = metadata_from_value(&old.metadata)?;
     let now = Utc::now();
-    validate_renewal_source(tx, &old, &old_metadata, authorization, now).await?;
+    if matches!(
+        authorization,
+        CertificateRenewalAuthorization::PresentedCertificate { .. }
+    ) {
+        validate_renewal_source(tx, &old, &old_metadata, authorization, now).await?;
+    }
 
     let key_mode = input.key_source.mode();
     let request_key_hash = renewal_request_key_hash(&input.idempotency_key);
@@ -968,6 +973,13 @@ pub async fn renew_certificate_v2_in_tx(
             });
         }
     };
+
+    if matches!(
+        authorization,
+        CertificateRenewalAuthorization::Operator { .. }
+    ) {
+        validate_renewal_source(tx, &old, &old_metadata, authorization, now).await?;
+    }
 
     let subject = profile::load_subject(&mut **tx, old.entity_id).await?;
     if subject.tenant_id() != stored_tenant_id {

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 use super::{
-    authority::{repo as authority_repo, AuthorityKind, AuthorityRecord},
+    authority::{repo as authority_repo, AuthorityKind, AuthorityRecord, AuthorityStatus},
     pki_core, profile, repo,
 };
 
@@ -76,6 +76,41 @@ pub struct RenewCertificate {
     pub revoke_old: bool,
 }
 
+#[derive(Debug, Clone)]
+pub enum RenewalKeySource {
+    Csr(String),
+    Generated,
+}
+
+impl RenewalKeySource {
+    pub(crate) fn mode(&self) -> &'static str {
+        match self {
+            Self::Csr(_) => "csr",
+            Self::Generated => "generated",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RenewCertificateV2 {
+    pub credential_id: Uuid,
+    pub ttl_secs: Option<u64>,
+    pub key_source: RenewalKeySource,
+    pub revoke_old: bool,
+    pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CertificateRenewalAuthorization {
+    Operator {
+        expected_entity_id: Uuid,
+        expected_tenant_id: Option<Uuid>,
+    },
+    PresentedCertificate {
+        credential_id: Uuid,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CertificateMetadata {
     pub certificate_pem: String,
@@ -95,6 +130,12 @@ pub struct CertificateMetadata {
     pub profile_name: Option<String>,
     #[serde(default)]
     pub identity_uri: Option<String>,
+    #[serde(default)]
+    pub renewed_from_credential_id: Option<Uuid>,
+    #[serde(default)]
+    pub renewal_threshold_seconds: Option<u64>,
+    #[serde(default)]
+    pub renewal_due_at: Option<DateTime<Utc>>,
     pub not_before: DateTime<Utc>,
     pub not_after: DateTime<Utc>,
     pub issued_from_csr: bool,
@@ -119,6 +160,8 @@ pub struct CertificateRecord {
     pub profile_id: Option<Uuid>,
     pub profile_name: Option<String>,
     pub identity_uri: Option<String>,
+    pub renewed_from_credential_id: Option<Uuid>,
+    pub renewal_due_at: Option<DateTime<Utc>>,
     pub expires_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub revoked_at: Option<DateTime<Utc>>,
@@ -650,8 +693,15 @@ pub async fn issue_certificate_from_csr_v2_in_tx(
         )?;
         let chain_pem = issued.chain_pem.clone();
         let mut attempt_tx = tx.begin().await.map_err(AppError::Database)?;
-        let outcome =
-            persist_managed_certificate(&mut attempt_tx, input.entity_id, &authority, issued).await;
+        let outcome = persist_managed_certificate(
+            &mut attempt_tx,
+            input.entity_id,
+            &authority,
+            issued,
+            true,
+            None,
+        )
+        .await;
         match outcome {
             Ok(certificate) => {
                 repo::complete_certificate_issuance_request(
@@ -739,8 +789,15 @@ pub async fn issue_generated_certificate_v2_in_tx(
         )?;
         let chain_pem = issued.chain_pem.clone();
         let mut attempt_tx = tx.begin().await.map_err(AppError::Database)?;
-        let outcome =
-            persist_managed_certificate(&mut attempt_tx, input.entity_id, &authority, issued).await;
+        let outcome = persist_managed_certificate(
+            &mut attempt_tx,
+            input.entity_id,
+            &authority,
+            issued,
+            false,
+            None,
+        )
+        .await;
         match outcome {
             Ok(certificate) => {
                 attempt_tx.commit().await.map_err(AppError::Database)?;
@@ -827,6 +884,226 @@ pub async fn renew_certificate_in_tx(
         revoke_certificate_in_tx(tx, &serial, Some("superseded".into())).await?;
     }
     Ok(issued)
+}
+
+pub async fn renew_certificate_v2(
+    pool: &sqlx::PgPool,
+    config: &Config,
+    authorization: CertificateRenewalAuthorization,
+    input: RenewCertificateV2,
+) -> Result<IssuedCertificate, AppError> {
+    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let issued = renew_certificate_v2_in_tx(&mut tx, config, authorization, input).await?;
+    tx.commit().await.map_err(AppError::Database)?;
+    Ok(issued)
+}
+
+/// Exact-credential, issuer-aware renewal. Operator authorization is bound to
+/// the entity and tenant observed before the transaction; certificate
+/// authorization is bound to the exact credential that authenticated the
+/// caller. The transport never supplies tenant, entity, issuer, or profile.
+pub async fn renew_certificate_v2_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    config: &Config,
+    authorization: CertificateRenewalAuthorization,
+    input: RenewCertificateV2,
+) -> Result<IssuedCertificate, AppError> {
+    validate_idempotency_key(&input.idempotency_key)?;
+    if matches!(&input.key_source, RenewalKeySource::Generated)
+        && !config.pki_generated_key_issuance_enabled
+    {
+        return Err(AppError::Forbidden);
+    }
+
+    let old = repo::lock_certificate_by_id(tx, input.credential_id).await?;
+    let (_, stored_tenant_id) = identity::repo::lock_active_entity(tx, old.entity_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("entity not found"))?;
+    if old.tenant_id != stored_tenant_id {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "locked certificate scope changed during renewal"
+        )));
+    }
+    validate_renewal_authorization(&old, authorization)?;
+
+    let old_metadata = metadata_from_value(&old.metadata)?;
+    let now = Utc::now();
+    validate_renewal_source(tx, &old, &old_metadata, authorization, now).await?;
+    let threshold_seconds = renewal_threshold_for_certificate(
+        tx,
+        old.entity_id,
+        old_metadata.profile_id,
+        old_metadata.renewal_threshold_seconds,
+    )
+    .await?;
+    let renewal_due_at = renewal_due_at(
+        old_metadata.not_before,
+        old_metadata.not_after,
+        threshold_seconds,
+    )?;
+    if matches!(
+        authorization,
+        CertificateRenewalAuthorization::PresentedCertificate { .. }
+    ) && now < renewal_due_at
+    {
+        return Err(AppError::bad_request(format!(
+            "certificate renewal is not due until {}",
+            renewal_due_at.to_rfc3339()
+        )));
+    }
+
+    let key_mode = input.key_source.mode();
+    let request_key_hash = renewal_request_key_hash(&input.idempotency_key);
+    let request_fingerprint = renewal_request_fingerprint(
+        input.credential_id,
+        input.ttl_secs,
+        input.revoke_old,
+        key_mode,
+        match &input.key_source {
+            RenewalKeySource::Csr(csr_pem) => csr_pem.as_bytes(),
+            RenewalKeySource::Generated => &[],
+        },
+    );
+    let renewal_id = match repo::claim_certificate_renewal(
+        tx,
+        input.credential_id,
+        &request_key_hash,
+        &request_fingerprint,
+        key_mode,
+    )
+    .await?
+    {
+        repo::CertificateRenewalRequestClaim::New { renewal_id } => renewal_id,
+        repo::CertificateRenewalRequestClaim::Replay { credential_id } => {
+            let certificate =
+                record_from_row(repo::fetch_certificate_by_id(&mut **tx, credential_id).await?)?;
+            if certificate.renewed_from_credential_id != Some(input.credential_id) {
+                return Err(AppError::Internal(anyhow::anyhow!(
+                    "stored certificate renewal link is inconsistent"
+                )));
+            }
+            return Ok(IssuedCertificate {
+                chain_pem: certificate.chain_pem.clone(),
+                certificate,
+                private_key_pem: None,
+                idempotent_replay: true,
+            });
+        }
+    };
+
+    let subject = profile::load_subject(&mut **tx, old.entity_id).await?;
+    if subject.tenant_id() != stored_tenant_id {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "locked entity scope changed during certificate renewal"
+        )));
+    }
+    let certificate_profile = profile::resolve_for_subject_in_tx(tx, &subject, "client").await?;
+    let authority = authority_repo::lock_active_leaf_issuer_for_scope(tx, stored_tenant_id).await?;
+    validate_issuer_scope(&authority, stored_tenant_id)?;
+    let issuer = pki_core::PkiIssuer::from_managed_authority(&authority, &config.pki_ca_keys)?;
+    let (csr_pem, mut generated) = match input.key_source {
+        RenewalKeySource::Csr(csr_pem) => (csr_pem, None),
+        RenewalKeySource::Generated => {
+            let generated = pki_core::generate_leaf_request(&certificate_profile)?;
+            (generated.csr_pem().to_string(), Some(generated))
+        }
+    };
+
+    for attempt in 0..SERIAL_INSERT_ATTEMPTS {
+        let issued = pki_core::issue_from_csr(
+            &certificate_profile,
+            &subject,
+            &issuer,
+            pki_core::IssueFromCsr {
+                csr_pem: &csr_pem,
+                requested_ttl_seconds: input.ttl_secs,
+            },
+        )?;
+        let chain_pem = issued.chain_pem.clone();
+        let mut attempt_tx = tx.begin().await.map_err(AppError::Database)?;
+        let outcome = persist_managed_certificate(
+            &mut attempt_tx,
+            old.entity_id,
+            &authority,
+            issued,
+            key_mode == "csr",
+            Some(old.id),
+        )
+        .await;
+        match outcome {
+            Ok(certificate) => {
+                if input.revoke_old {
+                    let mut metadata = old.metadata.clone();
+                    metadata["revoked_at"] = json!(Utc::now());
+                    metadata["revocation_reason"] = json!("superseded");
+                    repo::revoke_certificate(&mut **attempt_tx, old.id, metadata).await?;
+                    // PR-008 replaces this global dirty mark with an exact
+                    // issuer-keyed update. Credential status is still changed
+                    // atomically and is immediately authoritative in Atom.
+                    repo::mark_crl_dirty_tx(&mut attempt_tx).await?;
+                }
+                repo::complete_certificate_renewal(
+                    &mut attempt_tx,
+                    renewal_id,
+                    certificate.credential_id,
+                )
+                .await?;
+                attempt_tx.commit().await.map_err(AppError::Database)?;
+                let private_key_pem = generated
+                    .take()
+                    .map(pki_core::GeneratedLeafRequest::into_private_key_pem)
+                    .map(OneTimePrivateKey::from_zeroizing);
+                return Ok(IssuedCertificate {
+                    certificate,
+                    private_key_pem,
+                    chain_pem: Some(chain_pem),
+                    idempotent_replay: false,
+                });
+            }
+            Err(error) if is_unique_violation(&error) => {
+                attempt_tx.rollback().await.map_err(AppError::Database)?;
+                if attempt + 1 == SERIAL_INSERT_ATTEMPTS {
+                    return Err(AppError::conflict(
+                        "failed to allocate a unique certificate serial number",
+                    ));
+                }
+            }
+            Err(error) => {
+                attempt_tx.rollback().await.map_err(AppError::Database)?;
+                return Err(error);
+            }
+        }
+    }
+
+    Err(AppError::conflict(
+        "failed to allocate a unique certificate serial number",
+    ))
+}
+
+/// Resolve a certificate's renewal window from its stored profile snapshot,
+/// falling back to the referenced/effective profile for pre-PR-007 rows.
+pub async fn certificate_renewal_due_at(
+    pool: &sqlx::PgPool,
+    credential_id: Uuid,
+) -> Result<DateTime<Utc>, AppError> {
+    let row = repo::certificate_by_id(pool, credential_id).await?;
+    let metadata = metadata_from_value(&row.metadata)?;
+    if let Some(due_at) = metadata.renewal_due_at {
+        return Ok(due_at);
+    }
+    let threshold_seconds = if let Some(value) = metadata.renewal_threshold_seconds {
+        value
+    } else if let Some(profile_id) = metadata.profile_id {
+        profile::profile_by_id(pool, profile_id)
+            .await?
+            .renewal_threshold_seconds()
+    } else {
+        let subject = profile::load_subject(pool, row.entity_id).await?;
+        profile::resolve_for_subject(pool, &subject, "client")
+            .await?
+            .renewal_threshold_seconds()
+    };
+    renewal_due_at(metadata.not_before, metadata.not_after, threshold_seconds)
 }
 
 pub async fn revoke_certificate(
@@ -1184,6 +1461,9 @@ async fn persist_certificate(
         profile_id: None,
         profile_name: None,
         identity_uri: None,
+        renewed_from_credential_id: None,
+        renewal_threshold_seconds: None,
+        renewal_due_at: None,
         not_before: input.not_before,
         not_after: input.not_after,
         issued_from_csr: input.issued_from_csr,
@@ -1214,6 +1494,8 @@ async fn persist_managed_certificate(
     entity_id: Uuid,
     authority: &AuthorityRecord,
     issued: pki_core::IssuedCertificate,
+    issued_from_csr: bool,
+    renewed_from_credential_id: Option<Uuid>,
 ) -> Result<CertificateRecord, AppError> {
     let issuer_serial_number = authority.serial_number.clone().ok_or_else(|| {
         AppError::Internal(anyhow::anyhow!("managed issuer serial number is missing"))
@@ -1221,6 +1503,11 @@ async fn persist_managed_certificate(
     let issuer_fingerprint_sha256 = authority.fingerprint_sha256.clone().ok_or_else(|| {
         AppError::Internal(anyhow::anyhow!("managed issuer fingerprint is missing"))
     })?;
+    let renewal_due_at = renewal_due_at(
+        issued.not_before,
+        issued.not_after,
+        issued.renewal_threshold_seconds,
+    )?;
     let metadata = CertificateMetadata {
         certificate_pem: issued.certificate_pem,
         chain_pem: Some(issued.chain_pem),
@@ -1242,9 +1529,12 @@ async fn persist_managed_certificate(
         profile_id: Some(issued.profile_id),
         profile_name: Some(issued.profile_name),
         identity_uri: Some(issued.identity_uri),
+        renewed_from_credential_id,
+        renewal_threshold_seconds: Some(issued.renewal_threshold_seconds),
+        renewal_due_at: Some(renewal_due_at),
         not_before: issued.not_before,
         not_after: issued.not_after,
-        issued_from_csr: true,
+        issued_from_csr,
         revoked_at: None,
         revocation_reason: None,
     };
@@ -1282,6 +1572,8 @@ fn record_from_row(row: repo::CertificateCredential) -> Result<CertificateRecord
         profile_id: metadata.profile_id,
         profile_name: metadata.profile_name,
         identity_uri: metadata.identity_uri,
+        renewed_from_credential_id: metadata.renewed_from_credential_id,
+        renewal_due_at: metadata.renewal_due_at,
         expires_at: row.expires_at,
         created_at: row.created_at,
         revoked_at: metadata.revoked_at,
@@ -1348,6 +1640,170 @@ fn issuance_request_fingerprint(entity_id: Uuid, ttl_secs: Option<u64>, csr_pem:
         None => context.update(&[0]),
     }
     context.update(csr_pem);
+    hex::encode(context.finish())
+}
+
+fn validate_renewal_authorization(
+    old: &repo::CertificateCredential,
+    authorization: CertificateRenewalAuthorization,
+) -> Result<(), AppError> {
+    let authorized = match authorization {
+        CertificateRenewalAuthorization::Operator {
+            expected_entity_id,
+            expected_tenant_id,
+        } => old.entity_id == expected_entity_id && old.tenant_id == expected_tenant_id,
+        CertificateRenewalAuthorization::PresentedCertificate { credential_id } => {
+            old.id == credential_id
+        }
+    };
+    if authorized {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden)
+    }
+}
+
+async fn validate_renewal_source(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    old: &repo::CertificateCredential,
+    metadata: &CertificateMetadata,
+    authorization: CertificateRenewalAuthorization,
+    now: DateTime<Utc>,
+) -> Result<(), AppError> {
+    if old.status == "revoked" {
+        return match authorization {
+            CertificateRenewalAuthorization::Operator { .. } => {
+                Err(AppError::bad_request("cannot renew a revoked certificate"))
+            }
+            CertificateRenewalAuthorization::PresentedCertificate { .. } => {
+                Err(AppError::Unauthorized("certificate revoked".into()))
+            }
+        };
+    }
+    if old.status != "active" {
+        return Err(AppError::Unauthorized("certificate is not active".into()));
+    }
+    let expires_at = old
+        .expires_at
+        .ok_or_else(|| AppError::bad_request("cannot renew a certificate without an expiry"))?;
+
+    if matches!(
+        authorization,
+        CertificateRenewalAuthorization::Operator { .. }
+    ) {
+        // An explicitly authorized operator is the recovery path for an
+        // expired (but never revoked) subject certificate.
+        return Ok(());
+    }
+
+    if metadata.not_before > now {
+        return Err(AppError::Unauthorized(
+            "certificate is not yet valid".into(),
+        ));
+    }
+    if expires_at <= now {
+        return Err(AppError::Unauthorized("certificate expired".into()));
+    }
+
+    if let Some(issuer_id) = old.issuer_id {
+        let issuer = authority_repo::lock_authority_for_certificate_authentication(tx, issuer_id)
+            .await
+            .map_err(|_| AppError::Unauthorized("certificate issuer is unavailable".into()))?;
+        let scope_matches = match old.tenant_id {
+            Some(tenant_id) => {
+                issuer.kind == AuthorityKind::TenantIntermediate
+                    && issuer.tenant_id == Some(tenant_id)
+            }
+            None => issuer.kind == AuthorityKind::PlatformLeafIssuer && issuer.tenant_id.is_none(),
+        };
+        if !scope_matches
+            || !matches!(
+                issuer.status,
+                AuthorityStatus::Active | AuthorityStatus::Retiring
+            )
+        {
+            return Err(AppError::Unauthorized(
+                "certificate issuer is not trusted for renewal".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn renewal_threshold_for_certificate(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    entity_id: Uuid,
+    profile_id: Option<Uuid>,
+    stored_threshold_seconds: Option<u64>,
+) -> Result<u64, AppError> {
+    if let Some(value) = stored_threshold_seconds {
+        return Ok(value);
+    }
+    if let Some(profile_id) = profile_id {
+        return Ok(profile::profile_by_id(&mut **tx, profile_id)
+            .await?
+            .renewal_threshold_seconds());
+    }
+    let subject = profile::load_subject(&mut **tx, entity_id).await?;
+    Ok(profile::resolve_for_subject_in_tx(tx, &subject, "client")
+        .await?
+        .renewal_threshold_seconds())
+}
+
+fn renewal_due_at(
+    not_before: DateTime<Utc>,
+    not_after: DateTime<Utc>,
+    threshold_seconds: u64,
+) -> Result<DateTime<Utc>, AppError> {
+    if threshold_seconds == 0 {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "stored certificate renewal threshold is invalid"
+        )));
+    }
+    let threshold = i64::try_from(threshold_seconds).map_err(|_| {
+        AppError::Internal(anyhow::anyhow!(
+            "stored certificate renewal threshold is too large"
+        ))
+    })?;
+    let due_at = not_after
+        .checked_sub_signed(chrono::Duration::seconds(threshold))
+        .ok_or_else(|| {
+            AppError::Internal(anyhow::anyhow!(
+                "stored certificate renewal window is invalid"
+            ))
+        })?;
+    Ok(due_at.max(not_before))
+}
+
+fn renewal_request_key_hash(value: &str) -> String {
+    let mut context = digest::Context::new(&digest::SHA256);
+    context.update(b"atom:pki:certificate-renewal-key:v1\0");
+    context.update(value.as_bytes());
+    hex::encode(context.finish())
+}
+
+fn renewal_request_fingerprint(
+    credential_id: Uuid,
+    ttl_secs: Option<u64>,
+    revoke_old: bool,
+    key_mode: &str,
+    request_material: &[u8],
+) -> String {
+    let mut context = digest::Context::new(&digest::SHA256);
+    context.update(b"atom:pki:certificate-renewal-request:v1\0");
+    context.update(credential_id.as_bytes());
+    match ttl_secs {
+        Some(ttl) => {
+            context.update(&[1]);
+            context.update(&ttl.to_be_bytes());
+        }
+        None => context.update(&[0]),
+    }
+    context.update(&[u8::from(revoke_old)]);
+    context.update(&(key_mode.len() as u64).to_be_bytes());
+    context.update(key_mode.as_bytes());
+    context.update(&(request_material.len() as u64).to_be_bytes());
+    context.update(request_material);
     hex::encode(context.finish())
 }
 

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -1036,7 +1036,7 @@ pub async fn renew_certificate_v2_in_tx(
                     let mut metadata = old.metadata.clone();
                     metadata["revoked_at"] = json!(Utc::now());
                     metadata["revocation_reason"] = json!("superseded");
-                    repo::revoke_certificate(&mut **attempt_tx, old.id, metadata).await?;
+                    repo::revoke_certificate(&mut *attempt_tx, old.id, metadata).await?;
                     // PR-008 replaces this global dirty mark with an exact
                     // issuer-keyed update. Credential status is still changed
                     // atomically and is immediately authoritative in Atom.

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -1706,7 +1706,12 @@ async fn validate_renewal_source(
             }
             None => issuer.kind == AuthorityKind::PlatformLeafIssuer && issuer.tenant_id.is_none(),
         };
+        let issuer_is_current = matches!(
+            (issuer.not_before.as_ref(), issuer.not_after.as_ref()),
+            (Some(not_before), Some(not_after)) if not_before <= &now && &now < not_after
+        );
         if !scope_matches
+            || !issuer_is_current
             || !matches!(
                 issuer.status,
                 AuthorityStatus::Active | AuthorityStatus::Retiring

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -276,6 +276,8 @@ mod tests {
             "issueCertificateFromCsr",
             "issueCertificateFromCsrV2",
             "renewCertificate",
+            "renewCertificateFromCsrV2",
+            "renewGeneratedCertificateV2",
             "revokeCertificate",
             "revokeEntityCertificates",
             "addOwnership",

--- a/tests/common/pki.rs
+++ b/tests/common/pki.rs
@@ -181,7 +181,7 @@ pub async fn rotate_tenant_issuer(
 ) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
     let pending =
-        provisioning::begin_tenant_intermediate_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
+        provisioning::begin_tenant_authority_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
             .await
             .unwrap();
     tx.commit().await.unwrap();

--- a/tests/common/pki.rs
+++ b/tests/common/pki.rs
@@ -127,6 +127,94 @@ pub async fn provision_tenant_issuer(
         .unwrap()
 }
 
+pub async fn provision_platform_leaf_issuer(
+    pool: &PgPool,
+    config: &Config,
+    root: &TestRoot,
+) -> AuthorityRecord {
+    let mut tx = pool.begin().await.unwrap();
+    provisioning::import_root_in_tx(&mut tx, &root.pem)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let pending = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &config.pki_ca_keys)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    let signed = sign_authority_csr(&pending, root);
+    let mut tx = pool.begin().await.unwrap();
+    let imported = provisioning::import_signed_authority_in_tx(
+        &mut tx,
+        &config.pki_ca_keys,
+        pending.id,
+        &signed,
+    )
+    .await
+    .unwrap();
+    assert!(imported.succeeded(), "{:?}", imported.validation_error);
+    tx.commit().await.unwrap();
+    sqlx::query(
+        r#"UPDATE pki_authorities
+           SET ocsp_url = $2, ca_issuers_url = $3,
+               crl_distribution_point_url = $4
+           WHERE id = $1"#,
+    )
+    .bind(imported.authority.id)
+    .bind(OCSP_URL)
+    .bind(CA_ISSUERS_URL)
+    .bind(CRL_URL)
+    .execute(pool)
+    .await
+    .unwrap();
+    authority_repo::authority_by_id(pool, imported.authority.id)
+        .await
+        .unwrap()
+}
+
+pub async fn rotate_tenant_issuer(
+    pool: &PgPool,
+    config: &Config,
+    root: &TestRoot,
+    tenant_id: Uuid,
+) -> AuthorityRecord {
+    let mut tx = pool.begin().await.unwrap();
+    let pending =
+        provisioning::begin_tenant_intermediate_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
+            .await
+            .unwrap();
+    tx.commit().await.unwrap();
+    let signed = sign_authority_csr(&pending, root);
+    let mut tx = pool.begin().await.unwrap();
+    let imported = provisioning::import_signed_authority_in_tx(
+        &mut tx,
+        &config.pki_ca_keys,
+        pending.id,
+        &signed,
+    )
+    .await
+    .unwrap();
+    assert!(imported.succeeded(), "{:?}", imported.validation_error);
+    tx.commit().await.unwrap();
+    sqlx::query(
+        r#"UPDATE pki_authorities
+           SET ocsp_url = $2, ca_issuers_url = $3,
+               crl_distribution_point_url = $4
+           WHERE id = $1"#,
+    )
+    .bind(imported.authority.id)
+    .bind(OCSP_URL)
+    .bind(CA_ISSUERS_URL)
+    .bind(CRL_URL)
+    .execute(pool)
+    .await
+    .unwrap();
+    authority_repo::authority_by_id(pool, imported.authority.id)
+        .await
+        .unwrap()
+}
+
 fn sign_authority_csr(pending: &AuthorityRecord, root: &TestRoot) -> String {
     let mut csr =
         CertificateSigningRequestParams::from_pem(pending.csr_pem.as_deref().unwrap()).unwrap();
@@ -157,6 +245,19 @@ pub async fn create_entity(pool: &PgPool, tenant_id: Uuid, prefix: &str) -> Uuid
     .bind(id)
     .bind(format!("{prefix}-{id}"))
     .bind(tenant_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+pub async fn create_global_entity(pool: &PgPool, prefix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO entities (id, kind, name, status) VALUES ($1, 'service', $2, 'active')",
+    )
+    .bind(id)
+    .bind(format!("{prefix}-{id}"))
     .execute(pool)
     .await
     .unwrap();

--- a/tests/m34_pki_renewal.rs
+++ b/tests/m34_pki_renewal.rs
@@ -1,0 +1,664 @@
+//! PR-007 exact-credential, issuer-aware renewal coverage.
+//!
+//! Requires PostgreSQL and OpenSSL. CI runs this ignored binary against its own
+//! freshly migrated database, single-threaded.
+
+mod common;
+
+use async_graphql::{Request, Variables};
+use atom::{
+    auth::AuthContext,
+    certs::{authority::AuthorityStatus, service},
+    config::Config,
+    graphql::build_schema,
+};
+use chrono::{Duration as ChronoDuration, Utc};
+use rcgen::{CertificateParams, DnType, KeyPair};
+use ring::digest;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
+use uuid::Uuid;
+use x509_parser::pem::parse_x509_pem;
+use zeroize::Zeroize;
+
+#[tokio::test]
+#[ignore]
+async fn issuer_aware_renewal_enforces_the_pr007_contract() {
+    let pool = common::pool().await;
+    let config = common::pki::managed_config(true, true);
+    let tenant_a = common::pki::create_tenant(&pool, "pki-renew-a").await;
+    let tenant_b = common::pki::create_tenant(&pool, "pki-renew-b").await;
+    let entity_a = common::pki::create_entity(&pool, tenant_a, "pki-renew-a").await;
+    let entity_b = common::pki::create_entity(&pool, tenant_b, "pki-renew-b").await;
+    let root = common::pki::test_root("PR-007 Offline Root");
+    let issuer_v1 = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let schema = build_schema(common::pki::graphql_state(pool.clone(), config.clone()));
+
+    assert_v2_schema_contract(&schema).await;
+
+    // Same-issuer renewal preserves overlap and records one exact history link.
+    let old_overlap = issue_managed(&pool, &config, tenant_a, entity_a, "old-overlap").await;
+    assert_eq!(old_overlap.issuer_id, Some(issuer_v1.id));
+    let overlap_csr = csr();
+    let overlap = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            old_overlap.credential_id,
+            &overlap_csr,
+            "renew-overlap",
+            false,
+        ))
+        .await;
+    assert!(overlap.errors.is_empty(), "{:?}", overlap.errors);
+    let overlap = overlap.data.into_json().unwrap()["renewCertificateFromCsrV2"].clone();
+    assert_eq!(overlap["idempotentReplay"], false);
+    assert!(overlap["privateKeyPem"].is_null());
+    let overlap_id = uuid_field(&overlap, "credentialId");
+    assert_eq!(
+        overlap["certificate"]["renewedFromCredentialId"],
+        old_overlap.credential_id.to_string()
+    );
+    assert_eq!(overlap["certificate"]["issuerId"], issuer_v1.id.to_string());
+    assert!(overlap["certificate"]["renewalDueAt"].is_string());
+    let old_after = service::certificate_by_id(&pool, old_overlap.credential_id)
+        .await
+        .unwrap();
+    let new_after = service::certificate_by_id(&pool, overlap_id).await.unwrap();
+    assert_eq!(old_after.status, "active");
+    assert_eq!(new_after.status, "active");
+    assert_eq!(
+        new_after.renewed_from_credential_id,
+        Some(old_overlap.credential_id)
+    );
+    assert_ne!(new_after.serial_number, old_after.serial_number);
+    assert_ne!(new_after.fingerprint_sha256, old_after.fingerprint_sha256);
+    assert_eq!(
+        renewal_replacement(&pool, old_overlap.credential_id).await,
+        overlap_id
+    );
+    assert_profile_window(&pool, overlap_id).await;
+
+    // Exact retries return the original replacement without a second event or
+    // certificate. Any changed request for the already-renewed source conflicts.
+    let replay = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            old_overlap.credential_id,
+            &overlap_csr,
+            "renew-overlap",
+            false,
+        ))
+        .await;
+    assert!(replay.errors.is_empty(), "{:?}", replay.errors);
+    let replay = replay.data.into_json().unwrap()["renewCertificateFromCsrV2"].clone();
+    assert_eq!(replay["idempotentReplay"], true);
+    assert_eq!(uuid_field(&replay, "credentialId"), overlap_id);
+    assert!(replay["privateKeyPem"].is_null());
+    let changed_retry = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            old_overlap.credential_id,
+            &csr(),
+            "renew-overlap-changed",
+            false,
+        ))
+        .await;
+    assert!(errors_contain(&changed_retry.errors, "already renewed"));
+    assert_eq!(renewal_count(&pool, old_overlap.credential_id).await, 1);
+    assert_audit_and_outbox_linkage(&pool, old_overlap.credential_id, overlap_id).await;
+
+    // A caller from another tenant cannot rotate the exact credential.
+    let cross_tenant = schema
+        .execute(renew_csr_request(
+            entity_b,
+            Some(tenant_b),
+            old_overlap.credential_id,
+            &csr(),
+            "renew-cross-tenant",
+            false,
+        ))
+        .await;
+    assert!(errors_contain(&cross_tenant.errors, "forbidden"));
+    assert_eq!(renewal_count(&pool, old_overlap.credential_id).await, 1);
+
+    // A leaf issued by v1 renews under v2 after the one-active-issuer handover.
+    let old_rotation = issue_managed(&pool, &config, tenant_a, entity_a, "old-rotation").await;
+    let issuer_v2 = common::pki::rotate_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    assert_ne!(issuer_v1.id, issuer_v2.id);
+    let retired_v1 = atom::certs::authority::repo::authority_by_id(&pool, issuer_v1.id)
+        .await
+        .unwrap();
+    assert_eq!(retired_v1.status, AuthorityStatus::Retiring);
+    assert!(!retired_v1.issuance_enabled);
+    let rotated = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            old_rotation.credential_id,
+            &csr(),
+            "renew-rotation",
+            false,
+        ))
+        .await;
+    assert!(rotated.errors.is_empty(), "{:?}", rotated.errors);
+    let rotated = rotated.data.into_json().unwrap()["renewCertificateFromCsrV2"].clone();
+    assert_eq!(rotated["certificate"]["issuerId"], issuer_v2.id.to_string());
+    assert_eq!(old_rotation.issuer_id, Some(issuer_v1.id));
+
+    // Generated renewal is a separate explicit API. Its key is returned only
+    // on the first response and immediate revocation is atomic with linkage.
+    let old_generated = issue_managed(&pool, &config, tenant_a, entity_a, "old-generated").await;
+    let generated = schema
+        .execute(renew_generated_request(
+            common::admin_id(),
+            None,
+            old_generated.credential_id,
+            "renew-generated",
+            true,
+        ))
+        .await;
+    assert!(generated.errors.is_empty(), "{:?}", generated.errors);
+    let generated = generated.data.into_json().unwrap()["renewGeneratedCertificateV2"].clone();
+    let generated_id = uuid_field(&generated, "credentialId");
+    let mut generated_key = generated["privateKeyPem"].as_str().unwrap().to_string();
+    let generated_pem = generated["certificate"]["certificatePem"].as_str().unwrap();
+    assert_key_matches_certificate(&generated_key, generated_pem);
+    assert_eq!(
+        service::certificate_by_id(&pool, old_generated.credential_id)
+            .await
+            .unwrap()
+            .status,
+        "revoked"
+    );
+    assert_eq!(
+        renewal_replacement(&pool, old_generated.credential_id).await,
+        generated_id
+    );
+    let generated_audit =
+        audit_details(&pool, "certificate.renew", old_generated.credential_id).await;
+    assert_eq!(generated_audit["key_mode"], "generated");
+    assert_eq!(generated_audit["revoke_old"], true);
+
+    // A revoked certificate is never renewal authentication and cannot be
+    // recovered through operator renewal; it must follow fresh enrollment.
+    let revoked_self = service::renew_certificate_v2(
+        &pool,
+        &config,
+        service::CertificateRenewalAuthorization::PresentedCertificate {
+            credential_id: old_generated.credential_id,
+        },
+        service::RenewCertificateV2 {
+            credential_id: old_generated.credential_id,
+            ttl_secs: Some(3600),
+            key_source: service::RenewalKeySource::Csr(csr()),
+            revoke_old: false,
+            idempotency_key: "revoked-self".into(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(revoked_self.to_string().contains("revoked"));
+    let revoked_operator = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            old_generated.credential_id,
+            &csr(),
+            "revoked-operator",
+            false,
+        ))
+        .await;
+    assert!(errors_contain(&revoked_operator.errors, "revoked"));
+
+    // The certificate-authenticated service seam accepts an exact, valid
+    // certificate in its profile window and rejects credential substitution.
+    let old_self = issue_managed(&pool, &config, tenant_a, entity_a, "old-self").await;
+    let wrong_presented = service::renew_certificate_v2(
+        &pool,
+        &config,
+        service::CertificateRenewalAuthorization::PresentedCertificate {
+            credential_id: old_generated.credential_id,
+        },
+        service::RenewCertificateV2 {
+            credential_id: old_self.credential_id,
+            ttl_secs: Some(3600),
+            key_source: service::RenewalKeySource::Csr(csr()),
+            revoke_old: false,
+            idempotency_key: "wrong-presented".into(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(wrong_presented.to_string().contains("forbidden"));
+    let self_renewed = service::renew_certificate_v2(
+        &pool,
+        &config,
+        service::CertificateRenewalAuthorization::PresentedCertificate {
+            credential_id: old_self.credential_id,
+        },
+        service::RenewCertificateV2 {
+            credential_id: old_self.credential_id,
+            ttl_secs: Some(3600),
+            key_source: service::RenewalKeySource::Csr(csr()),
+            revoke_old: false,
+            idempotency_key: "valid-self".into(),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        self_renewed.certificate.renewed_from_credential_id,
+        Some(old_self.credential_id)
+    );
+
+    // Expired certificate authentication fails, while a normally authorized
+    // operator can explicitly recover the expired (not revoked) subject.
+    let old_expired = issue_managed(&pool, &config, tenant_a, entity_a, "old-expired").await;
+    expire_certificate(&pool, old_expired.credential_id).await;
+    let expired_self = service::renew_certificate_v2(
+        &pool,
+        &config,
+        service::CertificateRenewalAuthorization::PresentedCertificate {
+            credential_id: old_expired.credential_id,
+        },
+        service::RenewCertificateV2 {
+            credential_id: old_expired.credential_id,
+            ttl_secs: Some(3600),
+            key_source: service::RenewalKeySource::Csr(csr()),
+            revoke_old: false,
+            idempotency_key: "expired-self".into(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(expired_self.to_string().contains("expired"));
+    let recovered = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            old_expired.credential_id,
+            &csr(),
+            "expired-operator-recovery",
+            false,
+        ))
+        .await;
+    assert!(recovered.errors.is_empty(), "{:?}", recovered.errors);
+
+    // Legacy issuer_id=NULL credentials migrate by renewal, never rewriting:
+    // tenant subjects use their tenant issuer and global subjects use the
+    // separately provisioned platform leaf issuer.
+    let legacy_tenant = insert_legacy_certificate(&pool, entity_a).await;
+    let tenant_migration = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            legacy_tenant,
+            &csr(),
+            "legacy-tenant",
+            false,
+        ))
+        .await;
+    assert!(
+        tenant_migration.errors.is_empty(),
+        "{:?}",
+        tenant_migration.errors
+    );
+    assert_eq!(
+        tenant_migration.data.into_json().unwrap()["renewCertificateFromCsrV2"]["certificate"]
+            ["issuerId"],
+        issuer_v2.id.to_string()
+    );
+    assert!(service::certificate_by_id(&pool, legacy_tenant)
+        .await
+        .unwrap()
+        .issuer_id
+        .is_none());
+
+    let global_entity = common::pki::create_global_entity(&pool, "pki-renew-global").await;
+    let platform_issuer = common::pki::provision_platform_leaf_issuer(&pool, &config, &root).await;
+    let legacy_global = insert_legacy_certificate(&pool, global_entity).await;
+    let global_migration = schema
+        .execute(renew_csr_request(
+            common::admin_id(),
+            None,
+            legacy_global,
+            &csr(),
+            "legacy-global",
+            false,
+        ))
+        .await;
+    assert!(
+        global_migration.errors.is_empty(),
+        "{:?}",
+        global_migration.errors
+    );
+    assert_eq!(
+        global_migration.data.into_json().unwrap()["renewCertificateFromCsrV2"]["certificate"]
+            ["issuerId"],
+        platform_issuer.id.to_string()
+    );
+
+    generated_key.zeroize();
+}
+
+async fn assert_v2_schema_contract(schema: &atom::graphql::AtomSchema) {
+    let response = schema
+        .execute(Request::new(
+            r#"{
+              csr: __type(name: "RenewCertificateFromCsrV2Input") { inputFields { name } }
+              generated: __type(name: "RenewGeneratedCertificateV2Input") { inputFields { name } }
+              certificate: __type(name: "Certificate") { fields { name } }
+              mutation: __schema { mutationType { fields { name } } }
+            }"#,
+        ))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().unwrap();
+    assert_eq!(
+        sorted_field_names(&data["csr"]["inputFields"]),
+        vec![
+            "credentialId",
+            "csrPem",
+            "idempotencyKey",
+            "revokeOld",
+            "ttlSecs"
+        ]
+    );
+    assert_eq!(
+        sorted_field_names(&data["generated"]["inputFields"]),
+        vec!["credentialId", "idempotencyKey", "revokeOld", "ttlSecs"]
+    );
+    let certificate_fields = sorted_field_names(&data["certificate"]["fields"]);
+    assert!(certificate_fields.contains(&"renewalDueAt"));
+    assert!(certificate_fields.contains(&"renewedFromCredentialId"));
+    let mutations = sorted_field_names(&data["mutation"]["mutationType"]["fields"]);
+    assert!(mutations.contains(&"renewCertificate"));
+    assert!(mutations.contains(&"renewCertificateFromCsrV2"));
+    assert!(mutations.contains(&"renewGeneratedCertificateV2"));
+}
+
+async fn issue_managed(
+    pool: &PgPool,
+    config: &Config,
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    label: &str,
+) -> service::CertificateRecord {
+    service::issue_certificate_from_csr_v2(
+        pool,
+        config,
+        Some(tenant_id),
+        service::IssueCertificateFromCsrV2 {
+            entity_id,
+            ttl_secs: Some(3600),
+            csr_pem: csr(),
+            idempotency_key: format!("{label}-{}", Uuid::new_v4()),
+        },
+    )
+    .await
+    .unwrap()
+    .certificate
+}
+
+fn csr() -> String {
+    let key = KeyPair::generate().unwrap();
+    CertificateParams::default()
+        .serialize_request(&key)
+        .unwrap()
+        .pem()
+        .unwrap()
+}
+
+fn renew_csr_request(
+    actor_id: Uuid,
+    actor_tenant_id: Option<Uuid>,
+    credential_id: Uuid,
+    csr_pem: &str,
+    idempotency_key: &str,
+    revoke_old: bool,
+) -> Request {
+    Request::new(
+        r#"mutation Renew($input: RenewCertificateFromCsrV2Input!) {
+          renewCertificateFromCsrV2(input: $input) {
+            idempotentReplay privateKeyPem chainPem
+            certificate {
+              credentialId renewedFromCredentialId entityId tenantId issuerId
+              serialNumber fingerprintSha256 certificatePem profileId
+              renewalDueAt status
+            }
+          }
+        }"#,
+    )
+    .variables(Variables::from_json(json!({
+        "input": {
+            "credentialId": credential_id,
+            "ttlSecs": 3600,
+            "csrPem": csr_pem,
+            "revokeOld": revoke_old,
+            "idempotencyKey": idempotency_key,
+        }
+    })))
+    .data(auth(actor_id, actor_tenant_id))
+}
+
+fn renew_generated_request(
+    actor_id: Uuid,
+    actor_tenant_id: Option<Uuid>,
+    credential_id: Uuid,
+    idempotency_key: &str,
+    revoke_old: bool,
+) -> Request {
+    Request::new(
+        r#"mutation Renew($input: RenewGeneratedCertificateV2Input!) {
+          renewGeneratedCertificateV2(input: $input) {
+            idempotentReplay privateKeyPem chainPem
+            certificate {
+              credentialId renewedFromCredentialId entityId tenantId issuerId
+              serialNumber fingerprintSha256 certificatePem profileId
+              renewalDueAt status
+            }
+          }
+        }"#,
+    )
+    .variables(Variables::from_json(json!({
+        "input": {
+            "credentialId": credential_id,
+            "ttlSecs": 3600,
+            "revokeOld": revoke_old,
+            "idempotencyKey": idempotency_key,
+        }
+    })))
+    .data(auth(actor_id, actor_tenant_id))
+}
+
+fn auth(entity_id: Uuid, tenant_id: Option<Uuid>) -> AuthContext {
+    AuthContext {
+        entity_id,
+        tenant_id,
+        session_id: None,
+        ..Default::default()
+    }
+}
+
+fn uuid_field(value: &Value, field: &str) -> Uuid {
+    value["certificate"][field]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+fn sorted_field_names(value: &Value) -> Vec<&str> {
+    let mut names = value
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|field| field["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names
+}
+
+fn errors_contain(errors: &[async_graphql::ServerError], expected: &str) -> bool {
+    errors.iter().any(|error| error.message.contains(expected))
+}
+
+async fn renewal_replacement(pool: &PgPool, old_id: Uuid) -> Uuid {
+    sqlx::query_scalar(
+        "SELECT replacement_credential_id FROM certificate_renewals WHERE previous_credential_id = $1",
+    )
+    .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn renewal_count(pool: &PgPool, old_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM certificate_renewals WHERE previous_credential_id = $1",
+    )
+    .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn assert_profile_window(pool: &PgPool, credential_id: Uuid) {
+    let (metadata, expires_at): (Value, chrono::DateTime<Utc>) =
+        sqlx::query_as("SELECT metadata, expires_at FROM credentials WHERE id = $1")
+            .bind(credential_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(metadata["renewal_threshold_seconds"], 86_400);
+    let due_at = chrono::DateTime::parse_from_rfc3339(metadata["renewal_due_at"].as_str().unwrap())
+        .unwrap()
+        .with_timezone(&Utc);
+    let not_before = chrono::DateTime::parse_from_rfc3339(metadata["not_before"].as_str().unwrap())
+        .unwrap()
+        .with_timezone(&Utc);
+    assert_eq!(due_at, not_before);
+    assert!(due_at < expires_at);
+}
+
+async fn assert_audit_and_outbox_linkage(pool: &PgPool, old_id: Uuid, new_id: Uuid) {
+    let details = audit_details(pool, "certificate.renew", old_id).await;
+    assert_eq!(details["old_credential_id"], old_id.to_string());
+    assert_eq!(details["new_credential_id"], new_id.to_string());
+    assert_eq!(details["key_mode"], "csr");
+    assert_eq!(details["revoke_old"], false);
+    let payload: Value = sqlx::query_scalar(
+        r#"SELECT payload FROM event_outbox
+           WHERE event = 'certificate.renew' AND (payload->>'target_id')::uuid = $1"#,
+    )
+    .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(payload["details"]["new_credential_id"], new_id.to_string());
+    let event_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM event_outbox WHERE event = 'certificate.renew' AND (payload->>'target_id')::uuid = $1",
+    )
+    .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(event_count, 1);
+    let replay_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_logs WHERE event = 'certificate.renew_replayed' AND target_id = $1",
+    )
+    .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(replay_count, 1);
+}
+
+async fn audit_details(pool: &PgPool, event: &str, old_id: Uuid) -> Value {
+    sqlx::query_scalar(
+        "SELECT details FROM audit_logs WHERE event = $1 AND target_id = $2 ORDER BY created_at DESC LIMIT 1",
+    )
+    .bind(event)
+    .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn expire_certificate(pool: &PgPool, credential_id: Uuid) {
+    sqlx::query(
+        r#"UPDATE credentials
+           SET expires_at = now() - interval '1 minute',
+               metadata = jsonb_set(
+                   metadata,
+                   '{not_after}',
+                   to_jsonb(now() - interval '1 minute')
+               )
+           WHERE id = $1"#,
+    )
+    .bind(credential_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_legacy_certificate(pool: &PgPool, entity_id: Uuid) -> Uuid {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, entity_id.to_string());
+    params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
+    params.not_after = OffsetDateTime::now_utc() + Duration::days(1);
+    let certificate = params.self_signed(&key).unwrap();
+    let fingerprint = hex::encode(digest::digest(&digest::SHA256, certificate.der().as_ref()));
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+    let expires_at = now + ChronoDuration::days(1);
+    let metadata = json!({
+        "certificate_pem": certificate.pem(),
+        "chain_pem": null,
+        "subject": {"common_name": entity_id},
+        "dns_names": [],
+        "ip_addresses": [],
+        "issuer_kind": "legacy_file_issuer",
+        "issuer_subject": "PR-007 legacy issuer",
+        "issuer_serial_number": "01",
+        "issuer_fingerprint_sha256": format!("legacy-{}", Uuid::new_v4()),
+        "fingerprint_sha256": fingerprint,
+        "profile_id": null,
+        "profile_name": null,
+        "identity_uri": null,
+        "not_before": now - ChronoDuration::minutes(1),
+        "not_after": expires_at,
+        "issued_from_csr": false,
+        "revoked_at": null,
+        "revocation_reason": null,
+    });
+    sqlx::query(
+        r#"INSERT INTO credentials (
+               id, entity_id, kind, identifier, metadata, expires_at, issuer_id
+           ) VALUES ($1, $2, 'certificate', $3, $4, $5, NULL)"#,
+    )
+    .bind(id)
+    .bind(entity_id)
+    .bind(Uuid::new_v4().simple().to_string())
+    .bind(metadata)
+    .bind(expires_at)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+fn assert_key_matches_certificate(private_key_pem: &str, certificate_pem: &str) {
+    let key = KeyPair::from_pem(private_key_pem).unwrap();
+    let (_, public_pem) = parse_x509_pem(key.public_key_pem().as_bytes()).unwrap();
+    let (_, certificate_pem) = parse_x509_pem(certificate_pem.as_bytes()).unwrap();
+    let (_, certificate) = x509_parser::parse_x509_certificate(&certificate_pem.contents).unwrap();
+    assert_eq!(public_pem.contents, certificate.public_key().raw);
+}

--- a/tests/m34_pki_renewal.rs
+++ b/tests/m34_pki_renewal.rs
@@ -127,6 +127,8 @@ async fn issuer_aware_renewal_enforces_the_pr007_contract() {
 
     // A leaf issued by v1 renews under v2 after the one-active-issuer handover.
     let old_rotation = issue_managed(&pool, &config, tenant_a, entity_a, "old-rotation").await;
+    let old_retiring_self =
+        issue_managed(&pool, &config, tenant_a, entity_a, "old-retiring-self").await;
     let issuer_v2 = common::pki::rotate_tenant_issuer(&pool, &config, &root, tenant_a).await;
     assert_ne!(issuer_v1.id, issuer_v2.id);
     let retired_v1 = atom::certs::authority::repo::authority_by_id(&pool, issuer_v1.id)
@@ -148,6 +150,27 @@ async fn issuer_aware_renewal_enforces_the_pr007_contract() {
     let rotated = rotated.data.into_json().unwrap()["renewCertificateFromCsrV2"].clone();
     assert_eq!(rotated["certificate"]["issuerId"], issuer_v2.id.to_string());
     assert_eq!(old_rotation.issuer_id, Some(issuer_v1.id));
+    let retiring_self = service::renew_certificate_v2(
+        &pool,
+        &config,
+        service::CertificateRenewalAuthorization::PresentedCertificate {
+            credential_id: old_retiring_self.credential_id,
+        },
+        service::RenewCertificateV2 {
+            credential_id: old_retiring_self.credential_id,
+            ttl_secs: Some(3600),
+            key_source: service::RenewalKeySource::Csr(csr()),
+            revoke_old: false,
+            idempotency_key: "retiring-self".into(),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(retiring_self.certificate.issuer_id, Some(issuer_v2.id));
+    assert_eq!(
+        retiring_self.certificate.renewed_from_credential_id,
+        Some(old_retiring_self.credential_id)
+    );
 
     // Generated renewal is a separate explicit API. Its key is returned only
     // on the first response and immediate revocation is atomic with linkage.

--- a/tests/m34_pki_renewal.rs
+++ b/tests/m34_pki_renewal.rs
@@ -182,17 +182,38 @@ async fn issuer_aware_renewal_enforces_the_pr007_contract() {
         audit_details(&pool, "certificate.renew", old_generated.credential_id).await;
     assert_eq!(generated_audit["key_mode"], "generated");
     assert_eq!(generated_audit["revoke_old"], true);
+    let generated_replay = schema
+        .execute(renew_generated_request(
+            common::admin_id(),
+            None,
+            old_generated.credential_id,
+            "renew-generated",
+            true,
+        ))
+        .await;
+    assert!(
+        generated_replay.errors.is_empty(),
+        "{:?}",
+        generated_replay.errors
+    );
+    let generated_replay =
+        generated_replay.data.into_json().unwrap()["renewGeneratedCertificateV2"].clone();
+    assert_eq!(generated_replay["idempotentReplay"], true);
+    assert!(generated_replay["privateKeyPem"].is_null());
+    assert_eq!(uuid_field(&generated_replay, "credentialId"), generated_id);
 
     // A revoked certificate is never renewal authentication and cannot be
     // recovered through operator renewal; it must follow fresh enrollment.
+    let old_revoked = issue_managed(&pool, &config, tenant_a, entity_a, "old-revoked").await;
+    revoke_certificate(&pool, old_revoked.credential_id).await;
     let revoked_self = service::renew_certificate_v2(
         &pool,
         &config,
         service::CertificateRenewalAuthorization::PresentedCertificate {
-            credential_id: old_generated.credential_id,
+            credential_id: old_revoked.credential_id,
         },
         service::RenewCertificateV2 {
-            credential_id: old_generated.credential_id,
+            credential_id: old_revoked.credential_id,
             ttl_secs: Some(3600),
             key_source: service::RenewalKeySource::Csr(csr()),
             revoke_old: false,
@@ -206,7 +227,7 @@ async fn issuer_aware_renewal_enforces_the_pr007_contract() {
         .execute(renew_csr_request(
             common::admin_id(),
             None,
-            old_generated.credential_id,
+            old_revoked.credential_id,
             &csr(),
             "revoked-operator",
             false,
@@ -597,6 +618,23 @@ async fn expire_certificate(pool: &PgPool, credential_id: Uuid) {
                    metadata,
                    '{not_after}',
                    to_jsonb(now() - interval '1 minute')
+               )
+           WHERE id = $1"#,
+    )
+    .bind(credential_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn revoke_certificate(pool: &PgPool, credential_id: Uuid) {
+    sqlx::query(
+        r#"UPDATE credentials
+           SET status = 'revoked',
+               metadata = jsonb_set(
+                   jsonb_set(metadata, '{revoked_at}', to_jsonb(now())),
+                   '{revocation_reason}',
+                   '"test_revocation"'::jsonb
                )
            WHERE id = $1"#,
     )


### PR DESCRIPTION
## Objective

Implement PR-007 exact-credential, issuer-aware renewal into the subject scope's current active managed issuer while preserving history and supporting controlled overlap.

## Dependencies

- PR-006 — merged into `certificates` by #51 at `8429f757826f5671ee05663e6d1a6e72a02eedc5`.
- This branch is based on that exact merged `certificates` tip.

## Changes

- Adds separate CSR and explicitly controlled generated-key v2 renewal mutations keyed by exact credential ID.
- Adds a transactional renewal/idempotency ledger with one immutable replacement link per source certificate and database-enforced same-entity/managed-issuer invariants.
- Revalidates entity and tenant ownership under lock, supports exact certificate-authenticated self-renewal, and selects the current active tenant or platform leaf issuer.
- Stores the certificate profile renewal threshold and exposes `renewalDueAt`; legacy rows resolve it through their stored/referenced/effective profile.
- Preserves old/new overlap by default and supports atomic immediate revocation of the exact source credential.
- Returns generated private key material only on the first successful response and never stores or logs it.
- Documents issuer rotation, legacy tenant/global migration, expiry recovery, idempotency, and compatibility.
- Keeps the legacy serial-based renewal mutation unchanged.

## Acceptance criteria validation

- [x] **Renewal cannot cross tenant or entity.** Exact row locking plus operator entity/tenant revalidation and presented-credential equality enforce scope; `m34_pki_renewal` proves cross-tenant and credential-substitution denial.
- [x] **Old issuer may be retiring; new leaf uses the active issuer.** Renewal locks the current active scope issuer; `m34_pki_renewal` proves v1-to-v2 rotation and certificate-authenticated renewal from a retiring v1 issuer into v2.
- [x] **Expired/revoked credentials follow explicit policy.** Presented certificates must be active and currently valid; revoked sources cannot be operator-renewed, while an authorized operator may recover an expired, non-revoked source. The integration test covers every branch.
- [x] **New serial/fingerprint and correct issuer ID.** Managed issuance allocates a new serial and certificate; the test asserts serial and fingerprint inequality and the current issuer ID.
- [x] **Old and new remain unambiguously resolvable during overlap.** The source stays active unless `revokeOld` is set, both exact IDs resolve, and the dedicated relation points from source to replacement; tested.
- [x] **Legacy global certificates migrate to their subject scope.** The test proves tenant-owned legacy credentials renew under the tenant issuer and global credentials under the platform leaf issuer without rewriting the old row.
- [x] **Certificate-authenticated renewal accepts valid and rejects expired/revoked input, with recovery documented.** Service tests prove valid, expired, revoked, wrong-credential, and retiring-issuer cases; operator recovery and fresh-enrollment guidance are documented.

## Mandatory tests

- [x] Same-issuer renewal — CSR renewal remains on v1 and preserves overlap.
- [x] Rotation renewal — v1 source renews under active v2, including self-renewal from retiring v1.
- [x] Legacy migration — tenant and global legacy credentials select their correct managed issuers.
- [x] Revoked/expired input — certificate-auth rejection, revoked operator rejection, and expired operator recovery.
- [x] Overlap — both exact credentials remain active and linked.
- [x] Immediate revoke — generated renewal atomically revokes only the source with reason `superseded`.
- [x] Idempotent retries — exact CSR/generated retries return the same credential, changed requests conflict, and generated replay omits the private key.
- [x] Audit/outbox linkage — first success contains old/new credential and issuer evidence with one lifecycle event; replay does not duplicate the outbox event.
- [x] `m34_pki_renewal::issuer_aware_renewal_enforces_the_pr007_contract` — passed in Rust CI run #284.

## Additional validation

- `cargo fmt --check` — passed (Rust CI run #284).
- `cargo clippy -- -D warnings` — passed (Rust CI run #284).
- `cargo test --no-run --locked` — passed (Rust CI run #284).
- Fresh-database test matrix: `cargo test --lib -- --include-ignored --test-threads=1` and every eligible `cargo test --test <binary> -- --include-ignored --test-threads=1` — passed (Rust CI run #284).
- API Docs workflow run #225 — passed.
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm run build` in `docs/` — passed.
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm audit --prod --audit-level high` in `docs/` — passed at the configured high threshold; one pre-existing moderate advisory remains.
- `git diff --check origin/certificates...HEAD` — passed.
- Final diff review found no placeholders, secret logging, unresolved comments, or unrelated refactors.

## Non-goals

No bulk fleet automation, expiry sweeper/notification behavior (PR-015), or subject-facing enrollment transport (PR-014) is included.

## Compatibility and risks

- The legacy `renewCertificate` mutation remains available and unchanged.
- Managed generated-key renewal remains behind the production-off PR-006 feature flag.
- Issuer, profile, tenant, and entity are server-derived; callers cannot substitute them.
- Replacement creation, linkage, optional revocation, and lifecycle outbox insertion share one transaction. Audit storage follows the repository's existing post-commit best-effort policy.
- The new migration is additive. It stores only domain-separated request/key digests, never CSR or idempotency-key plaintext.
- This PR targets `certificates`; `main` was not used.