### PR TITLE
[PKI PR-008] Implement issuer-aware certificate revocation

### DIFF
--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -271,6 +271,61 @@ The original serial-based `renewCertificate` mutation remains the explicit v1
 compatibility path until resolver-v2 migration is complete. New integrations
 must use the exact-credential v2 mutations.
 
+## Issuer-aware revocation (v2)
+
+Use `revokeCertificateV2` for managed certificates. It accepts exactly one of
+these selectors:
+
+- `credentialId`;
+- `fingerprintSha256`; or
+- `issuerId` together with `serialNumber`.
+
+Serial alone is deliberately not a managed-certificate selector. The original
+`revokeCertificate` mutation is retained only for legacy `issuerId: null`
+credentials; it rejects managed certificates so new callers cannot create an
+ambiguous mutation dependency before the resolver-v2 cutover.
+
+```graphql
+mutation RevokeManagedCertificate($input: RevokeCertificateV2Input!) {
+  revokeCertificateV2(input: $input) {
+    idempotentReplay
+    reason
+    actorEntityId
+    revokedAt
+    certificate {
+      credentialId
+      issuerId
+      serialNumber
+      status
+    }
+  }
+}
+```
+
+Revocation transitions the exact credential directly from `active` to
+`revoked`; Atom does not use a publication-dependent pending state. The status
+change, immutable `certificate_revocations` evidence, and dirty flag for only
+the affected issuer commit in one database transaction. Runtime resolution
+denies the credential from that commit onward, even before a CRL or OCSP
+artifact is regenerated. PR-009 and PR-010 own artifact encoding and serving.
+
+Reason values are short reason codes (for example `key_compromise`,
+`superseded`, or `cessation_of_operation`), not free-form incident notes. Audit
+and lifecycle outbox payloads identify the actor, credential, issuer,
+fingerprint, serial, reason, and revocation time but contain no certificate,
+key, CSR, or other secret material.
+
+An exact repeated request is idempotent: it returns the original actor, reason,
+and time with `idempotentReplay: true`, does not rewrite history, and does not
+enqueue a second `certificate.revoke` event. Revoked credentials cannot use the
+renewal recovery path; enroll a fresh credential instead.
+
+`revokeEntityCertificates` revokes every active certificate for one authorized
+entity and records the affected credential and issuer IDs in its event. Entity
+suspension and tenant freeze/delete fail closed in runtime resolution. Tenant
+or entity deletion also records exact revocation evidence for every certificate
+it transitions; restoring the subject never reactivates those certificates.
+
 ## Legacy CA files
 
 The original v1 issuer remains available for backward compatibility and loads
@@ -311,6 +366,7 @@ offline-root flow above.
 | Generated-path leaf private key | Returned once by legacy/generated issuance, never stored |
 | CSR private key | Never enters Atom |
 | Managed CSR idempotency state | Request/key digests and committed credential ID only |
+| Certificate revocation evidence | `certificate_revocations`, one immutable row per exact credential |
 | CRL cache | `certificate_crl_state` |
 
 ## Public PKI Endpoints

--- a/migrations/010_pki_certificate_revocation.sql
+++ b/migrations/010_pki_certificate_revocation.sql
@@ -1,0 +1,178 @@
+-- Issuer-aware, immediately authoritative certificate revocation state.
+--
+-- credentials.status remains the hot-path decision. This immutable companion
+-- row records who revoked the exact credential, why, when, and which issuer's
+-- publication artifacts must be refreshed. The trigger covers every lifecycle
+-- path that transitions a certificate to revoked, including entity/tenant
+-- deletion and compatibility mutations.
+
+CREATE TABLE certificate_revocations (
+    credential_id              UUID        PRIMARY KEY
+                                             REFERENCES credentials(id) ON DELETE CASCADE,
+    issuer_id                  UUID        REFERENCES pki_authorities(id) ON DELETE RESTRICT,
+    issuer_fingerprint_sha256  TEXT        CHECK (
+                                             issuer_fingerprint_sha256 IS NULL
+                                             OR issuer_fingerprint_sha256 ~ '^[0-9a-f]{64}$'
+                                           ),
+    serial_number              TEXT        NOT NULL CHECK (serial_number ~ '^[0-9a-f]+$'),
+    reason                     TEXT        NOT NULL CHECK (
+                                             length(btrim(reason)) BETWEEN 1 AND 128
+                                           ),
+    actor_entity_id            UUID        REFERENCES entities(id) ON DELETE SET NULL,
+    revoked_at                 TIMESTAMPTZ NOT NULL,
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_certificate_revocations_issuer
+    ON certificate_revocations(issuer_id, revoked_at DESC)
+    WHERE issuer_id IS NOT NULL;
+
+CREATE INDEX idx_certificate_revocations_issuer_fingerprint
+    ON certificate_revocations(issuer_fingerprint_sha256, revoked_at DESC)
+    WHERE issuer_fingerprint_sha256 IS NOT NULL;
+
+-- Preserve already-revoked data during rollout. Old rows did not have a
+-- normalized actor column and some historical fixtures lack issuer metadata;
+-- those nullable fields stay explicitly unknown rather than being invented.
+INSERT INTO certificate_revocations (
+    credential_id, issuer_id, issuer_fingerprint_sha256, serial_number,
+    reason, actor_entity_id, revoked_at
+)
+SELECT c.id,
+       c.issuer_id,
+       CASE
+           WHEN c.metadata->>'issuer_fingerprint_sha256' ~ '^[0-9a-f]{64}$'
+           THEN c.metadata->>'issuer_fingerprint_sha256'
+       END,
+       c.identifier,
+       left(COALESCE(NULLIF(btrim(c.metadata->>'revocation_reason'), ''), 'unspecified'), 128),
+       CASE
+           WHEN c.metadata->>'revoked_by_entity_id'
+                ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+           THEN (c.metadata->>'revoked_by_entity_id')::uuid
+       END,
+       CASE
+           WHEN c.metadata->>'revoked_at' ~ '^\d{4}-\d{2}-\d{2}[T ]'
+           THEN (c.metadata->>'revoked_at')::timestamptz
+           ELSE c.created_at
+       END
+  FROM credentials c
+ WHERE c.kind = 'certificate'
+   AND c.status = 'revoked'
+   AND c.identifier IS NOT NULL
+ON CONFLICT (credential_id) DO NOTHING;
+
+-- Any existing per-issuer cache represented by a revoked credential is stale.
+UPDATE certificate_crl_state s
+   SET dirty = TRUE,
+       issuer_id = COALESCE(s.issuer_id, r.issuer_id),
+       updated_at = now()
+  FROM certificate_revocations r
+ WHERE r.issuer_fingerprint_sha256 = s.issuer_fingerprint_sha256;
+
+INSERT INTO certificate_crl_state (
+    issuer_fingerprint_sha256, issuer_id, crl_number, dirty
+)
+SELECT DISTINCT ON (r.issuer_fingerprint_sha256)
+       r.issuer_fingerprint_sha256, r.issuer_id, 0, TRUE
+  FROM certificate_revocations r
+ WHERE r.issuer_fingerprint_sha256 IS NOT NULL
+   AND NOT EXISTS (
+       SELECT 1 FROM certificate_crl_state s
+        WHERE s.issuer_fingerprint_sha256 = r.issuer_fingerprint_sha256
+   )
+   AND (
+       r.issuer_id IS NULL
+       OR NOT EXISTS (
+           SELECT 1 FROM certificate_crl_state s WHERE s.issuer_id = r.issuer_id
+       )
+   )
+ ORDER BY r.issuer_fingerprint_sha256, r.revoked_at DESC;
+
+CREATE OR REPLACE FUNCTION record_certificate_revocation()
+RETURNS trigger AS $$
+DECLARE
+    event_time       TIMESTAMPTZ;
+    event_reason     TEXT;
+    event_actor      UUID;
+    issuer_fingerprint TEXT;
+    existing_fingerprint TEXT;
+BEGIN
+    IF NEW.kind <> 'certificate' OR NEW.status <> 'revoked' THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD.status = 'revoked' THEN
+        RETURN NEW;
+    END IF;
+
+    event_time := COALESCE((NEW.metadata->>'revoked_at')::timestamptz, now());
+    event_reason := left(
+        COALESCE(NULLIF(btrim(NEW.metadata->>'revocation_reason'), ''), 'unspecified'),
+        128
+    );
+    event_actor := NULLIF(NEW.metadata->>'revoked_by_entity_id', '')::uuid;
+    issuer_fingerprint := NULLIF(NEW.metadata->>'issuer_fingerprint_sha256', '');
+
+    INSERT INTO certificate_revocations (
+        credential_id, issuer_id, issuer_fingerprint_sha256, serial_number,
+        reason, actor_entity_id, revoked_at
+    ) VALUES (
+        NEW.id, NEW.issuer_id, issuer_fingerprint, NEW.identifier,
+        event_reason, event_actor, event_time
+    )
+    ON CONFLICT (credential_id) DO NOTHING;
+
+    -- CRL/OCSP generation is deliberately outside this PR. Mark only the
+    -- exact issuer cache stale; never fan out to unrelated tenants/issuers.
+    IF issuer_fingerprint IS NOT NULL THEN
+        IF NEW.issuer_id IS NOT NULL THEN
+            SELECT s.issuer_fingerprint_sha256
+              INTO existing_fingerprint
+              FROM certificate_crl_state s
+             WHERE s.issuer_id = NEW.issuer_id
+             FOR UPDATE;
+            IF FOUND THEN
+                IF existing_fingerprint <> issuer_fingerprint THEN
+                    RAISE EXCEPTION 'certificate issuer artifact fingerprint mismatch'
+                        USING ERRCODE = '23514';
+                END IF;
+                UPDATE certificate_crl_state
+                   SET dirty = TRUE, updated_at = now()
+                 WHERE issuer_id = NEW.issuer_id;
+                RETURN NEW;
+            END IF;
+        END IF;
+
+        INSERT INTO certificate_crl_state (
+            issuer_fingerprint_sha256, issuer_id, crl_number, dirty
+        ) VALUES (issuer_fingerprint, NEW.issuer_id, 0, TRUE)
+        ON CONFLICT (issuer_fingerprint_sha256) DO UPDATE
+            SET dirty = TRUE,
+                issuer_id = COALESCE(
+                    certificate_crl_state.issuer_id,
+                    EXCLUDED.issuer_id
+                ),
+                updated_at = now();
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_credentials_record_certificate_revocation
+    AFTER INSERT OR UPDATE OF status ON credentials
+    FOR EACH ROW EXECUTE FUNCTION record_certificate_revocation();
+
+-- The ledger is immutable evidence. Credential deletion cascades it; all
+-- other mutation attempts are rejected.
+CREATE OR REPLACE FUNCTION prevent_certificate_revocation_mutation()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'certificate revocation records are immutable'
+        USING ERRCODE = '23514';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_certificate_revocations_immutable
+    BEFORE UPDATE ON certificate_revocations
+    FOR EACH ROW EXECUTE FUNCTION prevent_certificate_revocation_mutation();

--- a/migrations/010_pki_certificate_revocation.sql
+++ b/migrations/010_pki_certificate_revocation.sql
@@ -18,7 +18,10 @@ CREATE TABLE certificate_revocations (
     reason                     TEXT        NOT NULL CHECK (
                                              length(btrim(reason)) BETWEEN 1 AND 128
                                            ),
-    actor_entity_id            UUID        REFERENCES entities(id) ON DELETE SET NULL,
+    -- Deliberately not an FK: revocation evidence must retain the actor UUID
+    -- after that actor is purged, and an ON DELETE action would conflict with
+    -- this table's immutability trigger.
+    actor_entity_id            UUID,
     revoked_at                 TIMESTAMPTZ NOT NULL,
     created_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/migrations/010_pki_certificate_revocation.sql
+++ b/migrations/010_pki_certificate_revocation.sql
@@ -44,6 +44,8 @@ INSERT INTO certificate_revocations (
 SELECT c.id,
        c.issuer_id,
        CASE
+           WHEN a.fingerprint_sha256 ~ '^[0-9a-f]{64}$'
+           THEN a.fingerprint_sha256
            WHEN c.metadata->>'issuer_fingerprint_sha256' ~ '^[0-9a-f]{64}$'
            THEN c.metadata->>'issuer_fingerprint_sha256'
        END,
@@ -60,6 +62,7 @@ SELECT c.id,
            ELSE c.created_at
        END
   FROM credentials c
+  LEFT JOIN pki_authorities a ON a.id = c.issuer_id
  WHERE c.kind = 'certificate'
    AND c.status = 'revoked'
    AND c.identifier IS NOT NULL
@@ -114,7 +117,16 @@ BEGIN
         128
     );
     event_actor := NULLIF(NEW.metadata->>'revoked_by_entity_id', '')::uuid;
-    issuer_fingerprint := NULLIF(NEW.metadata->>'issuer_fingerprint_sha256', '');
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT a.fingerprint_sha256
+          INTO issuer_fingerprint
+          FROM pki_authorities a
+         WHERE a.id = NEW.issuer_id;
+    END IF;
+    issuer_fingerprint := COALESCE(
+        issuer_fingerprint,
+        NULLIF(NEW.metadata->>'issuer_fingerprint_sha256', '')
+    );
 
     INSERT INTO certificate_revocations (
         credential_id, issuer_id, issuer_fingerprint_sha256, serial_number,

--- a/product-docs/development/pki/pr-008-revocation.md
+++ b/product-docs/development/pki/pr-008-revocation.md
@@ -1,5 +1,9 @@
 # PR-008 — Issuer-Aware Revocation State Machine
 
+## Status
+
+Implemented by the PR-008 delivery branch.
+
 ## Objective
 
 Make certificate revocation immediately authoritative in Atom and ready for per-issuer CRL/OCSP publication.

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -530,7 +530,7 @@ async fn revoke_certificate_exact(
         "credential_id": revoked.certificate.credential_id,
         "entity_id": revoked.certificate.entity_id,
         "issuer_id": revoked.certificate.issuer_id,
-        "issuer_fingerprint_sha256": revoked.certificate.issuer_fingerprint_sha256,
+        "issuer_fingerprint_sha256": revoked.issuer_fingerprint_sha256,
         "serial_number": revoked.certificate.serial_number,
         "reason": revoked.reason,
         "revoked_at": revoked.revoked_at,

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -403,37 +403,58 @@ impl CertificateMutation {
         ctx: &Context<'_>,
         input: RevokeCertificateInput,
     ) -> Result<Certificate> {
-        let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
         let cert = service::certificate_by_serial(&state.pool, &input.serial_number)
             .await
             .map_err(gql_error)?;
-        require_certificate_revoke(state, &auth, &cert).await?;
-        let mut tx = state.pool.begin().await.map_err(|e| gql_error(db_err(e)))?;
-        let revoked =
-            service::revoke_certificate_in_tx(&mut tx, &input.serial_number, input.reason)
-                .await
-                .map_err(gql_error)?;
-        audit::commit_with_audit(
-            &state.pool,
-            tx,
-            state.config.events.enabled(),
-            &audit::AuditEvent {
-                actor_entity_id: Some(auth.entity_id),
-                tenant_id: cert.tenant_id,
-                target_kind: Some("credential"),
-                target_id: Some(cert.credential_id),
-                event: "certificate.revoke",
-                outcome: AuditOutcome::Allow,
-                details: serde_json::json!({
-                    "entity_id": cert.entity_id,
-                    "serial_number": cert.serial_number
-                }),
-            },
+        if cert.issuer_id.is_some() {
+            return Err(async_graphql::Error::new(
+                "managed certificate revocation requires revokeCertificateV2",
+            ));
+        }
+        Ok(revoke_certificate_exact(
+            ctx,
+            service::CertificateRevocationSelector::CredentialId(cert.credential_id),
+            input.reason,
         )
-        .await
-        .map_err(gql_error)?;
-        Ok(revoked.into())
+        .await?
+        .certificate)
+    }
+
+    /// Issuer-aware revocation by exact credential, fingerprint, or issuer and serial.
+    async fn revoke_certificate_v2(
+        &self,
+        ctx: &Context<'_>,
+        input: RevokeCertificateV2Input,
+    ) -> Result<CertificateRevocation> {
+        let selector = match (
+            input.credential_id,
+            input.fingerprint_sha256,
+            input.issuer_id,
+            input.serial_number,
+        ) {
+            (Some(credential_id), None, None, None) => {
+                service::CertificateRevocationSelector::CredentialId(parse_id(
+                    credential_id,
+                    "credentialId",
+                )?)
+            }
+            (None, Some(fingerprint), None, None) => {
+                service::CertificateRevocationSelector::FingerprintSha256(fingerprint)
+            }
+            (None, None, Some(issuer_id), Some(serial_number)) => {
+                service::CertificateRevocationSelector::IssuerSerial {
+                    issuer_id: parse_id(issuer_id, "issuerId")?,
+                    serial_number,
+                }
+            }
+            _ => {
+                return Err(async_graphql::Error::new(
+                    "provide exactly one selector: credentialId, fingerprintSha256, or issuerId with serialNumber",
+                ))
+            }
+        };
+        revoke_certificate_exact(ctx, selector, input.reason).await
     }
 
     async fn revoke_entity_certificates(
@@ -447,9 +468,14 @@ impl CertificateMutation {
         let entity_id = parse_id(entity_id, "entityId")?;
         let tenant_id = require_credential_management(state, &auth, entity_id).await?;
         let mut tx = state.pool.begin().await.map_err(|e| gql_error(db_err(e)))?;
-        let count = service::revoke_entity_certificates_in_tx(&mut tx, entity_id, reason)
-            .await
-            .map_err(gql_error)?;
+        let revoked = service::revoke_entity_certificates_v2_in_tx(
+            &mut tx,
+            entity_id,
+            reason,
+            Some(auth.entity_id),
+        )
+        .await
+        .map_err(gql_error)?;
         audit::commit_with_audit(
             &state.pool,
             tx,
@@ -461,13 +487,93 @@ impl CertificateMutation {
                 target_id: Some(entity_id),
                 event: "certificate.revoke_entity",
                 outcome: AuditOutcome::Allow,
-                details: serde_json::json!({"count": count}),
+                details: serde_json::json!({
+                    "count": revoked.count,
+                    "credential_ids": revoked.credential_ids,
+                    "issuer_ids": revoked.issuer_ids,
+                    "reason": revoked.reason,
+                }),
             },
         )
         .await
         .map_err(gql_error)?;
-        Ok(count as i64)
+        Ok(revoked.count as i64)
     }
+}
+
+async fn revoke_certificate_exact(
+    ctx: &Context<'_>,
+    selector: service::CertificateRevocationSelector,
+    reason: Option<String>,
+) -> Result<CertificateRevocation> {
+    let auth = require_auth(ctx)?;
+    let state = ctx.data::<AppState>()?;
+    let cert = service::certificate_by_revocation_selector(&state.pool, &selector)
+        .await
+        .map_err(gql_error)?;
+    require_certificate_revoke(state, &auth, &cert).await?;
+    let selector_kind = selector.kind();
+    let mut tx = state.pool.begin().await.map_err(|e| gql_error(db_err(e)))?;
+    let revoked = service::revoke_certificate_v2_in_tx(
+        &mut tx,
+        service::RevokeCertificateV2 {
+            selector,
+            reason,
+            actor_entity_id: Some(auth.entity_id),
+            expected_entity_id: cert.entity_id,
+            expected_tenant_id: cert.tenant_id,
+        },
+    )
+    .await
+    .map_err(gql_error)?;
+    let details = serde_json::json!({
+        "credential_id": revoked.certificate.credential_id,
+        "entity_id": revoked.certificate.entity_id,
+        "issuer_id": revoked.certificate.issuer_id,
+        "issuer_fingerprint_sha256": revoked.certificate.issuer_fingerprint_sha256,
+        "serial_number": revoked.certificate.serial_number,
+        "reason": revoked.reason,
+        "revoked_at": revoked.revoked_at,
+        "selector": selector_kind,
+        "idempotent_replay": revoked.idempotent_replay,
+    });
+    if revoked.idempotent_replay {
+        tx.commit()
+            .await
+            .map_err(|error| gql_error(db_err(error)))?;
+        audit::write(
+            &state.pool,
+            false,
+            audit::AuditEvent {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id: revoked.certificate.tenant_id,
+                target_kind: Some("credential"),
+                target_id: Some(revoked.certificate.credential_id),
+                event: "certificate.revoke_replayed",
+                outcome: AuditOutcome::Allow,
+                details,
+            },
+        )
+        .await;
+    } else {
+        audit::commit_with_audit(
+            &state.pool,
+            tx,
+            state.config.events.enabled(),
+            &audit::AuditEvent {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id: revoked.certificate.tenant_id,
+                target_kind: Some("credential"),
+                target_id: Some(revoked.certificate.credential_id),
+                event: "certificate.revoke",
+                outcome: AuditOutcome::Allow,
+                details,
+            },
+        )
+        .await
+        .map_err(gql_error)?;
+    }
+    Ok(revoked.into())
 }
 
 async fn renew_certificate_v2(
@@ -494,6 +600,7 @@ async fn renew_certificate_v2(
         &mut tx,
         &state.config,
         service::CertificateRenewalAuthorization::Operator {
+            actor_entity_id: Some(auth.entity_id),
             expected_entity_id: old.entity_id,
             expected_tenant_id: old.tenant_id,
         },
@@ -619,9 +726,61 @@ pub struct RevokeCertificateInput {
     pub reason: Option<String>,
 }
 
+#[derive(InputObject)]
+pub struct RevokeCertificateV2Input {
+    pub credential_id: Option<ID>,
+    pub fingerprint_sha256: Option<String>,
+    pub issuer_id: Option<ID>,
+    pub serial_number: Option<String>,
+    pub reason: Option<String>,
+}
+
 pub struct CertificateList {
     pub items: Vec<Certificate>,
     pub total: i64,
+}
+
+pub struct CertificateRevocation {
+    certificate: Certificate,
+    reason: String,
+    actor_entity_id: Option<Uuid>,
+    revoked_at: chrono::DateTime<chrono::Utc>,
+    idempotent_replay: bool,
+}
+
+impl From<service::CertificateRevocationResult> for CertificateRevocation {
+    fn from(value: service::CertificateRevocationResult) -> Self {
+        Self {
+            certificate: value.certificate.into(),
+            reason: value.reason,
+            actor_entity_id: value.actor_entity_id,
+            revoked_at: value.revoked_at,
+            idempotent_replay: value.idempotent_replay,
+        }
+    }
+}
+
+#[Object]
+impl CertificateRevocation {
+    async fn certificate(&self) -> &Certificate {
+        &self.certificate
+    }
+
+    async fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    async fn actor_entity_id(&self) -> Option<ID> {
+        self.actor_entity_id.map(|id| ID(id.to_string()))
+    }
+
+    async fn revoked_at(&self) -> String {
+        self.revoked_at.to_rfc3339()
+    }
+
+    async fn idempotent_replay(&self) -> bool {
+        self.idempotent_replay
+    }
 }
 
 #[Object]

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -39,6 +39,17 @@ pub struct CrlState {
     pub dirty: bool,
 }
 
+#[derive(Debug, Clone, FromRow)]
+pub struct CertificateRevocationRecord {
+    pub credential_id: Uuid,
+    pub issuer_id: Option<Uuid>,
+    pub issuer_fingerprint_sha256: Option<String>,
+    pub serial_number: String,
+    pub reason: String,
+    pub actor_entity_id: Option<Uuid>,
+    pub revoked_at: DateTime<Utc>,
+}
+
 pub async fn entity_tenant_id<'e, E>(executor: E, entity_id: Uuid) -> Result<Option<Uuid>, AppError>
 where
     E: sqlx::Executor<'e, Database = Postgres>,
@@ -356,6 +367,100 @@ pub async fn lock_certificate_by_id(
     .map_err(db_err)
 }
 
+pub async fn certificate_by_fingerprint<'e, E>(
+    executor: E,
+    fingerprint_sha256: &str,
+) -> Result<CertificateCredential, AppError>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, CertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+               c.expires_at, c.created_at
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        WHERE c.kind = 'certificate'
+          AND c.metadata->>'fingerprint_sha256' = $1
+        "#,
+    )
+    .bind(fingerprint_sha256)
+    .fetch_one(executor)
+    .await
+    .map_err(db_err)
+}
+
+pub async fn lock_certificate_by_fingerprint(
+    tx: &mut Transaction<'_, Postgres>,
+    fingerprint_sha256: &str,
+) -> Result<CertificateCredential, AppError> {
+    sqlx::query_as::<_, CertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+               c.expires_at, c.created_at
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        WHERE c.kind = 'certificate'
+          AND c.metadata->>'fingerprint_sha256' = $1
+        FOR UPDATE OF c
+        "#,
+    )
+    .bind(fingerprint_sha256)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(db_err)
+}
+
+pub async fn certificate_by_issuer_serial<'e, E>(
+    executor: E,
+    issuer_id: Uuid,
+    serial_number: &str,
+) -> Result<CertificateCredential, AppError>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, CertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+               c.expires_at, c.created_at
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        WHERE c.kind = 'certificate'
+          AND c.issuer_id = $1
+          AND c.identifier = $2
+        "#,
+    )
+    .bind(issuer_id)
+    .bind(serial_number)
+    .fetch_one(executor)
+    .await
+    .map_err(db_err)
+}
+
+pub async fn lock_certificate_by_issuer_serial(
+    tx: &mut Transaction<'_, Postgres>,
+    issuer_id: Uuid,
+    serial_number: &str,
+) -> Result<CertificateCredential, AppError> {
+    sqlx::query_as::<_, CertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
+               c.expires_at, c.created_at
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        WHERE c.kind = 'certificate'
+          AND c.issuer_id = $1
+          AND c.identifier = $2
+        FOR UPDATE OF c
+        "#,
+    )
+    .bind(issuer_id)
+    .bind(serial_number)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(db_err)
+}
+
 pub async fn list_certificates(
     pool: &PgPool,
     entity_id: Option<Uuid>,
@@ -420,6 +525,47 @@ where
     Ok(())
 }
 
+pub async fn revoke_certificate_if_active(
+    tx: &mut Transaction<'_, Postgres>,
+    credential_id: Uuid,
+    metadata: Value,
+) -> Result<bool, AppError> {
+    let result = sqlx::query(
+        r#"
+        UPDATE credentials
+        SET status = 'revoked', metadata = $2
+        WHERE id = $1 AND kind = 'certificate' AND status = 'active'
+        "#,
+    )
+    .bind(credential_id)
+    .bind(metadata)
+    .execute(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    Ok(result.rows_affected() == 1)
+}
+
+pub async fn certificate_revocation_by_id<'e, E>(
+    executor: E,
+    credential_id: Uuid,
+) -> Result<CertificateRevocationRecord, AppError>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, CertificateRevocationRecord>(
+        r#"
+        SELECT credential_id, issuer_id, issuer_fingerprint_sha256,
+               serial_number, reason, actor_entity_id, revoked_at
+        FROM certificate_revocations
+        WHERE credential_id = $1
+        "#,
+    )
+    .bind(credential_id)
+    .fetch_one(executor)
+    .await
+    .map_err(db_err)
+}
+
 pub async fn active_entity_certificates<'e, E>(
     executor: E,
     entity_id: Uuid,
@@ -434,6 +580,7 @@ where
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id
         WHERE c.kind = 'certificate' AND c.entity_id = $1 AND c.status = 'active'
+        FOR UPDATE OF c
         "#,
     )
     .bind(entity_id)
@@ -522,32 +669,6 @@ pub async fn store_crl_tx(
     .bind(this_update)
     .bind(next_update)
     .bind(issuer_fingerprint_sha256)
-    .execute(&mut **tx)
-    .await
-    .map_err(AppError::Database)?;
-    Ok(())
-}
-
-pub async fn mark_crl_dirty(pool: &PgPool) -> Result<(), AppError> {
-    sqlx::query(
-        r#"
-        UPDATE certificate_crl_state
-        SET dirty = TRUE, updated_at = now()
-        "#,
-    )
-    .execute(pool)
-    .await
-    .map_err(AppError::Database)?;
-    Ok(())
-}
-
-pub async fn mark_crl_dirty_tx(tx: &mut Transaction<'_, Postgres>) -> Result<(), AppError> {
-    sqlx::query(
-        r#"
-        UPDATE certificate_crl_state
-        SET dirty = TRUE, updated_at = now()
-        "#,
-    )
     .execute(&mut **tx)
     .await
     .map_err(AppError::Database)?;

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -103,12 +103,59 @@ pub struct RenewCertificateV2 {
 #[derive(Debug, Clone, Copy)]
 pub enum CertificateRenewalAuthorization {
     Operator {
+        actor_entity_id: Option<Uuid>,
         expected_entity_id: Uuid,
         expected_tenant_id: Option<Uuid>,
     },
     PresentedCertificate {
         credential_id: Uuid,
     },
+}
+
+#[derive(Debug, Clone)]
+pub enum CertificateRevocationSelector {
+    CredentialId(Uuid),
+    FingerprintSha256(String),
+    IssuerSerial {
+        issuer_id: Uuid,
+        serial_number: String,
+    },
+}
+
+impl CertificateRevocationSelector {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::CredentialId(_) => "credential_id",
+            Self::FingerprintSha256(_) => "fingerprint_sha256",
+            Self::IssuerSerial { .. } => "issuer_serial",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RevokeCertificateV2 {
+    pub selector: CertificateRevocationSelector,
+    pub reason: Option<String>,
+    pub actor_entity_id: Option<Uuid>,
+    pub expected_entity_id: Uuid,
+    pub expected_tenant_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CertificateRevocationResult {
+    pub certificate: CertificateRecord,
+    pub reason: String,
+    pub actor_entity_id: Option<Uuid>,
+    pub revoked_at: DateTime<Utc>,
+    pub idempotent_replay: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BulkCertificateRevocationResult {
+    pub count: usize,
+    pub credential_ids: Vec<Uuid>,
+    pub issuer_ids: Vec<Uuid>,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1023,14 +1070,27 @@ pub async fn renew_certificate_v2_in_tx(
         match outcome {
             Ok(certificate) => {
                 if input.revoke_old {
-                    let mut metadata = old.metadata.clone();
-                    metadata["revoked_at"] = json!(Utc::now());
-                    metadata["revocation_reason"] = json!("superseded");
-                    repo::revoke_certificate(&mut *attempt_tx, old.id, metadata).await?;
-                    // PR-008 replaces this global dirty mark with an exact
-                    // issuer-keyed update. Credential status is still changed
-                    // atomically and is immediately authoritative in Atom.
-                    repo::mark_crl_dirty_tx(&mut attempt_tx).await?;
+                    let actor_entity_id = match authorization {
+                        CertificateRenewalAuthorization::Operator {
+                            actor_entity_id, ..
+                        } => actor_entity_id,
+                        CertificateRenewalAuthorization::PresentedCertificate { .. } => {
+                            Some(old.entity_id)
+                        }
+                    };
+                    let metadata = revocation_metadata(
+                        old.metadata.clone(),
+                        "superseded",
+                        actor_entity_id,
+                        Utc::now(),
+                    );
+                    if !repo::revoke_certificate_if_active(&mut attempt_tx, old.id, metadata)
+                        .await?
+                    {
+                        return Err(AppError::conflict(
+                            "renewal source revocation state changed concurrently",
+                        ));
+                    }
                 }
                 repo::complete_certificate_renewal(
                     &mut attempt_tx,
@@ -1118,13 +1178,124 @@ pub async fn revoke_certificate_in_tx(
 ) -> Result<CertificateRecord, AppError> {
     let serial = normalize_serial(serial_number)?;
     let current = repo::certificate_by_serial(&mut **tx, &serial).await?;
-    let mut metadata = current.metadata.clone();
+    if current.issuer_id.is_some() {
+        return Err(AppError::bad_request(
+            "managed certificate revocation requires an exact v2 selector",
+        ));
+    }
+    let result = revoke_certificate_v2_in_tx(
+        tx,
+        RevokeCertificateV2 {
+            selector: CertificateRevocationSelector::CredentialId(current.id),
+            reason,
+            actor_entity_id: None,
+            expected_entity_id: current.entity_id,
+            expected_tenant_id: current.tenant_id,
+        },
+    )
+    .await?;
+    Ok(result.certificate)
+}
+
+pub async fn certificate_by_revocation_selector(
+    pool: &sqlx::PgPool,
+    selector: &CertificateRevocationSelector,
+) -> Result<CertificateRecord, AppError> {
+    let row = match selector {
+        CertificateRevocationSelector::CredentialId(credential_id) => {
+            repo::certificate_by_id(pool, *credential_id).await?
+        }
+        CertificateRevocationSelector::FingerprintSha256(fingerprint) => {
+            let fingerprint = validated_fingerprint(fingerprint)?;
+            repo::certificate_by_fingerprint(pool, &fingerprint).await?
+        }
+        CertificateRevocationSelector::IssuerSerial {
+            issuer_id,
+            serial_number,
+        } => {
+            let serial = normalize_serial(serial_number)?;
+            repo::certificate_by_issuer_serial(pool, *issuer_id, &serial).await?
+        }
+    };
+    record_from_row(row)
+}
+
+pub async fn revoke_certificate_v2(
+    pool: &sqlx::PgPool,
+    input: RevokeCertificateV2,
+) -> Result<CertificateRevocationResult, AppError> {
+    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let result = revoke_certificate_v2_in_tx(&mut tx, input).await?;
+    tx.commit().await.map_err(AppError::Database)?;
+    Ok(result)
+}
+
+/// Revoke one exact certificate. The row lock makes first-write semantics and
+/// idempotent replay deterministic. The database trigger records immutable
+/// revocation evidence and dirties only this certificate's issuer artifacts in
+/// the same transaction.
+pub async fn revoke_certificate_v2_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    input: RevokeCertificateV2,
+) -> Result<CertificateRevocationResult, AppError> {
+    let current = match &input.selector {
+        CertificateRevocationSelector::CredentialId(credential_id) => {
+            repo::lock_certificate_by_id(tx, *credential_id).await?
+        }
+        CertificateRevocationSelector::FingerprintSha256(fingerprint) => {
+            let fingerprint = validated_fingerprint(fingerprint)?;
+            repo::lock_certificate_by_fingerprint(tx, &fingerprint).await?
+        }
+        CertificateRevocationSelector::IssuerSerial {
+            issuer_id,
+            serial_number,
+        } => {
+            let serial = normalize_serial(serial_number)?;
+            repo::lock_certificate_by_issuer_serial(tx, *issuer_id, &serial).await?
+        }
+    };
+    if current.entity_id != input.expected_entity_id
+        || current.tenant_id != input.expected_tenant_id
+    {
+        return Err(AppError::Forbidden);
+    }
+
+    if current.status == "revoked" {
+        let revocation = repo::certificate_revocation_by_id(&mut **tx, current.id).await?;
+        return Ok(CertificateRevocationResult {
+            certificate: record_from_row(current)?,
+            reason: revocation.reason,
+            actor_entity_id: revocation.actor_entity_id,
+            revoked_at: revocation.revoked_at,
+            idempotent_replay: true,
+        });
+    }
+    if current.status != "active" {
+        return Err(AppError::Unauthorized("certificate is not active".into()));
+    }
+
+    let reason = normalize_revocation_reason(input.reason.as_deref())?;
     let now = Utc::now();
-    metadata["revoked_at"] = json!(now);
-    metadata["revocation_reason"] = json!(reason.clone().unwrap_or_else(|| "unspecified".into()));
-    repo::revoke_certificate(&mut **tx, current.id, metadata).await?;
-    repo::mark_crl_dirty_tx(tx).await?;
-    record_from_row(repo::certificate_by_serial(&mut **tx, &serial).await?)
+    let metadata = revocation_metadata(
+        current.metadata.clone(),
+        &reason,
+        input.actor_entity_id,
+        now,
+    );
+    if !repo::revoke_certificate_if_active(tx, current.id, metadata).await? {
+        return Err(AppError::conflict(
+            "certificate revocation state changed concurrently",
+        ));
+    }
+    let revocation = repo::certificate_revocation_by_id(&mut **tx, current.id).await?;
+    let certificate = record_from_row(repo::fetch_certificate_by_id(&mut **tx, current.id).await?)?;
+    Ok(CertificateRevocationResult {
+        certificate,
+        reason: revocation.reason,
+        actor_entity_id: revocation.actor_entity_id,
+        revoked_at: revocation.revoked_at,
+        idempotent_replay: false,
+    })
 }
 
 pub async fn revoke_entity_certificates(
@@ -1147,19 +1318,45 @@ pub async fn revoke_entity_certificates_in_tx(
     entity_id: Uuid,
     reason: Option<String>,
 ) -> Result<usize, AppError> {
+    Ok(
+        revoke_entity_certificates_v2_in_tx(tx, entity_id, reason, None)
+            .await?
+            .count,
+    )
+}
+
+pub async fn revoke_entity_certificates_v2_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    entity_id: Uuid,
+    reason: Option<String>,
+    actor_entity_id: Option<Uuid>,
+) -> Result<BulkCertificateRevocationResult, AppError> {
+    // Serializes explicit entity-wide revocation with issuance paths, which
+    // also lock the active entity before inserting a certificate.
+    identity::repo::lock_active_entity(tx, entity_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("entity not found"))?;
+    let reason = normalize_revocation_reason(reason.as_deref().or(Some("entity_revoked")))?;
     let certs = repo::active_entity_certificates(&mut **tx, entity_id).await?;
-    let count = certs.len();
+    let mut credential_ids = Vec::with_capacity(certs.len());
+    let mut issuer_ids = Vec::new();
     for cert in certs {
-        let mut metadata = cert.metadata.clone();
-        metadata["revoked_at"] = json!(Utc::now());
-        metadata["revocation_reason"] =
-            json!(reason.clone().unwrap_or_else(|| "entity_revoked".into()));
-        repo::revoke_certificate(&mut **tx, cert.id, metadata).await?;
+        let metadata = revocation_metadata(cert.metadata, &reason, actor_entity_id, Utc::now());
+        if repo::revoke_certificate_if_active(tx, cert.id, metadata).await? {
+            credential_ids.push(cert.id);
+            if let Some(issuer_id) = cert.issuer_id {
+                if !issuer_ids.contains(&issuer_id) {
+                    issuer_ids.push(issuer_id);
+                }
+            }
+        }
     }
-    if count > 0 {
-        repo::mark_crl_dirty_tx(tx).await?;
-    }
-    Ok(count)
+    Ok(BulkCertificateRevocationResult {
+        count: credential_ids.len(),
+        credential_ids,
+        issuer_ids,
+        reason,
+    })
 }
 
 pub async fn certificate_by_serial(
@@ -1372,6 +1569,43 @@ pub fn normalize_serial(serial_number: &str) -> Result<String, AppError> {
         return Err(AppError::bad_request("invalid certificate serial number"));
     }
     Ok(normalized)
+}
+
+fn validated_fingerprint(value: &str) -> Result<String, AppError> {
+    let normalized = normalize_fingerprint(value);
+    if normalized.len() != 64 || hex::decode(&normalized).is_err() {
+        return Err(AppError::bad_request(
+            "invalid certificate SHA-256 fingerprint",
+        ));
+    }
+    Ok(normalized)
+}
+
+fn normalize_revocation_reason(value: Option<&str>) -> Result<String, AppError> {
+    let reason = value.unwrap_or("unspecified").trim().to_ascii_lowercase();
+    if reason.is_empty()
+        || reason.len() > 64
+        || !reason
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(AppError::bad_request(
+            "revocation reason must be a 1-64 character reason code",
+        ));
+    }
+    Ok(reason)
+}
+
+fn revocation_metadata(
+    mut metadata: Value,
+    reason: &str,
+    actor_entity_id: Option<Uuid>,
+    revoked_at: DateTime<Utc>,
+) -> Value {
+    metadata["revoked_at"] = json!(revoked_at);
+    metadata["revocation_reason"] = json!(reason);
+    metadata["revoked_by_entity_id"] = json!(actor_entity_id);
+    metadata
 }
 
 fn validate_file_issuer_config(config: &Config) -> Result<(), AppError> {
@@ -1639,6 +1873,7 @@ fn validate_renewal_authorization(
 ) -> Result<(), AppError> {
     let authorized = match authorization {
         CertificateRenewalAuthorization::Operator {
+            actor_entity_id: _,
             expected_entity_id,
             expected_tenant_id,
         } => old.entity_id == expected_entity_id && old.tenant_id == expected_tenant_id,

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -144,6 +144,7 @@ pub struct RevokeCertificateV2 {
 #[derive(Debug, Clone)]
 pub struct CertificateRevocationResult {
     pub certificate: CertificateRecord,
+    pub issuer_fingerprint_sha256: Option<String>,
     pub reason: String,
     pub actor_entity_id: Option<Uuid>,
     pub revoked_at: DateTime<Utc>,
@@ -1264,6 +1265,7 @@ pub async fn revoke_certificate_v2_in_tx(
         let revocation = repo::certificate_revocation_by_id(&mut **tx, current.id).await?;
         return Ok(CertificateRevocationResult {
             certificate: record_from_row(current)?,
+            issuer_fingerprint_sha256: revocation.issuer_fingerprint_sha256,
             reason: revocation.reason,
             actor_entity_id: revocation.actor_entity_id,
             revoked_at: revocation.revoked_at,
@@ -1291,6 +1293,7 @@ pub async fn revoke_certificate_v2_in_tx(
     let certificate = record_from_row(repo::fetch_certificate_by_id(&mut **tx, current.id).await?)?;
     Ok(CertificateRevocationResult {
         certificate,
+        issuer_fingerprint_sha256: revocation.issuer_fingerprint_sha256,
         reason: revocation.reason,
         actor_entity_id: revocation.actor_entity_id,
         revoked_at: revocation.revoked_at,

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -279,6 +279,7 @@ mod tests {
             "renewCertificateFromCsrV2",
             "renewGeneratedCertificateV2",
             "revokeCertificate",
+            "revokeCertificateV2",
             "revokeEntityCertificates",
             "addOwnership",
             "removeOwnership",

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -368,10 +368,11 @@ impl CertificateService for AtomCertificates {
             .await
             .map_err(crate::error::db_err)
             .map_err(Status::from)?;
-        let revoked = certs::service::revoke_entity_certificates_in_tx(
+        let revoked = certs::service::revoke_entity_certificates_v2_in_tx(
             &mut tx,
             entity_id,
             (!req.reason.is_empty()).then_some(req.reason),
+            Some(auth.entity_id),
         )
         .await
         .map_err(Status::from)?;
@@ -386,14 +387,20 @@ impl CertificateService for AtomCertificates {
                 target_id: Some(entity_id),
                 event: "certificate.revoke_entity",
                 outcome: AuditOutcome::Allow,
-                details: serde_json::json!({"count": revoked, "transport": "grpc"}),
+                details: serde_json::json!({
+                    "count": revoked.count,
+                    "credential_ids": revoked.credential_ids,
+                    "issuer_ids": revoked.issuer_ids,
+                    "reason": revoked.reason,
+                    "transport": "grpc",
+                }),
             },
         )
         .await
         .map_err(Status::from)?;
 
         Ok(Response::new(RevokeEntityCertificatesResponse {
-            revoked: revoked as u64,
+            revoked: revoked.count as u64,
         }))
     }
 }

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -733,7 +733,7 @@ pub async fn delete_entity_with_audit(
         return Err(AppError::not_found(format!("entity {id} not found")));
     }
 
-    let revoked_certificates: i64 = sqlx::query_scalar(
+    let revoked_certificates: Vec<(Uuid, Option<Uuid>)> = sqlx::query_as(
         r#"WITH revoked AS (
                UPDATE credentials
                SET status = 'revoked',
@@ -741,22 +741,21 @@ pub async fn delete_entity_with_audit(
                        WHEN kind = 'certificate'
                        THEN metadata || jsonb_build_object(
                            'revoked_at', now(),
-                           'revocation_reason', 'entity_deleted'
+                           'revocation_reason', 'entity_deleted',
+                           'revoked_by_entity_id', $2::uuid
                        )
                        ELSE metadata
                    END
                WHERE entity_id = $1 AND status = 'active'
-               RETURNING kind
+               RETURNING id, kind, issuer_id
            )
-           SELECT COUNT(*) FILTER (WHERE kind = 'certificate') FROM revoked"#,
+           SELECT id, issuer_id FROM revoked WHERE kind = 'certificate'"#,
     )
     .bind(id)
-    .fetch_one(&mut *tx)
+    .bind(actor_id)
+    .fetch_all(&mut *tx)
     .await
     .map_err(db_err)?;
-    if revoked_certificates > 0 {
-        crate::certs::repo::mark_crl_dirty_tx(&mut tx).await?;
-    }
     sqlx::query(
         "UPDATE sessions SET revoked_at = now() WHERE entity_id = $1 AND revoked_at IS NULL",
     )
@@ -781,7 +780,20 @@ pub async fn delete_entity_with_audit(
         target_id: Some(id),
         event: "entity.delete",
         outcome: crate::models::enums::AuditOutcome::Allow,
-        details: serde_json::json!({}),
+        details: serde_json::json!({
+            "certificate_revocations": {
+                "count": revoked_certificates.len(),
+                "credential_ids": revoked_certificates
+                    .iter()
+                    .map(|(credential_id, _)| credential_id)
+                    .collect::<Vec<_>>(),
+                "issuer_ids": revoked_certificates
+                    .iter()
+                    .filter_map(|(_, issuer_id)| *issuer_id)
+                    .collect::<Vec<_>>(),
+                "reason": "entity_deleted",
+            }
+        }),
     };
     crate::audit::commit_with_audit(pool, tx, events_enabled, &event).await?;
     Ok(())

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -733,6 +733,7 @@ pub async fn delete_entity_with_audit(
         return Err(AppError::not_found(format!("entity {id} not found")));
     }
 
+    let revocation_actor_id = actor_id.or(deleted_by);
     let revoked_certificates: Vec<(Uuid, Option<Uuid>)> = sqlx::query_as(
         r#"WITH revoked AS (
                UPDATE credentials
@@ -752,7 +753,7 @@ pub async fn delete_entity_with_audit(
            SELECT id, issuer_id FROM revoked WHERE kind = 'certificate'"#,
     )
     .bind(id)
-    .bind(actor_id)
+    .bind(revocation_actor_id)
     .fetch_all(&mut *tx)
     .await
     .map_err(db_err)?;

--- a/src/identity/service.rs
+++ b/src/identity/service.rs
@@ -2254,6 +2254,19 @@ pub async fn revoke_credential_in_tx(
     entity_id: Uuid,
     cred_id: Uuid,
 ) -> Result<(), AppError> {
+    let kind: String = sqlx::query_scalar(
+        "SELECT kind FROM credentials WHERE id = $1 AND entity_id = $2 FOR UPDATE",
+    )
+    .bind(cred_id)
+    .bind(entity_id)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    if kind == "certificate" {
+        return Err(AppError::bad_request(
+            "use the exact certificate revocation API for certificate credentials",
+        ));
+    }
     // Overwrite any prior revocation provenance (e.g. a `tenant_deleted` marker
     // from a tenant soft delete) with this explicit revocation, so a later tenant
     // restore — which only reactivates credentials still marked `tenant_deleted` —

--- a/src/tenants/repo.rs
+++ b/src/tenants/repo.rs
@@ -572,6 +572,7 @@ pub async fn soft_delete_tenant_with_audit(
         other => AppError::Database(other),
     })?;
 
+    let revocation_actor_id = actor_id.or(deleted_by);
     let revoked_certificates: Vec<(Uuid, Option<Uuid>)> = sqlx::query_as(
         r#"WITH revoked AS (
                UPDATE credentials c
@@ -590,7 +591,7 @@ pub async fn soft_delete_tenant_with_audit(
            SELECT id, issuer_id FROM revoked WHERE kind = 'certificate'"#,
     )
     .bind(id)
-    .bind(actor_id)
+    .bind(revocation_actor_id)
     .fetch_all(&mut *tx)
     .await
     .map_err(db_err)?;

--- a/src/tenants/repo.rs
+++ b/src/tenants/repo.rs
@@ -572,29 +572,28 @@ pub async fn soft_delete_tenant_with_audit(
         other => AppError::Database(other),
     })?;
 
-    let revoked_certificates: i64 = sqlx::query_scalar(
+    let revoked_certificates: Vec<(Uuid, Option<Uuid>)> = sqlx::query_as(
         r#"WITH revoked AS (
                UPDATE credentials c
                SET status = 'revoked',
                    metadata = c.metadata || jsonb_build_object(
                        'revoked_at', now(),
-                       'revocation_reason', 'tenant_deleted'
+                       'revocation_reason', 'tenant_deleted',
+                       'revoked_by_entity_id', $2::uuid
                    )
                FROM entities e
                WHERE c.entity_id = e.id
                  AND e.tenant_id = $1
                  AND c.status = 'active'
-               RETURNING c.id, c.kind
+               RETURNING c.id, c.kind, c.issuer_id
            )
-           SELECT COUNT(*) FROM revoked WHERE kind = 'certificate'"#,
+           SELECT id, issuer_id FROM revoked WHERE kind = 'certificate'"#,
     )
     .bind(id)
-    .fetch_one(&mut *tx)
+    .bind(actor_id)
+    .fetch_all(&mut *tx)
     .await
     .map_err(db_err)?;
-    if revoked_certificates > 0 {
-        crate::certs::repo::mark_crl_dirty_tx(&mut tx).await?;
-    }
 
     sqlx::query(
         "UPDATE sessions SET revoked_at = now()
@@ -613,7 +612,20 @@ pub async fn soft_delete_tenant_with_audit(
         target_id: Some(id),
         event: "tenant.delete",
     };
-    let details = serde_json::json!({});
+    let details = serde_json::json!({
+        "certificate_revocations": {
+            "count": revoked_certificates.len(),
+            "credential_ids": revoked_certificates
+                .iter()
+                .map(|(credential_id, _)| credential_id)
+                .collect::<Vec<_>>(),
+            "issuer_ids": revoked_certificates
+                .iter()
+                .filter_map(|(_, issuer_id)| *issuer_id)
+                .collect::<Vec<_>>(),
+            "reason": "tenant_deleted",
+        }
+    });
     crate::audit::commit_with_observation(tx, events_enabled, &meta, &details).await?;
     Ok(tenant)
 }

--- a/tests/m13_graphql_authz_admin.rs
+++ b/tests/m13_graphql_authz_admin.rs
@@ -1120,15 +1120,23 @@ async fn entity_and_resource_lifecycle_mutations_write_audit_events() {
         "status mutations must not emit duplicate generic entity.update rows"
     );
 
-    for event in [
-        "entity.enable",
-        "entity.disable",
-        "entity.delete",
-        "entity.restore",
-    ] {
+    for event in ["entity.enable", "entity.disable", "entity.restore"] {
         let details = latest_entity_audit_details(&pool, device_id, event).await;
         assert_eq!(details, serde_json::json!({}), "{event}");
     }
+    let delete_details = latest_entity_audit_details(&pool, device_id, "entity.delete").await;
+    assert_eq!(
+        delete_details,
+        serde_json::json!({
+            "certificate_revocations": {
+                "count": 0,
+                "credential_ids": [],
+                "issuer_ids": [],
+                "reason": "entity_deleted",
+            }
+        }),
+        "entity.delete"
+    );
 
     let resource_details =
         latest_resource_audit_details(&pool, channel_id, "resource.update").await;

--- a/tests/m21_soft_delete.rs
+++ b/tests/m21_soft_delete.rs
@@ -62,17 +62,19 @@ async fn soft_delete_entity_hides_it_and_revokes_access() {
         .expect("insert credential");
     let cert_id = Uuid::new_v4();
     let serial = format!("{:032x}", cert_id.as_u128());
+    let issuer = format!("{:032x}{:032x}", cert_id.as_u128(), cert_id.as_u128());
     sqlx::query(
-        "INSERT INTO credentials (id, entity_id, kind, identifier, status)
-         VALUES ($1, $2, 'certificate', $3, 'active')",
+        "INSERT INTO credentials (id, entity_id, kind, identifier, status, metadata)
+         VALUES ($1, $2, 'certificate', $3, 'active',
+                 jsonb_build_object('issuer_fingerprint_sha256', $4::text))",
     )
     .bind(cert_id)
     .bind(id)
     .bind(&serial)
+    .bind(&issuer)
     .execute(&pool)
     .await
     .expect("insert certificate credential");
-    let issuer = format!("sd-issuer-{cert_id}");
     sqlx::query(
         "INSERT INTO certificate_crl_state (issuer_fingerprint_sha256, dirty)
          VALUES ($1, FALSE)",
@@ -1333,17 +1335,19 @@ async fn soft_delete_tenant_marks_and_revokes_child_credentials_and_sessions() {
     .await
     .expect("insert api credential");
     let cert_id = Uuid::new_v4();
+    let issuer = format!("{:032x}{:032x}", cert_id.as_u128(), cert_id.as_u128());
     sqlx::query(
-        "INSERT INTO credentials (id, entity_id, kind, identifier, status)
-         VALUES ($1, $2, 'certificate', $3, 'active')",
+        "INSERT INTO credentials (id, entity_id, kind, identifier, status, metadata)
+         VALUES ($1, $2, 'certificate', $3, 'active',
+                 jsonb_build_object('issuer_fingerprint_sha256', $4::text))",
     )
     .bind(cert_id)
     .bind(entity_id)
     .bind(format!("{:032x}", cert_id.as_u128()))
+    .bind(&issuer)
     .execute(&pool)
     .await
     .expect("insert certificate credential");
-    let issuer = format!("sd-tenant-issuer-{cert_id}");
     sqlx::query(
         "INSERT INTO certificate_crl_state (issuer_fingerprint_sha256, dirty)
          VALUES ($1, FALSE)",

--- a/tests/m35_pki_revocation.rs
+++ b/tests/m35_pki_revocation.rs
@@ -7,11 +7,7 @@ mod common;
 
 use async_graphql::{Request, Variables};
 use atom::{
-    auth::AuthContext,
-    certs::{profile, service},
-    graphql::build_schema,
-    models::enums::TenantStatus,
-    tenants,
+    auth::AuthContext, certs::service, graphql::build_schema, models::enums::TenantStatus, tenants,
 };
 use rcgen::{CertificateParams, DnType, KeyPair};
 use serde_json::{json, Value};
@@ -37,8 +33,8 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
 
     let exact = issue_managed(&pool, &config, tenant_a, entity_a, "exact").await;
     let unaffected = issue_managed(&pool, &config, tenant_b, entity_b, "unaffected").await;
-    set_artifact_clean(&pool, issuer_a.id, &issuer_a.fingerprint_sha256).await;
-    set_artifact_clean(&pool, issuer_b.id, &issuer_b.fingerprint_sha256).await;
+    set_artifact_clean(&pool, issuer_a.id, issuer_a.fingerprint_sha256.as_deref()).await;
+    set_artifact_clean(&pool, issuer_b.id, issuer_b.fingerprint_sha256.as_deref()).await;
 
     // Authorization is evaluated against the exact resolved credential and
     // rechecked under lock, so another tenant cannot revoke it.
@@ -95,7 +91,7 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
 
     // Repeated revocation is a no-op: it returns the original evidence and
     // does not enqueue a second lifecycle event or rewrite reason/time.
-    let event_count = event_count(&pool, "certificate.revoke", exact.credential_id).await;
+    let first_event_count = event_count(&pool, "certificate.revoke", exact.credential_id).await;
     let replay = schema
         .execute(revoke_request(
             common::admin_id(),
@@ -110,7 +106,7 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
     assert_eq!(replay["revokedAt"], first_revoked_at);
     assert_eq!(
         event_count(&pool, "certificate.revoke", exact.credential_id).await,
-        event_count
+        first_event_count
     );
     assert_audit_and_outbox(&pool, exact.credential_id, issuer_a.id).await;
 
@@ -273,7 +269,7 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
     // A transaction failure rolls credential state, immutable evidence, and
     // issuer dirtiness back together.
     let rollback_cert = issue_managed(&pool, &config, tenant_b, entity_b, "rollback").await;
-    set_artifact_clean(&pool, issuer_b.id, &issuer_b.fingerprint_sha256).await;
+    set_artifact_clean(&pool, issuer_b.id, issuer_b.fingerprint_sha256.as_deref()).await;
     let mut rollback_tx = pool.begin().await.unwrap();
     service::revoke_certificate_v2_in_tx(
         &mut rollback_tx,
@@ -301,7 +297,7 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
     // insert failure must undo the revocation trigger's status, evidence, and
     // exact issuer dirty mark.
     let outbox_failure = issue_managed(&pool, &config, tenant_b, entity_b, "outbox-failure").await;
-    set_artifact_clean(&pool, issuer_b.id, &issuer_b.fingerprint_sha256).await;
+    set_artifact_clean(&pool, issuer_b.id, issuer_b.fingerprint_sha256.as_deref()).await;
     install_rejecting_outbox_trigger(&pool).await;
     let failed = schema
         .execute(revoke_request(
@@ -390,7 +386,7 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
     set_artifact_clean(
         &pool,
         lifecycle_issuer.id,
-        &lifecycle_issuer.fingerprint_sha256,
+        lifecycle_issuer.fingerprint_sha256.as_deref(),
     )
     .await;
     tenants::repo::soft_delete_tenant_with_audit(
@@ -470,17 +466,9 @@ async fn issue_managed(
     entity_id: Uuid,
     key: &str,
 ) -> service::CertificateRecord {
-    let profile = profile::resolve_for_subject(
-        pool,
-        &profile::load_subject(pool, entity_id).await.unwrap(),
-        "client",
-    )
-    .await
-    .unwrap();
     let issued = service::issue_certificate_from_csr_v2(
         pool,
         config,
-        common::admin_id(),
         Some(tenant_id),
         service::IssueCertificateFromCsrV2 {
             entity_id,
@@ -491,7 +479,6 @@ async fn issue_managed(
     )
     .await
     .unwrap();
-    assert_eq!(issued.certificate.profile_id, Some(profile.id));
     issued.certificate
 }
 
@@ -527,8 +514,7 @@ fn auth(entity_id: Uuid, tenant_id: Option<Uuid>) -> AuthContext {
         entity_id,
         tenant_id,
         session_id: None,
-        credential_id: None,
-        credential_scoped: false,
+        ..Default::default()
     }
 }
 
@@ -587,7 +573,8 @@ async fn assert_revocation_row(
     let _: chrono::DateTime<chrono::Utc> = row.get("revoked_at");
 }
 
-async fn set_artifact_clean(pool: &PgPool, issuer_id: Uuid, fingerprint: &str) {
+async fn set_artifact_clean(pool: &PgPool, issuer_id: Uuid, fingerprint: Option<&str>) {
+    let fingerprint = fingerprint.expect("managed issuer fingerprint");
     sqlx::query(
         r#"INSERT INTO certificate_crl_state
               (issuer_fingerprint_sha256, issuer_id, crl_number, dirty)

--- a/tests/m35_pki_revocation.rs
+++ b/tests/m35_pki_revocation.rs
@@ -297,6 +297,35 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
     assert!(!revocation_exists(&pool, rollback_cert.credential_id).await);
     assert!(!artifact_dirty(&pool, issuer_b.id).await);
 
+    // The GraphQL/outbox boundary is atomic too: a forced lifecycle-event
+    // insert failure must undo the revocation trigger's status, evidence, and
+    // exact issuer dirty mark.
+    let outbox_failure = issue_managed(&pool, &config, tenant_b, entity_b, "outbox-failure").await;
+    set_artifact_clean(&pool, issuer_b.id, &issuer_b.fingerprint_sha256).await;
+    install_rejecting_outbox_trigger(&pool).await;
+    let failed = schema
+        .execute(revoke_request(
+            common::admin_id(),
+            None,
+            json!({
+                "credentialId": outbox_failure.credential_id,
+                "reason": "transaction_failure"
+            }),
+        ))
+        .await;
+    drop_rejecting_outbox_trigger(&pool).await;
+    assert!(!failed.errors.is_empty());
+    assert_eq!(
+        certificate_status(&pool, outbox_failure.credential_id).await,
+        "active"
+    );
+    assert!(!revocation_exists(&pool, outbox_failure.credential_id).await);
+    assert!(!artifact_dirty(&pool, issuer_b.id).await);
+    assert_eq!(
+        event_count(&pool, "certificate.revoke", outbox_failure.credential_id).await,
+        0
+    );
+
     // Entity and tenant suspension/freeze fail closed without inventing a
     // revocation. Tenant deletion then performs durable lifecycle revocation.
     let lifecycle_tenant = common::pki::create_tenant(&pool, "pki-revoke-lifecycle").await;
@@ -652,4 +681,40 @@ async fn assert_tenant_delete_event(pool: &PgPool, tenant_id: Uuid, credential_i
         .unwrap()
         .contains(&json!(credential_id)));
     assert!(!payload.to_string().contains("PRIVATE KEY"));
+}
+
+async fn install_rejecting_outbox_trigger(pool: &PgPool) {
+    sqlx::query(
+        r#"CREATE OR REPLACE FUNCTION m35_reject_certificate_revoke_event()
+           RETURNS trigger AS $$
+           BEGIN
+             IF NEW.event = 'certificate.revoke' THEN
+               RAISE EXCEPTION 'forced PR-008 outbox failure';
+             END IF;
+             RETURN NEW;
+           END;
+           $$ LANGUAGE plpgsql"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"CREATE TRIGGER m35_reject_certificate_revoke_event
+           BEFORE INSERT ON event_outbox
+           FOR EACH ROW EXECUTE FUNCTION m35_reject_certificate_revoke_event()"#,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn drop_rejecting_outbox_trigger(pool: &PgPool) {
+    sqlx::query("DROP TRIGGER m35_reject_certificate_revoke_event ON event_outbox")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DROP FUNCTION m35_reject_certificate_revoke_event()")
+        .execute(pool)
+        .await
+        .unwrap();
 }

--- a/tests/m35_pki_revocation.rs
+++ b/tests/m35_pki_revocation.rs
@@ -1,0 +1,655 @@
+//! PR-008 issuer-aware revocation state-machine coverage.
+//!
+//! Requires PostgreSQL and OpenSSL. CI runs this ignored binary against its own
+//! freshly migrated database, single-threaded.
+
+mod common;
+
+use async_graphql::{Request, Variables};
+use atom::{
+    auth::AuthContext,
+    certs::{profile, service},
+    graphql::build_schema,
+    models::enums::TenantStatus,
+    tenants,
+};
+use rcgen::{CertificateParams, DnType, KeyPair};
+use serde_json::{json, Value};
+use sqlx::{PgPool, Row};
+use time::{Duration, OffsetDateTime};
+use uuid::Uuid;
+
+#[tokio::test]
+#[ignore]
+async fn issuer_aware_revocation_enforces_the_pr008_contract() {
+    let pool = common::pool().await;
+    let config = common::pki::managed_config(false, true);
+    let root = common::pki::test_root("PR-008 Offline Root");
+    let tenant_a = common::pki::create_tenant(&pool, "pki-revoke-a").await;
+    let tenant_b = common::pki::create_tenant(&pool, "pki-revoke-b").await;
+    let entity_a = common::pki::create_entity(&pool, tenant_a, "pki-revoke-a").await;
+    let entity_b = common::pki::create_entity(&pool, tenant_b, "pki-revoke-b").await;
+    let issuer_a = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let issuer_b = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_b).await;
+    let schema = build_schema(common::pki::graphql_state(pool.clone(), config.clone()));
+
+    assert_v2_schema_contract(&schema).await;
+
+    let exact = issue_managed(&pool, &config, tenant_a, entity_a, "exact").await;
+    let unaffected = issue_managed(&pool, &config, tenant_b, entity_b, "unaffected").await;
+    set_artifact_clean(&pool, issuer_a.id, &issuer_a.fingerprint_sha256).await;
+    set_artifact_clean(&pool, issuer_b.id, &issuer_b.fingerprint_sha256).await;
+
+    // Authorization is evaluated against the exact resolved credential and
+    // rechecked under lock, so another tenant cannot revoke it.
+    let denied = schema
+        .execute(revoke_request(
+            entity_b,
+            Some(tenant_b),
+            json!({"credentialId": exact.credential_id, "reason": "key_compromise"}),
+        ))
+        .await;
+    assert!(errors_contain(&denied.errors, "forbidden"));
+    assert_eq!(
+        certificate_status(&pool, exact.credential_id).await,
+        "active"
+    );
+
+    // Exact ID revocation is immediately authoritative and records immutable
+    // actor/reason/issuer evidence without dirtying any other issuer.
+    let first = schema
+        .execute(revoke_request(
+            common::admin_id(),
+            None,
+            json!({"credentialId": exact.credential_id, "reason": "key_compromise"}),
+        ))
+        .await;
+    assert!(first.errors.is_empty(), "{:?}", first.errors);
+    let first = first.data.into_json().unwrap()["revokeCertificateV2"].clone();
+    assert_eq!(first["idempotentReplay"], false);
+    assert_eq!(first["reason"], "key_compromise");
+    assert_eq!(first["actorEntityId"], common::admin_id().to_string());
+    assert_eq!(
+        first["certificate"]["credentialId"],
+        exact.credential_id.to_string()
+    );
+    assert_eq!(first["certificate"]["status"], "revoked");
+    let first_revoked_at = first["revokedAt"].as_str().unwrap().to_string();
+    assert_revocation_row(
+        &pool,
+        exact.credential_id,
+        issuer_a.id,
+        "key_compromise",
+        Some(common::admin_id()),
+    )
+    .await;
+    assert!(artifact_dirty(&pool, issuer_a.id).await);
+    assert!(!artifact_dirty(&pool, issuer_b.id).await);
+    assert!(service::resolve_certificate_identity(
+        &pool,
+        &exact.serial_number,
+        Some(&exact.fingerprint_sha256),
+    )
+    .await
+    .is_err());
+
+    // Repeated revocation is a no-op: it returns the original evidence and
+    // does not enqueue a second lifecycle event or rewrite reason/time.
+    let event_count = event_count(&pool, "certificate.revoke", exact.credential_id).await;
+    let replay = schema
+        .execute(revoke_request(
+            common::admin_id(),
+            None,
+            json!({"credentialId": exact.credential_id, "reason": "superseded"}),
+        ))
+        .await;
+    assert!(replay.errors.is_empty(), "{:?}", replay.errors);
+    let replay = replay.data.into_json().unwrap()["revokeCertificateV2"].clone();
+    assert_eq!(replay["idempotentReplay"], true);
+    assert_eq!(replay["reason"], "key_compromise");
+    assert_eq!(replay["revokedAt"], first_revoked_at);
+    assert_eq!(
+        event_count(&pool, "certificate.revoke", exact.credential_id).await,
+        event_count
+    );
+    assert_audit_and_outbox(&pool, exact.credential_id, issuer_a.id).await;
+
+    // A revoked certificate cannot enter the PR-007 renewal state machine.
+    let renew_revoked = service::renew_certificate_v2(
+        &pool,
+        &config,
+        service::CertificateRenewalAuthorization::Operator {
+            actor_entity_id: Some(common::admin_id()),
+            expected_entity_id: entity_a,
+            expected_tenant_id: Some(tenant_a),
+        },
+        service::RenewCertificateV2 {
+            credential_id: exact.credential_id,
+            ttl_secs: Some(3600),
+            key_source: service::RenewalKeySource::Csr(csr()),
+            revoke_old: false,
+            idempotency_key: "revoked-renewal".into(),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(renew_revoked.to_string().contains("revoked"));
+
+    // Fingerprint and issuer+serial are independent exact selectors. The old
+    // serial-only mutation rejects managed certificates.
+    let by_fingerprint = issue_managed(&pool, &config, tenant_a, entity_a, "fingerprint").await;
+    let fingerprint_response = schema
+        .execute(revoke_request(
+            common::admin_id(),
+            None,
+            json!({
+                "fingerprintSha256": by_fingerprint.fingerprint_sha256,
+                "reason": "affiliation_changed"
+            }),
+        ))
+        .await;
+    assert!(
+        fingerprint_response.errors.is_empty(),
+        "{:?}",
+        fingerprint_response.errors
+    );
+    assert_eq!(
+        certificate_status(&pool, by_fingerprint.credential_id).await,
+        "revoked"
+    );
+
+    let by_issuer_serial = issue_managed(&pool, &config, tenant_b, entity_b, "issuer-serial").await;
+    let issuer_serial_response = schema
+        .execute(revoke_request(
+            common::admin_id(),
+            None,
+            json!({
+                "issuerId": issuer_b.id,
+                "serialNumber": by_issuer_serial.serial_number,
+                "reason": "cessation_of_operation"
+            }),
+        ))
+        .await;
+    assert!(
+        issuer_serial_response.errors.is_empty(),
+        "{:?}",
+        issuer_serial_response.errors
+    );
+    assert_eq!(
+        certificate_status(&pool, by_issuer_serial.credential_id).await,
+        "revoked"
+    );
+    let legacy_managed = schema
+        .execute(
+            Request::new(format!(
+                r#"mutation {{ revokeCertificate(input: {{ serialNumber: "{}" }}) {{ credentialId }} }}"#,
+                unaffected.serial_number
+            ))
+            .data(auth(common::admin_id(), None)),
+        )
+        .await;
+    assert!(errors_contain(
+        &legacy_managed.errors,
+        "requires revokeCertificateV2"
+    ));
+
+    // The selector remains unambiguous once PR-011 removes global serial
+    // uniqueness. Exercise that future database shape inside a rolled-back DDL
+    // transaction so this PR does not perform the resolver-v2 cutover early.
+    let duplicate_a = issue_managed(&pool, &config, tenant_a, entity_a, "duplicate-a").await;
+    let duplicate_b = issue_managed(&pool, &config, tenant_b, entity_b, "duplicate-b").await;
+    let mut duplicate_tx = pool.begin().await.unwrap();
+    sqlx::query("DROP INDEX idx_credentials_certificate_serial")
+        .execute(&mut *duplicate_tx)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE credentials SET identifier = $1 WHERE id = $2")
+        .bind(&duplicate_a.serial_number)
+        .bind(duplicate_b.credential_id)
+        .execute(&mut *duplicate_tx)
+        .await
+        .unwrap();
+    let duplicate_result = service::revoke_certificate_v2_in_tx(
+        &mut duplicate_tx,
+        service::RevokeCertificateV2 {
+            selector: service::CertificateRevocationSelector::IssuerSerial {
+                issuer_id: issuer_b.id,
+                serial_number: duplicate_a.serial_number.clone(),
+            },
+            reason: Some("duplicate_serial_test".into()),
+            actor_entity_id: Some(common::admin_id()),
+            expected_entity_id: entity_b,
+            expected_tenant_id: Some(tenant_b),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        duplicate_result.certificate.credential_id,
+        duplicate_b.credential_id
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, String>("SELECT status FROM credentials WHERE id = $1")
+            .bind(duplicate_a.credential_id)
+            .fetch_one(&mut *duplicate_tx)
+            .await
+            .unwrap(),
+        "active"
+    );
+    duplicate_tx.rollback().await.unwrap();
+
+    // Entity-wide revocation changes every active certificate exactly once and
+    // carries the affected credential/issuer set in its audit/outbox payload.
+    let bulk_entity = common::pki::create_entity(&pool, tenant_a, "pki-revoke-bulk").await;
+    let bulk_one = issue_managed(&pool, &config, tenant_a, bulk_entity, "bulk-one").await;
+    let bulk_two = issue_managed(&pool, &config, tenant_a, bulk_entity, "bulk-two").await;
+    let bulk = schema
+        .execute(
+            Request::new(format!(
+                r#"mutation {{ revokeEntityCertificates(entityId: "{bulk_entity}", reason: "entity_revoked") }}"#
+            ))
+            .data(auth(common::admin_id(), None)),
+        )
+        .await;
+    assert!(bulk.errors.is_empty(), "{:?}", bulk.errors);
+    assert_eq!(
+        bulk.data.into_json().unwrap()["revokeEntityCertificates"],
+        2
+    );
+    assert_eq!(
+        certificate_status(&pool, bulk_one.credential_id).await,
+        "revoked"
+    );
+    assert_eq!(
+        certificate_status(&pool, bulk_two.credential_id).await,
+        "revoked"
+    );
+    let repeated_bulk =
+        service::revoke_entity_certificates(&pool, bulk_entity, Some("entity_revoked".into()))
+            .await
+            .unwrap();
+    assert_eq!(repeated_bulk, 0);
+
+    // A transaction failure rolls credential state, immutable evidence, and
+    // issuer dirtiness back together.
+    let rollback_cert = issue_managed(&pool, &config, tenant_b, entity_b, "rollback").await;
+    set_artifact_clean(&pool, issuer_b.id, &issuer_b.fingerprint_sha256).await;
+    let mut rollback_tx = pool.begin().await.unwrap();
+    service::revoke_certificate_v2_in_tx(
+        &mut rollback_tx,
+        service::RevokeCertificateV2 {
+            selector: service::CertificateRevocationSelector::CredentialId(
+                rollback_cert.credential_id,
+            ),
+            reason: Some("transaction_rollback".into()),
+            actor_entity_id: Some(common::admin_id()),
+            expected_entity_id: entity_b,
+            expected_tenant_id: Some(tenant_b),
+        },
+    )
+    .await
+    .unwrap();
+    rollback_tx.rollback().await.unwrap();
+    assert_eq!(
+        certificate_status(&pool, rollback_cert.credential_id).await,
+        "active"
+    );
+    assert!(!revocation_exists(&pool, rollback_cert.credential_id).await);
+    assert!(!artifact_dirty(&pool, issuer_b.id).await);
+
+    // Entity and tenant suspension/freeze fail closed without inventing a
+    // revocation. Tenant deletion then performs durable lifecycle revocation.
+    let lifecycle_tenant = common::pki::create_tenant(&pool, "pki-revoke-lifecycle").await;
+    let lifecycle_entity =
+        common::pki::create_entity(&pool, lifecycle_tenant, "pki-revoke-lifecycle").await;
+    let lifecycle_issuer =
+        common::pki::provision_tenant_issuer(&pool, &config, &root, lifecycle_tenant).await;
+    let lifecycle = issue_managed(
+        &pool,
+        &config,
+        lifecycle_tenant,
+        lifecycle_entity,
+        "lifecycle",
+    )
+    .await;
+    tenants::repo::change_tenant_status_with_audit(
+        &pool,
+        true,
+        Some(common::admin_id()),
+        lifecycle_tenant,
+        TenantStatus::Frozen,
+        "tenant.freeze",
+    )
+    .await
+    .unwrap();
+    assert!(service::resolve_certificate_identity(
+        &pool,
+        &lifecycle.serial_number,
+        Some(&lifecycle.fingerprint_sha256),
+    )
+    .await
+    .is_err());
+    assert_eq!(
+        certificate_status(&pool, lifecycle.credential_id).await,
+        "active"
+    );
+    tenants::repo::change_tenant_status(
+        &pool,
+        lifecycle_tenant,
+        TenantStatus::Active,
+        Some(common::admin_id()),
+    )
+    .await
+    .unwrap();
+    sqlx::query("UPDATE entities SET status = 'inactive' WHERE id = $1")
+        .bind(lifecycle_entity)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(service::resolve_certificate_identity(
+        &pool,
+        &lifecycle.serial_number,
+        Some(&lifecycle.fingerprint_sha256),
+    )
+    .await
+    .is_err());
+    sqlx::query("UPDATE entities SET status = 'active' WHERE id = $1")
+        .bind(lifecycle_entity)
+        .execute(&pool)
+        .await
+        .unwrap();
+    set_artifact_clean(
+        &pool,
+        lifecycle_issuer.id,
+        &lifecycle_issuer.fingerprint_sha256,
+    )
+    .await;
+    tenants::repo::soft_delete_tenant_with_audit(
+        &pool,
+        true,
+        Some(common::admin_id()),
+        lifecycle_tenant,
+        Some(common::admin_id()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        certificate_status(&pool, lifecycle.credential_id).await,
+        "revoked"
+    );
+    assert_revocation_row(
+        &pool,
+        lifecycle.credential_id,
+        lifecycle_issuer.id,
+        "tenant_deleted",
+        Some(common::admin_id()),
+    )
+    .await;
+    assert!(artifact_dirty(&pool, lifecycle_issuer.id).await);
+    assert!(service::resolve_certificate_identity(
+        &pool,
+        &lifecycle.serial_number,
+        Some(&lifecycle.fingerprint_sha256),
+    )
+    .await
+    .is_err());
+    assert_tenant_delete_event(&pool, lifecycle_tenant, lifecycle.credential_id).await;
+}
+
+async fn assert_v2_schema_contract(schema: &atom::graphql::AtomSchema) {
+    let response = schema
+        .execute(Request::new(
+            r#"{
+              input: __type(name: "RevokeCertificateV2Input") { inputFields { name } }
+              result: __type(name: "CertificateRevocation") { fields { name } }
+              mutation: __schema { mutationType { fields { name } } }
+            }"#,
+        ))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().unwrap();
+    assert_eq!(
+        sorted_field_names(&data["input"]["inputFields"]),
+        vec![
+            "credentialId",
+            "fingerprintSha256",
+            "issuerId",
+            "reason",
+            "serialNumber"
+        ]
+    );
+    assert_eq!(
+        sorted_field_names(&data["result"]["fields"]),
+        vec![
+            "actorEntityId",
+            "certificate",
+            "idempotentReplay",
+            "reason",
+            "revokedAt"
+        ]
+    );
+    let mutations = sorted_field_names(&data["mutation"]["mutationType"]["fields"]);
+    assert!(mutations.contains(&"revokeCertificate"));
+    assert!(mutations.contains(&"revokeCertificateV2"));
+    assert!(mutations.contains(&"revokeEntityCertificates"));
+}
+
+async fn issue_managed(
+    pool: &PgPool,
+    config: &atom::config::Config,
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    key: &str,
+) -> service::CertificateRecord {
+    let profile = profile::resolve_for_subject(
+        pool,
+        &profile::load_subject(pool, entity_id).await.unwrap(),
+        "client",
+    )
+    .await
+    .unwrap();
+    let issued = service::issue_certificate_from_csr_v2(
+        pool,
+        config,
+        common::admin_id(),
+        Some(tenant_id),
+        service::IssueCertificateFromCsrV2 {
+            entity_id,
+            ttl_secs: Some(3600),
+            csr_pem: csr(),
+            idempotency_key: format!("pr008-{key}"),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(issued.certificate.profile_id, Some(profile.id));
+    issued.certificate
+}
+
+fn csr() -> String {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "pr008-device");
+    params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
+    params.not_after = OffsetDateTime::now_utc() + Duration::hours(2);
+    params.serialize_request(&key).unwrap().pem().unwrap()
+}
+
+fn revoke_request(actor: Uuid, tenant_id: Option<Uuid>, input: Value) -> Request {
+    Request::new(
+        r#"mutation Revoke($input: RevokeCertificateV2Input!) {
+          revokeCertificateV2(input: $input) {
+            certificate { credentialId issuerId serialNumber fingerprintSha256 status }
+            reason
+            actorEntityId
+            revokedAt
+            idempotentReplay
+          }
+        }"#,
+    )
+    .variables(Variables::from_json(json!({"input": input})))
+    .data(auth(actor, tenant_id))
+}
+
+fn auth(entity_id: Uuid, tenant_id: Option<Uuid>) -> AuthContext {
+    AuthContext {
+        entity_id,
+        tenant_id,
+        session_id: None,
+        credential_id: None,
+        credential_scoped: false,
+    }
+}
+
+fn sorted_field_names(value: &Value) -> Vec<&str> {
+    let mut names = value
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|field| field["name"].as_str())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names
+}
+
+fn errors_contain(errors: &[async_graphql::ServerError], expected: &str) -> bool {
+    errors.iter().any(|error| error.message.contains(expected))
+}
+
+async fn certificate_status(pool: &PgPool, credential_id: Uuid) -> String {
+    sqlx::query_scalar("SELECT status FROM credentials WHERE id = $1")
+        .bind(credential_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn assert_revocation_row(
+    pool: &PgPool,
+    credential_id: Uuid,
+    issuer_id: Uuid,
+    reason: &str,
+    actor_entity_id: Option<Uuid>,
+) {
+    let row = sqlx::query(
+        r#"SELECT issuer_id, issuer_fingerprint_sha256, serial_number,
+                  reason, actor_entity_id, revoked_at
+             FROM certificate_revocations WHERE credential_id = $1"#,
+    )
+    .bind(credential_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(row.get::<Option<Uuid>, _>("issuer_id"), Some(issuer_id));
+    assert_eq!(
+        row.get::<Option<String>, _>("issuer_fingerprint_sha256")
+            .unwrap()
+            .len(),
+        64
+    );
+    assert!(!row.get::<String, _>("serial_number").is_empty());
+    assert_eq!(row.get::<String, _>("reason"), reason);
+    assert_eq!(
+        row.get::<Option<Uuid>, _>("actor_entity_id"),
+        actor_entity_id
+    );
+    let _: chrono::DateTime<chrono::Utc> = row.get("revoked_at");
+}
+
+async fn set_artifact_clean(pool: &PgPool, issuer_id: Uuid, fingerprint: &str) {
+    sqlx::query(
+        r#"INSERT INTO certificate_crl_state
+              (issuer_fingerprint_sha256, issuer_id, crl_number, dirty)
+           VALUES ($1, $2, 0, FALSE)
+           ON CONFLICT (issuer_fingerprint_sha256) DO UPDATE
+             SET issuer_id = EXCLUDED.issuer_id, dirty = FALSE, updated_at = now()"#,
+    )
+    .bind(fingerprint)
+    .bind(issuer_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn artifact_dirty(pool: &PgPool, issuer_id: Uuid) -> bool {
+    sqlx::query_scalar("SELECT dirty FROM certificate_crl_state WHERE issuer_id = $1")
+        .bind(issuer_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn revocation_exists(pool: &PgPool, credential_id: Uuid) -> bool {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM certificate_revocations WHERE credential_id = $1)",
+    )
+    .bind(credential_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn event_count(pool: &PgPool, event: &str, credential_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM event_outbox WHERE event = $1 AND (payload->>'target_id')::uuid = $2",
+    )
+    .bind(event)
+    .bind(credential_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn assert_audit_and_outbox(pool: &PgPool, credential_id: Uuid, issuer_id: Uuid) {
+    let audit: Value = sqlx::query_scalar(
+        r#"SELECT details FROM audit_logs
+           WHERE event = 'certificate.revoke' AND target_id = $1
+           ORDER BY created_at DESC LIMIT 1"#,
+    )
+    .bind(credential_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(audit["credential_id"], credential_id.to_string());
+    assert_eq!(audit["issuer_id"], issuer_id.to_string());
+    assert_eq!(audit["reason"], "key_compromise");
+    let outbox: Value = sqlx::query_scalar(
+        r#"SELECT payload FROM event_outbox
+           WHERE event = 'certificate.revoke' AND (payload->>'target_id')::uuid = $1
+           ORDER BY created_at DESC LIMIT 1"#,
+    )
+    .bind(credential_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        outbox["details"]["credential_id"],
+        credential_id.to_string()
+    );
+    assert_eq!(outbox["details"]["issuer_id"], issuer_id.to_string());
+    assert_eq!(outbox["details"]["reason"], "key_compromise");
+    let serialized = outbox.to_string();
+    assert!(!serialized.contains("PRIVATE KEY"));
+    assert!(!serialized.contains("BEGIN CERTIFICATE"));
+}
+
+async fn assert_tenant_delete_event(pool: &PgPool, tenant_id: Uuid, credential_id: Uuid) {
+    let payload: Value = sqlx::query_scalar(
+        r#"SELECT payload FROM event_outbox
+           WHERE event = 'tenant.delete' AND tenant_id = $1
+           ORDER BY created_at DESC LIMIT 1"#,
+    )
+    .bind(tenant_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let revocations = &payload["details"]["certificate_revocations"];
+    assert_eq!(revocations["reason"], "tenant_deleted");
+    assert!(revocations["credential_ids"]
+        .as_array()
+        .unwrap()
+        .contains(&json!(credential_id)));
+    assert!(!payload.to_string().contains("PRIVATE KEY"));
+}


### PR DESCRIPTION
## Objective

Implement PR-008's issuer-aware, immediately authoritative revocation state machine so one exact certificate can be revoked safely and only its issuer's publication state is invalidated.

## Dependencies

- PR-006 — merged into `certificates` by #51.
- PR-007 — merged into `certificates` by #52 at `83432542c7a19613d755c809e135a8e4fec44e92`.
- This branch starts from that current `certificates` tip.

## Changes

- Adds exact revocation selectors for credential ID, SHA-256 certificate fingerprint, and issuer ID plus serial.
- Adds immutable `certificate_revocations` evidence with authoritative issuer fingerprint, serial, reason, actor UUID, and revocation time.
- Uses a database trigger to commit credential status, revocation evidence, and only the affected issuer's dirty artifact state atomically.
- Makes repeat revocation a history-preserving replay with no second lifecycle outbox event.
- Adds entity-wide and tenant/entity lifecycle revocation evidence, actor propagation, and affected credential/issuer IDs in audit/outbox details.
- Rejects managed certificates on the legacy serial-only mutation while retaining that mutation for legacy `issuerId: null` certificates.
- Keeps renewal and runtime resolution fail closed for revoked credentials and inactive/frozen/deleted subjects.
- Documents the exact-selector API, idempotency contract, and publication boundary.

## Acceptance criteria validation

| Criterion | Implementation evidence | Verification evidence | Result |
|---|---|---|---|
| Serial alone is not used where issuers may share it | `revokeCertificateV2` accepts credential ID, fingerprint, or issuer+serial; managed certificates are rejected by the v1 serial mutation | `m35_pki_revocation` exercises all selectors and duplicates one serial across two issuers inside a rolled-back resolver-v2 database shape | Passed |
| Tenant A cannot revoke Tenant B credential | Authorization resolves the exact credential, then entity/tenant ownership is rechecked under its row lock | Cross-tenant GraphQL revocation is denied and the target remains active | Passed |
| Revocation is idempotent | The first transition writes immutable evidence; replay returns that original actor/reason/time and skips lifecycle outbox insertion | Repeated revoke asserts `idempotentReplay`, unchanged evidence, and unchanged event count | Passed |
| Revoked credentials cannot be renewed without an explicit replacement policy | PR-007 renewal validation rejects revoked source credentials; PR-008 propagates exact actor metadata when renewal revokes an old credential | Revoked-source renewal is denied in `m35_pki_revocation` | Passed |
| Entity/tenant suspension fails closed | Runtime resolution validates active entity and tenant state in addition to credential status | Frozen tenant, inactive entity, tenant deletion, and revoked credential resolution are denied | Passed |
| Only the affected issuer artifact state changes | The revocation trigger derives the fingerprint from the authority registry and dirties only that issuer row | Tenant A revocation dirties issuer A while issuer B remains clean; rollback restores the exact state | Passed |
| Audit/outbox contain no secrets and identify issuer/credential/reason | Direct and bulk events carry exact IDs, reason, actor, and time; key/certificate/CSR bodies are omitted | Integration assertions inspect audit/outbox payloads and reject private-key/certificate material | Passed |

## Mandatory tests

All mandatory tests are implemented in `tests/m35_pki_revocation.rs` and passed in Rust workflow run #292:

- Exact lookup — credential ID, fingerprint, and issuer+serial all passed.
- Duplicate serial issuers — exact issuer selection passed with the global serial index removed inside a rolled-back transaction.
- Cross-tenant denial — passed.
- Repeated revoke — original evidence and single lifecycle event passed.
- Entity-wide revoke — all active entity certificates revoked exactly once; repeat is a no-op.
- Tenant delete/freeze — fail-closed resolution and durable deletion evidence passed.
- Transaction failure — explicit rollback and forced outbox failure both restore status, evidence, artifact state, and event count.
- Resolver denial — revoked, frozen-tenant, and inactive-entity credentials are denied immediately.

Additional mandatory-behavior coverage passed for renewal denial, issuer-only dirtiness, lifecycle actor evidence, audit/outbox payload safety, and schema shape.

## Additional validation

- `cargo fmt --check` — passed locally and in Rust workflow #292.
- `cargo clippy -- -D warnings` — passed in Rust workflow #292.
- `cargo test --no-run --locked` — passed in Rust workflow #292.
- Repository CI fresh-database loop (`cargo test` for the library and every applicable integration binary with ignored tests enabled and one thread) — passed in Rust workflow #292.
- API Docs workflow #233: `buf lint`, generated-doc drift check, and OpenAPI lint — passed.
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm run build` — passed locally.
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm audit --prod --audit-level high` — passed locally (no high/critical findings; one pre-existing moderate advisory).
- `git diff --check certificates...HEAD` — passed locally.
- Rust workflow #290 also completed the complete fresh-database suite successfully before the final evidence-hardening commit.

## Non-goals

PR-008 does not add or change CRL encoding or OCSP response generation. Per-issuer publication remains PR-009/PR-010 scope. The resolver-v2 uniqueness cutover remains PR-011 scope.

## Compatibility and risks

- The migration backfills already-revoked certificates, retains unknown historical actor/issuer fields as null rather than inventing evidence, and preserves legacy certificate behavior.
- Actor UUID evidence intentionally has no entity foreign key: the immutable record must survive actor purge without an `ON DELETE` mutation conflicting with immutability.
- Global certificate serial uniqueness remains in place until PR-011; the duplicate-serial test proves the exact path without performing that cutover early.
- Managed callers must move from the legacy serial mutation to `revokeCertificateV2`; legacy file-issued `issuerId: null` credentials remain compatible.
- Runtime status is authoritative immediately. CRL/OCSP publication lag cannot reactivate or authorize a revoked credential.
- This pull request targets `certificates`; `main` was not used.