### PR TITLE
[PKI PR-009] Implement per-issuer CRL publication

### DIFF
--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -326,6 +326,29 @@ suspension and tenant freeze/delete fail closed in runtime resolution. Tenant
 or entity deletion also records exact revocation evidence for every certificate
 it transitions; restoring the subject never reactivates those certificates.
 
+## Per-issuer CRLs
+
+Each managed leaf issuer publishes its own DER-encoded CRL at
+`/certs/issuers/{issuer_id}/crl`. A CRL contains only revocations for
+certificates signed by that exact issuer, preserves the recorded RFC 5280 reason
+code, and is signed through the issuer's configured key provider. During CA
+rotation, `retiring` and `retired` issuers continue publishing their retained
+CRLs even though they cannot issue new leaves. An `expired` issuer may serve a
+still-valid cached artifact, but it cannot sign a replacement.
+
+The response uses `application/pkix-crl`, an ETag, bounded `Cache-Control`, and
+`If-None-Match` support. Pollers should retain every issuer URL needed by their
+certificate-validation window; a new issuer has a separate CRL and does not
+replace the old issuer's artifact. CRL numbers increase monotonically for the
+physical CA, including when legacy fingerprint-keyed state is adopted into the
+issuer-keyed cache.
+
+CRLs are compliance and interoperability artifacts, not Atom's primary
+revocation control. Runtime access is denied immediately from authoritative
+credential and subject state. Deployments should combine that resolver denial
+with short certificate lifetimes instead of waiting for a relying party's next
+CRL poll.
+
 ## Legacy CA files
 
 The original v1 issuer remains available for backward compatibility and loads
@@ -377,6 +400,7 @@ These endpoints are public because clients and runtimes need to verify certifica
 GET  /certs/ca-chain
 GET  /certs/trust-bundle.pem
 GET  /certs/crl
+GET  /certs/issuers/{issuer_id}/crl
 POST /certs/ocsp
 ```
 
@@ -385,6 +409,10 @@ every request. It returns an ETag derived from the bundle, accepts
 `If-None-Match`, and includes cache directives so relying parties can poll
 cheaply and notice a newly provisioned or rotated tenant authority without an
 Atom restart.
+
+`/certs/crl` remains the compatibility route for the legacy file-backed issuer.
+Managed-authority clients should use the issuer-specific route carried by their
+certificate's CRL distribution point.
 
 ## Runtime Lookup
 

--- a/migrations/011_pki_issuer_crls.sql
+++ b/migrations/011_pki_issuer_crls.sql
@@ -1,0 +1,134 @@
+-- Issuer-keyed CRL publication state with a legacy fingerprint namespace.
+--
+-- Managed authorities move to a stable issuer UUID key without replacing the
+-- physical row that already owns the last published CRL number. Legacy file
+-- issuers keep their fingerprint key and cached artifact until their separate
+-- migration is complete.
+
+ALTER TABLE certificate_crl_state
+    ADD COLUMN state_key TEXT GENERATED ALWAYS AS (
+        CASE
+            WHEN issuer_id IS NULL
+            THEN 'fingerprint:' || issuer_fingerprint_sha256
+            ELSE 'issuer:' || issuer_id::text
+        END
+    ) STORED,
+    ADD COLUMN crl_sha256 TEXT;
+
+UPDATE certificate_crl_state
+   SET crl_sha256 = CASE
+           WHEN crl_der IS NULL THEN NULL
+           ELSE encode(digest(crl_der, 'sha256'), 'hex')
+       END;
+
+ALTER TABLE certificate_crl_state
+    DROP CONSTRAINT certificate_crl_state_pkey,
+    ADD CONSTRAINT certificate_crl_state_pkey PRIMARY KEY (state_key),
+    ADD CONSTRAINT chk_certificate_crl_state_hash CHECK (
+        (crl_der IS NULL AND crl_sha256 IS NULL)
+        OR (
+            crl_der IS NOT NULL
+            AND crl_sha256 ~ '^[0-9a-f]{64}$'
+            AND crl_sha256 = encode(digest(crl_der, 'sha256'), 'hex')
+        )
+    );
+
+CREATE UNIQUE INDEX idx_certificate_crl_state_fingerprint
+    ON certificate_crl_state(issuer_fingerprint_sha256);
+
+-- PR-008 owns authoritative revocation. Replacing its trigger here changes
+-- only the artifact-state representation: managed rows use issuer UUID keys,
+-- while legacy rows continue to use fingerprint keys.
+CREATE OR REPLACE FUNCTION record_certificate_revocation()
+RETURNS trigger AS $$
+DECLARE
+    event_time             TIMESTAMPTZ;
+    event_reason           TEXT;
+    event_actor            UUID;
+    issuer_fingerprint     TEXT;
+    existing_fingerprint   TEXT;
+    existing_issuer        UUID;
+BEGIN
+    IF NEW.kind <> 'certificate' OR NEW.status <> 'revoked' THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD.status = 'revoked' THEN
+        RETURN NEW;
+    END IF;
+
+    event_time := COALESCE((NEW.metadata->>'revoked_at')::timestamptz, now());
+    event_reason := left(
+        COALESCE(NULLIF(btrim(NEW.metadata->>'revocation_reason'), ''), 'unspecified'),
+        128
+    );
+    event_actor := NULLIF(NEW.metadata->>'revoked_by_entity_id', '')::uuid;
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT a.fingerprint_sha256
+          INTO issuer_fingerprint
+          FROM pki_authorities a
+         WHERE a.id = NEW.issuer_id;
+    END IF;
+    issuer_fingerprint := COALESCE(
+        issuer_fingerprint,
+        NULLIF(NEW.metadata->>'issuer_fingerprint_sha256', '')
+    );
+
+    INSERT INTO certificate_revocations (
+        credential_id, issuer_id, issuer_fingerprint_sha256, serial_number,
+        reason, actor_entity_id, revoked_at
+    ) VALUES (
+        NEW.id, NEW.issuer_id, issuer_fingerprint, NEW.identifier,
+        event_reason, event_actor, event_time
+    )
+    ON CONFLICT (credential_id) DO NOTHING;
+
+    IF issuer_fingerprint IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT s.issuer_fingerprint_sha256
+          INTO existing_fingerprint
+          FROM certificate_crl_state s
+         WHERE s.issuer_id = NEW.issuer_id
+         FOR UPDATE;
+        IF FOUND THEN
+            IF existing_fingerprint <> issuer_fingerprint THEN
+                RAISE EXCEPTION 'certificate issuer artifact fingerprint mismatch'
+                    USING ERRCODE = '23514';
+            END IF;
+            UPDATE certificate_crl_state
+               SET dirty = TRUE, updated_at = now()
+             WHERE issuer_id = NEW.issuer_id;
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    SELECT s.issuer_id
+      INTO existing_issuer
+      FROM certificate_crl_state s
+     WHERE s.issuer_fingerprint_sha256 = issuer_fingerprint
+     FOR UPDATE;
+    IF FOUND
+       AND existing_issuer IS NOT NULL
+       AND existing_issuer IS DISTINCT FROM NEW.issuer_id THEN
+        RAISE EXCEPTION 'certificate artifact fingerprint belongs to another issuer'
+            USING ERRCODE = '23514';
+    END IF;
+
+    INSERT INTO certificate_crl_state (
+        issuer_fingerprint_sha256, issuer_id, crl_number, dirty
+    ) VALUES (
+        issuer_fingerprint, NEW.issuer_id, 0, TRUE
+    )
+    ON CONFLICT (issuer_fingerprint_sha256) DO UPDATE
+        SET dirty = TRUE,
+            issuer_id = COALESCE(
+                certificate_crl_state.issuer_id,
+                EXCLUDED.issuer_id
+            ),
+            updated_at = now();
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/product-docs/development/pki/pr-009-crl.md
+++ b/product-docs/development/pki/pr-009-crl.md
@@ -1,5 +1,9 @@
 # PR-009 — Per-Issuer CRL Generation and Routes
 
+## Status
+
+Implemented by the PR-009 delivery branch.
+
 ## Objective
 
 Publish standards-compliant CRLs for every issuer while retaining legacy artifacts during migration and rotation.

--- a/src/certs/http.rs
+++ b/src/certs/http.rs
@@ -1,9 +1,11 @@
 use axum::{
     body::Bytes,
-    extract::State,
+    extract::{Path, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
+use chrono::Utc;
+use uuid::Uuid;
 
 use crate::{certs::service, error::AppError, state::AppState};
 
@@ -30,6 +32,45 @@ pub async fn crl(State(state): State<AppState>) -> Result<Response, AppError> {
         HeaderValue::from_static("application/pkix-crl"),
     );
     Ok((StatusCode::OK, headers, der).into_response())
+}
+
+pub async fn issuer_crl(
+    Path(issuer_id): Path<Uuid>,
+    State(state): State<AppState>,
+    request_headers: HeaderMap,
+) -> Result<Response, AppError> {
+    let artifact = service::issuer_crl(&state.pool, &state.config, issuer_id).await?;
+    let etag = format!("\"{}\"", artifact.sha256);
+    let max_age = (artifact.next_update - Utc::now())
+        .num_seconds()
+        .clamp(0, 24 * 60 * 60);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/pkix-crl"),
+    );
+    headers.insert(
+        header::ETAG,
+        HeaderValue::from_str(&etag).map_err(|error| {
+            AppError::Internal(anyhow::anyhow!("invalid cached CRL identifier: {error}"))
+        })?,
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_str(&format!("public, max-age={max_age}, must-revalidate")).map_err(
+            |error| AppError::Internal(anyhow::anyhow!("invalid CRL cache lifetime: {error}")),
+        )?,
+    );
+    let not_modified = request_headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value == "*" || value.split(',').any(|candidate| candidate.trim() == etag)
+        });
+    if not_modified {
+        return Ok((StatusCode::NOT_MODIFIED, headers).into_response());
+    }
+    Ok((StatusCode::OK, headers, artifact.der).into_response())
 }
 
 pub async fn ocsp(State(state): State<AppState>, body: Bytes) -> Result<Response, AppError> {

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -9,10 +9,10 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
 use p256::{elliptic_curve::sec1::ToEncodedPoint, pkcs8::DecodePublicKey, PublicKey};
 use rcgen::{
-    CertificateParams, CertificateSigningRequestParams, CrlDistributionPoint, CustomExtension,
-    DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, PublicKeyData,
-    RsaKeySize, SanType, SerialNumber, SignatureAlgorithm, SigningKey, PKCS_ECDSA_P256_SHA256,
-    PKCS_ECDSA_P384_SHA384, PKCS_ED25519, PKCS_RSA_SHA256,
+    CertificateParams, CertificateRevocationListParams, CertificateSigningRequestParams,
+    CrlDistributionPoint, CustomExtension, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose, PublicKeyData, RsaKeySize, SanType, SerialNumber, SignatureAlgorithm,
+    SigningKey, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ED25519, PKCS_RSA_SHA256,
 };
 use ring::{digest, rand, rand::SecureRandom};
 use time::{Duration, OffsetDateTime};
@@ -174,9 +174,37 @@ impl PkiIssuer {
                 "issuing authority is not active and valid for leaf issuance",
             ));
         }
+        Self::from_managed_authority_material(authority, ca_keys)
+    }
+
+    /// Load a retained managed issuer for CRL/OCSP signing. Retiring and
+    /// retired keys deliberately remain usable for publication, but revoked,
+    /// expired, provisioning, and failed authorities never regain signing
+    /// authority through this artifact path.
+    pub fn from_managed_authority_for_artifacts(
+        authority: &AuthorityRecord,
+        ca_keys: &PkiCaKeyConfig,
+    ) -> Result<Self, AppError> {
+        if !matches!(
+            authority.status,
+            super::authority::AuthorityStatus::Active
+                | super::authority::AuthorityStatus::Retiring
+                | super::authority::AuthorityStatus::Retired
+        ) {
+            return Err(AppError::bad_request(
+                "authority is not eligible for artifact signing",
+            ));
+        }
+        Self::from_managed_authority_material(authority, ca_keys)
+    }
+
+    fn from_managed_authority_material(
+        authority: &AuthorityRecord,
+        ca_keys: &PkiCaKeyConfig,
+    ) -> Result<Self, AppError> {
         if authority.key_backend != AuthorityKeyBackend::EncryptedDatabase {
             return Err(AppError::Internal(anyhow::anyhow!(
-                "managed authority key backend is not available for leaf issuance"
+                "managed authority key backend is not available"
             )));
         }
         let certificate_pem =
@@ -250,6 +278,13 @@ impl PkiIssuer {
             ca_issuers_url: ca_issuers_url.to_string(),
             crl_distribution_point_url: crl_distribution_point_url.to_string(),
         })
+    }
+
+    pub fn sign_crl(&self, params: CertificateRevocationListParams) -> Result<Vec<u8>, AppError> {
+        let signer = Issuer::from_ca_cert_pem(&self.certificate_pem, &self.signing_key)
+            .map_err(core_encoding_error)?;
+        let crl = params.signed_by(&signer).map_err(core_encoding_error)?;
+        Ok(crl.der().to_vec())
     }
 }
 

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -98,6 +98,22 @@ pub struct PkiIssuer {
     crl_distribution_point_url: String,
 }
 
+/// Restricted signing surface for retained publication artifacts. Unlike a
+/// leaf issuer, this type carries no discovery URLs and cannot be passed to
+/// certificate issuance helpers.
+pub struct PkiArtifactSigner {
+    certificate_pem: String,
+    signing_key: PkiSigningKey,
+}
+
+struct ManagedAuthorityMaterial {
+    certificate_pem: String,
+    chain_pem: String,
+    signing_key: PkiSigningKey,
+    not_before: OffsetDateTime,
+    not_after: OffsetDateTime,
+}
+
 impl fmt::Debug for PkiIssuer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PkiIssuer")
@@ -174,42 +190,6 @@ impl PkiIssuer {
                 "issuing authority is not active and valid for leaf issuance",
             ));
         }
-        Self::from_managed_authority_material(authority, ca_keys)
-    }
-
-    /// Load a retained managed issuer for CRL/OCSP signing. Retiring and
-    /// retired keys deliberately remain usable for publication, but revoked,
-    /// expired, provisioning, and failed authorities never regain signing
-    /// authority through this artifact path.
-    pub fn from_managed_authority_for_artifacts(
-        authority: &AuthorityRecord,
-        ca_keys: &PkiCaKeyConfig,
-    ) -> Result<Self, AppError> {
-        if !matches!(
-            authority.status,
-            super::authority::AuthorityStatus::Active
-                | super::authority::AuthorityStatus::Retiring
-                | super::authority::AuthorityStatus::Retired
-        ) {
-            return Err(AppError::bad_request(
-                "authority is not eligible for artifact signing",
-            ));
-        }
-        Self::from_managed_authority_material(authority, ca_keys)
-    }
-
-    fn from_managed_authority_material(
-        authority: &AuthorityRecord,
-        ca_keys: &PkiCaKeyConfig,
-    ) -> Result<Self, AppError> {
-        if authority.key_backend != AuthorityKeyBackend::EncryptedDatabase {
-            return Err(AppError::Internal(anyhow::anyhow!(
-                "managed authority key backend is not available"
-            )));
-        }
-        let certificate_pem =
-            required_authority_field(authority.certificate_pem.as_deref(), "certificate")?;
-        let chain_pem = required_authority_field(authority.chain_pem.as_deref(), "chain")?;
         let ocsp_url = required_authority_field(authority.ocsp_url.as_deref(), "OCSP URL")?;
         let ca_issuers_url =
             required_authority_field(authority.ca_issuers_url.as_deref(), "CA issuers URL")?;
@@ -220,63 +200,50 @@ impl PkiIssuer {
         validate_route(ocsp_url, "OCSP")?;
         validate_route(ca_issuers_url, "CA issuers")?;
         validate_route(crl_distribution_point_url, "CRL distribution point")?;
-
-        let certificate_der = one_certificate_der(certificate_pem, "issuer certificate")?;
-        let (_, certificate) =
-            x509_parser::parse_x509_certificate(&certificate_der).map_err(|_| {
-                AppError::Internal(anyhow::anyhow!("stored invalid issuer certificate"))
-            })?;
-        validate_issuer_certificate(&certificate)?;
-        validate_chain(&certificate_der, chain_pem)?;
-
-        let fingerprint = hex::encode(digest::digest(&digest::SHA256, &certificate_der));
-        if authority.fingerprint_sha256.as_deref() != Some(&fingerprint)
-            || authority.not_before.map(|value| value.timestamp())
-                != Some(certificate.validity().not_before.timestamp())
-            || authority.not_after.map(|value| value.timestamp())
-                != Some(certificate.validity().not_after.timestamp())
-        {
-            return Err(AppError::Internal(anyhow::anyhow!(
-                "stored issuer metadata does not match its certificate"
-            )));
-        }
-
-        let context = AuthorityKeyContext {
-            authority_id: authority.id,
-            tenant_id: authority.tenant_id,
-            version: authority.version,
-        };
-        let provider = EncryptedDatabaseKeyProvider::new(ca_keys.clone());
-        let key =
-            EncryptedAuthorityKey::from_authority(authority).map_err(managed_key_provider_error)?;
-        let public = provider
-            .public_key(context, &key)
-            .map_err(managed_key_provider_error)?;
-        if public.subject_public_key_info_der != certificate.public_key().raw {
-            return Err(AppError::Internal(anyhow::anyhow!(
-                "managed authority key does not match its certificate"
-            )));
-        }
-        let public_key = PublicKey::from_public_key_der(&public.subject_public_key_info_der)
-            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid managed authority key")))?;
-        let raw_public_key = public_key.to_encoded_point(false).as_bytes().to_vec();
-        let not_before = certificate.validity().not_before.to_datetime();
-        let not_after = certificate.validity().not_after.to_datetime();
+        let material = managed_authority_material(authority, ca_keys)?;
 
         Ok(Self {
-            certificate_pem: pem_encode_certificate(&certificate_der),
-            chain_pem: chain_pem.to_string(),
-            signing_key: PkiSigningKey::EncryptedDatabase {
-                provider,
-                context,
-                key,
-                raw_public_key,
-            },
-            not_before,
-            not_after,
+            certificate_pem: material.certificate_pem,
+            chain_pem: material.chain_pem,
+            signing_key: material.signing_key,
+            not_before: material.not_before,
+            not_after: material.not_after,
             ocsp_url: ocsp_url.to_string(),
             ca_issuers_url: ca_issuers_url.to_string(),
             crl_distribution_point_url: crl_distribution_point_url.to_string(),
+        })
+    }
+}
+
+impl PkiArtifactSigner {
+    /// Load a retained managed leaf issuer for CRL/OCSP signing. Discovery
+    /// routes are deliberately not required: old issuers must keep publishing
+    /// even if they predate the route metadata migration.
+    pub fn from_managed_authority(
+        authority: &AuthorityRecord,
+        ca_keys: &PkiCaKeyConfig,
+    ) -> Result<Self, AppError> {
+        let now = Utc::now();
+        if !authority.kind.can_issue_leaf_credentials()
+            || !matches!(
+                authority.status,
+                super::authority::AuthorityStatus::Active
+                    | super::authority::AuthorityStatus::Retiring
+                    | super::authority::AuthorityStatus::Retired
+            )
+            || !authority
+                .not_before
+                .is_some_and(|not_before| not_before <= now)
+            || !authority.not_after.is_some_and(|not_after| now < not_after)
+        {
+            return Err(AppError::bad_request(
+                "authority is not eligible for artifact signing",
+            ));
+        }
+        let material = managed_authority_material(authority, ca_keys)?;
+        Ok(Self {
+            certificate_pem: material.certificate_pem,
+            signing_key: material.signing_key,
         })
     }
 
@@ -286,6 +253,72 @@ impl PkiIssuer {
         let crl = params.signed_by(&signer).map_err(core_encoding_error)?;
         Ok(crl.der().to_vec())
     }
+}
+
+fn managed_authority_material(
+    authority: &AuthorityRecord,
+    ca_keys: &PkiCaKeyConfig,
+) -> Result<ManagedAuthorityMaterial, AppError> {
+    if authority.key_backend != AuthorityKeyBackend::EncryptedDatabase {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "managed authority key backend is not available"
+        )));
+    }
+    let certificate_pem =
+        required_authority_field(authority.certificate_pem.as_deref(), "certificate")?;
+    let chain_pem = required_authority_field(authority.chain_pem.as_deref(), "chain")?;
+    let certificate_der = one_certificate_der(certificate_pem, "issuer certificate")?;
+    let (_, certificate) = x509_parser::parse_x509_certificate(&certificate_der)
+        .map_err(|_| AppError::Internal(anyhow::anyhow!("stored invalid issuer certificate")))?;
+    validate_issuer_certificate(&certificate)?;
+    validate_chain(&certificate_der, chain_pem)?;
+
+    let fingerprint = hex::encode(digest::digest(&digest::SHA256, &certificate_der));
+    if authority.fingerprint_sha256.as_deref() != Some(&fingerprint)
+        || authority.not_before.map(|value| value.timestamp())
+            != Some(certificate.validity().not_before.timestamp())
+        || authority.not_after.map(|value| value.timestamp())
+            != Some(certificate.validity().not_after.timestamp())
+    {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "stored issuer metadata does not match its certificate"
+        )));
+    }
+
+    let context = AuthorityKeyContext {
+        authority_id: authority.id,
+        tenant_id: authority.tenant_id,
+        version: authority.version,
+    };
+    let provider = EncryptedDatabaseKeyProvider::new(ca_keys.clone());
+    let key =
+        EncryptedAuthorityKey::from_authority(authority).map_err(managed_key_provider_error)?;
+    let public = provider
+        .public_key(context, &key)
+        .map_err(managed_key_provider_error)?;
+    if public.subject_public_key_info_der != certificate.public_key().raw {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "managed authority key does not match its certificate"
+        )));
+    }
+    let public_key = PublicKey::from_public_key_der(&public.subject_public_key_info_der)
+        .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid managed authority key")))?;
+    let raw_public_key = public_key.to_encoded_point(false).as_bytes().to_vec();
+    let not_before = certificate.validity().not_before.to_datetime();
+    let not_after = certificate.validity().not_after.to_datetime();
+
+    Ok(ManagedAuthorityMaterial {
+        certificate_pem: pem_encode_certificate(&certificate_der),
+        chain_pem: chain_pem.to_string(),
+        signing_key: PkiSigningKey::EncryptedDatabase {
+            provider,
+            context,
+            key,
+            raw_public_key,
+        },
+        not_before,
+        not_after,
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -32,11 +32,21 @@ pub enum CertificateRenewalRequestClaim {
 
 #[derive(Debug, Clone, FromRow)]
 pub struct CrlState {
+    pub issuer_fingerprint_sha256: String,
     pub crl_number: i64,
     pub crl_der: Option<Vec<u8>>,
+    pub crl_sha256: Option<String>,
     pub this_update: Option<DateTime<Utc>>,
     pub next_update: Option<DateTime<Utc>>,
     pub dirty: bool,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct IssuerRevocationEntry {
+    pub credential_id: Uuid,
+    pub serial_number: String,
+    pub reason: String,
+    pub revoked_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, FromRow)]
@@ -621,7 +631,8 @@ pub async fn crl_state_tx(
 ) -> Result<CrlState, AppError> {
     sqlx::query(
         r#"
-        INSERT INTO certificate_crl_state (issuer_fingerprint_sha256, crl_number, dirty)
+        INSERT INTO certificate_crl_state
+            (issuer_fingerprint_sha256, crl_number, dirty)
         VALUES ($1, 0, TRUE)
         ON CONFLICT (issuer_fingerprint_sha256) DO NOTHING
         "#,
@@ -633,9 +644,11 @@ pub async fn crl_state_tx(
 
     sqlx::query_as::<_, CrlState>(
         r#"
-        SELECT crl_number, crl_der, this_update, next_update, dirty
+        SELECT issuer_fingerprint_sha256, crl_number, crl_der, crl_sha256,
+               this_update, next_update, dirty
         FROM certificate_crl_state
         WHERE issuer_fingerprint_sha256 = $1
+        FOR UPDATE
         "#,
     )
     .bind(issuer_fingerprint_sha256)
@@ -649,6 +662,7 @@ pub async fn store_crl_tx(
     issuer_fingerprint_sha256: &str,
     crl_number: i64,
     crl_der: &[u8],
+    crl_sha256: &str,
     this_update: DateTime<Utc>,
     next_update: DateTime<Utc>,
 ) -> Result<(), AppError> {
@@ -657,20 +671,138 @@ pub async fn store_crl_tx(
         UPDATE certificate_crl_state
         SET crl_number = $1,
             crl_der = $2,
-            this_update = $3,
-            next_update = $4,
+            crl_sha256 = $3,
+            this_update = $4,
+            next_update = $5,
             dirty = FALSE,
             updated_at = now()
-        WHERE issuer_fingerprint_sha256 = $5
+        WHERE issuer_fingerprint_sha256 = $6
         "#,
     )
     .bind(crl_number)
     .bind(crl_der)
+    .bind(crl_sha256)
     .bind(this_update)
     .bind(next_update)
     .bind(issuer_fingerprint_sha256)
     .execute(&mut **tx)
     .await
     .map_err(AppError::Database)?;
+    Ok(())
+}
+
+pub async fn issuer_crl_state(
+    pool: &PgPool,
+    issuer_id: Uuid,
+) -> Result<Option<CrlState>, AppError> {
+    sqlx::query_as::<_, CrlState>(
+        r#"
+        SELECT issuer_fingerprint_sha256, crl_number, crl_der, crl_sha256,
+               this_update, next_update, dirty
+        FROM certificate_crl_state
+        WHERE issuer_id = $1
+        "#,
+    )
+    .bind(issuer_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(AppError::Database)
+}
+
+pub async fn issuer_crl_state_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    issuer_id: Uuid,
+    issuer_fingerprint_sha256: &str,
+) -> Result<CrlState, AppError> {
+    let result = sqlx::query(
+        r#"
+        INSERT INTO certificate_crl_state
+            (issuer_fingerprint_sha256, issuer_id, crl_number, dirty)
+        VALUES ($1, $2, 0, TRUE)
+        ON CONFLICT (issuer_fingerprint_sha256) DO UPDATE
+        SET issuer_id = EXCLUDED.issuer_id,
+            updated_at = now()
+        WHERE certificate_crl_state.issuer_id IS NULL
+           OR certificate_crl_state.issuer_id = EXCLUDED.issuer_id
+        "#,
+    )
+    .bind(issuer_fingerprint_sha256)
+    .bind(issuer_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::conflict(
+            "CRL fingerprint is already assigned to another issuer",
+        ));
+    }
+
+    sqlx::query_as::<_, CrlState>(
+        r#"
+        SELECT issuer_fingerprint_sha256, crl_number, crl_der, crl_sha256,
+               this_update, next_update, dirty
+        FROM certificate_crl_state
+        WHERE issuer_id = $1
+        FOR UPDATE
+        "#,
+    )
+    .bind(issuer_id)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(AppError::Database)
+}
+
+pub async fn issuer_revocations_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    issuer_id: Uuid,
+) -> Result<Vec<IssuerRevocationEntry>, AppError> {
+    sqlx::query_as::<_, IssuerRevocationEntry>(
+        r#"
+        SELECT credential_id, serial_number, reason, revoked_at
+        FROM certificate_revocations
+        WHERE issuer_id = $1
+        ORDER BY revoked_at, credential_id
+        "#,
+    )
+    .bind(issuer_id)
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(AppError::Database)
+}
+
+pub async fn store_issuer_crl_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    issuer_id: Uuid,
+    crl_number: i64,
+    crl_der: &[u8],
+    crl_sha256: &str,
+    this_update: DateTime<Utc>,
+    next_update: DateTime<Utc>,
+) -> Result<(), AppError> {
+    let result = sqlx::query(
+        r#"
+        UPDATE certificate_crl_state
+        SET crl_number = $1,
+            crl_der = $2,
+            crl_sha256 = $3,
+            this_update = $4,
+            next_update = $5,
+            dirty = FALSE,
+            updated_at = now()
+        WHERE issuer_id = $6
+        "#,
+    )
+    .bind(crl_number)
+    .bind(crl_der)
+    .bind(crl_sha256)
+    .bind(this_update)
+    .bind(next_update)
+    .bind(issuer_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(AppError::Database)?;
+    if result.rows_affected() != 1 {
+        return Err(AppError::not_found("issuer CRL state not found"));
+    }
     Ok(())
 }

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -1559,7 +1559,7 @@ pub async fn issuer_crl(
         return Err(AppError::not_found("issuer is expired"));
     }
     let signer =
-        pki_core::PkiIssuer::from_managed_authority_for_artifacts(&authority, &config.pki_ca_keys)?;
+        pki_core::PkiArtifactSigner::from_managed_authority(&authority, &config.pki_ca_keys)?;
     let crl_der = signer.sign_crl(CertificateRevocationListParams {
         this_update,
         next_update,

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -35,6 +35,7 @@ use super::{
 };
 
 const CRL_REGEN_LOCK_ID: i64 = 0x0041_544f_4d43_524c;
+const ISSUER_CRL_LOCK_DOMAIN: i64 = 0x504b_4939_4352_4c00;
 const LEAF_CLOCK_SKEW_SECS: i64 = 300;
 const CRL_TTL_HOURS: i64 = 24;
 const SERIAL_INSERT_ATTEMPTS: usize = 3;
@@ -157,6 +158,16 @@ pub struct BulkCertificateRevocationResult {
     pub credential_ids: Vec<Uuid>,
     pub issuer_ids: Vec<Uuid>,
     pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrlArtifact {
+    pub der: Vec<u8>,
+    pub sha256: String,
+    pub crl_number: i64,
+    pub this_update: DateTime<Utc>,
+    pub next_update: DateTime<Utc>,
+    pub cache_hit: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1420,11 +1431,10 @@ pub async fn generate_crl(
 
     let state = repo::crl_state_tx(&mut tx, &loaded.issuer_fingerprint_sha256).await?;
     let now_chrono = Utc::now();
-    if !should_regenerate_crl(&state, now_chrono) {
-        if let Some(crl_der) = state.crl_der {
-            tx.commit().await.map_err(AppError::Database)?;
-            return Ok(crl_der);
-        }
+    if let Some(cached) = cached_crl_artifact(&state, &loaded.issuer_fingerprint_sha256, now_chrono)
+    {
+        tx.commit().await.map_err(AppError::Database)?;
+        return Ok(cached.der);
     }
 
     let revoked = repo::revoked_certificates(pool, &loaded.issuer_fingerprint_sha256).await?;
@@ -1454,17 +1464,132 @@ pub async fn generate_crl(
     .signed_by(&loaded.issuer)
     .map_err(rcgen_err)?;
     let crl_der = crl.der().as_ref().to_vec();
+    let crl_sha256 = sha256_hex(&crl_der);
     repo::store_crl_tx(
         &mut tx,
         &loaded.issuer_fingerprint_sha256,
         crl_number,
         &crl_der,
+        &crl_sha256,
         to_chrono(now)?,
         to_chrono(next_update)?,
     )
     .await?;
     tx.commit().await.map_err(AppError::Database)?;
     Ok(crl_der)
+}
+
+/// Generate or return a validator-ready CRL for one managed leaf issuer.
+/// Clean cache reads avoid the signing lock; dirty/missing/expired/corrupt
+/// entries serialize on an issuer-derived advisory lock and recheck state.
+pub async fn issuer_crl(
+    pool: &sqlx::PgPool,
+    config: &Config,
+    issuer_id: Uuid,
+) -> Result<CrlArtifact, AppError> {
+    let authority = authority_repo::authority_by_id(pool, issuer_id).await?;
+    validate_crl_authority_role(&authority)?;
+    let now = Utc::now();
+    let fingerprint = authority
+        .fingerprint_sha256
+        .as_deref()
+        .ok_or_else(|| AppError::not_found("issuer has no published certificate"))?;
+    let cached = match repo::issuer_crl_state(pool, issuer_id).await? {
+        Some(state) => cached_crl_artifact(&state, fingerprint, now),
+        None => None,
+    };
+    if let Some(cached) = cached {
+        validate_crl_authority_retention(&authority, true, now)?;
+        return Ok(cached);
+    }
+    validate_crl_authority_retention(&authority, false, now)?;
+
+    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let lock_id = issuer_crl_lock_id(issuer_id);
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(lock_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(AppError::Database)?;
+
+    // Hold the authority lifecycle row stable until signing and persistence
+    // commit. Retirement remains allowed for later requests, while revocation
+    // or expiry cannot race this publication operation.
+    let authority =
+        authority_repo::lock_authority_for_certificate_authentication(&mut tx, issuer_id).await?;
+    validate_crl_authority_role(&authority)?;
+    let now = Utc::now();
+    validate_crl_authority_retention(&authority, false, now)?;
+    let fingerprint = authority
+        .fingerprint_sha256
+        .as_deref()
+        .ok_or_else(|| AppError::not_found("issuer has no published certificate"))?;
+    let state = repo::issuer_crl_state_tx(&mut tx, issuer_id, fingerprint).await?;
+    if let Some(cached) = cached_crl_artifact(&state, fingerprint, now) {
+        tx.commit().await.map_err(AppError::Database)?;
+        return Ok(cached);
+    }
+
+    let revoked_certs = repo::issuer_revocations_tx(&mut tx, issuer_id)
+        .await?
+        .into_iter()
+        .map(|entry| {
+            Ok(RevokedCertParams {
+                serial_number: SerialNumber::from(serial_bytes(&entry.serial_number)?),
+                revocation_time: to_offset(entry.revoked_at)?,
+                reason_code: Some(crl_revocation_reason(&entry.reason)),
+                invalidity_date: None,
+            })
+        })
+        .collect::<Result<Vec<_>, AppError>>()?;
+    let crl_number = state
+        .crl_number
+        .checked_add(1)
+        .filter(|number| *number > 0)
+        .ok_or_else(|| AppError::conflict("issuer CRL number is exhausted"))?;
+    let this_update = OffsetDateTime::from_unix_timestamp(now.timestamp())
+        .map_err(|_| AppError::bad_request("invalid CRL timestamp"))?;
+    let desired_next_update = this_update + Duration::hours(CRL_TTL_HOURS);
+    let issuer_not_after = authority
+        .not_after
+        .ok_or_else(|| AppError::not_found("issuer has no validity window"))?;
+    let issuer_not_after = to_offset(issuer_not_after)?;
+    let next_update = desired_next_update.min(issuer_not_after);
+    if next_update <= this_update {
+        return Err(AppError::not_found("issuer is expired"));
+    }
+    let signer =
+        pki_core::PkiIssuer::from_managed_authority_for_artifacts(&authority, &config.pki_ca_keys)?;
+    let crl_der = signer.sign_crl(CertificateRevocationListParams {
+        this_update,
+        next_update,
+        crl_number: SerialNumber::from(crl_number as u64),
+        issuing_distribution_point: None,
+        revoked_certs,
+        key_identifier_method: KeyIdMethod::Sha256,
+    })?;
+    let crl_sha256 = sha256_hex(&crl_der);
+    let this_update = to_chrono(this_update)?;
+    let next_update = to_chrono(next_update)?;
+    repo::store_issuer_crl_tx(
+        &mut tx,
+        issuer_id,
+        crl_number,
+        &crl_der,
+        &crl_sha256,
+        this_update,
+        next_update,
+    )
+    .await?;
+    tx.commit().await.map_err(AppError::Database)?;
+    Ok(CrlArtifact {
+        der: crl_der,
+        sha256: crl_sha256,
+        crl_number,
+        this_update,
+        next_update,
+        cache_hit: false,
+    })
 }
 
 pub async fn ocsp_response(
@@ -2174,6 +2299,103 @@ fn should_regenerate_crl(state: &repo::CrlState, now: DateTime<Utc>) -> bool {
             .unwrap_or(true)
 }
 
+fn cached_crl_artifact(
+    state: &repo::CrlState,
+    issuer_fingerprint_sha256: &str,
+    now: DateTime<Utc>,
+) -> Option<CrlArtifact> {
+    if should_regenerate_crl(state, now) {
+        return None;
+    }
+    if state.issuer_fingerprint_sha256 != issuer_fingerprint_sha256 {
+        return None;
+    }
+    let der = state.crl_der.as_ref()?;
+    let sha256 = state.crl_sha256.as_ref()?;
+    if sha256_hex(der) != *sha256 {
+        return None;
+    }
+    let Ok((remaining, _)) = x509_parser::parse_x509_crl(der) else {
+        return None;
+    };
+    if !remaining.is_empty() {
+        return None;
+    }
+    Some(CrlArtifact {
+        der: der.clone(),
+        sha256: sha256.clone(),
+        crl_number: state.crl_number,
+        this_update: state.this_update?,
+        next_update: state.next_update?,
+        cache_hit: true,
+    })
+}
+
+fn validate_crl_authority_role(authority: &AuthorityRecord) -> Result<(), AppError> {
+    if authority.kind.can_issue_leaf_credentials() {
+        Ok(())
+    } else {
+        Err(AppError::not_found(
+            "authority role does not publish leaf certificate CRLs",
+        ))
+    }
+}
+
+fn validate_crl_authority_retention(
+    authority: &AuthorityRecord,
+    serving_cached: bool,
+    now: DateTime<Utc>,
+) -> Result<(), AppError> {
+    let status_allowed = matches!(
+        authority.status,
+        AuthorityStatus::Active | AuthorityStatus::Retiring | AuthorityStatus::Retired
+    );
+    let expired = authority.status == AuthorityStatus::Expired
+        || authority
+            .not_after
+            .map(|not_after| not_after <= now)
+            .unwrap_or(true);
+    if serving_cached
+        && (status_allowed || authority.status == AuthorityStatus::Expired)
+        && authority.status != AuthorityStatus::Revoked
+    {
+        return Ok(());
+    }
+    if status_allowed && !expired {
+        Ok(())
+    } else {
+        Err(AppError::not_found(
+            "authority has no publishable CRL for this lifecycle state",
+        ))
+    }
+}
+
+fn issuer_crl_lock_id(issuer_id: Uuid) -> i64 {
+    let bytes = issuer_id.as_bytes();
+    let first = i64::from_be_bytes(bytes[..8].try_into().expect("UUID first half"));
+    let second = i64::from_be_bytes(bytes[8..].try_into().expect("UUID second half"));
+    first ^ second ^ ISSUER_CRL_LOCK_DOMAIN
+}
+
+fn crl_revocation_reason(reason: &str) -> RevocationReason {
+    match reason {
+        "key_compromise" => RevocationReason::KeyCompromise,
+        "ca_compromise" => RevocationReason::CaCompromise,
+        "affiliation_changed" => RevocationReason::AffiliationChanged,
+        "superseded" => RevocationReason::Superseded,
+        "cessation_of_operation" => RevocationReason::CessationOfOperation,
+        "certificate_hold" => RevocationReason::CertificateHold,
+        "remove_from_crl" => RevocationReason::RemoveFromCrl,
+        "privilege_withdrawn" => RevocationReason::PrivilegeWithdrawn,
+        "aa_compromise" => RevocationReason::AaCompromise,
+        _ => RevocationReason::Unspecified,
+    }
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    hex::encode(digest::digest(&digest::SHA256, value).as_ref())
+}
+
 fn is_unique_violation(err: &AppError) -> bool {
     matches!(
         err,
@@ -2608,8 +2830,10 @@ mod tests {
     fn crl_cache_regenerates_only_when_dirty_missing_or_expired() {
         let now = Utc::now();
         let fresh = repo::CrlState {
+            issuer_fingerprint_sha256: "a".repeat(64),
             crl_number: 1,
             crl_der: Some(vec![1, 2, 3]),
+            crl_sha256: Some(sha256_hex(&[1, 2, 3])),
             this_update: Some(now),
             next_update: Some(now + chrono::Duration::hours(1)),
             dirty: false,
@@ -2627,6 +2851,50 @@ mod tests {
         let mut expired = fresh;
         expired.next_update = Some(now - chrono::Duration::seconds(1));
         assert!(should_regenerate_crl(&expired, now));
+    }
+
+    #[test]
+    fn crl_reason_codes_follow_rfc_5280_values() {
+        assert_eq!(
+            crl_revocation_reason("key_compromise"),
+            RevocationReason::KeyCompromise
+        );
+        assert_eq!(
+            crl_revocation_reason("ca_compromise"),
+            RevocationReason::CaCompromise
+        );
+        assert_eq!(
+            crl_revocation_reason("affiliation_changed"),
+            RevocationReason::AffiliationChanged
+        );
+        assert_eq!(
+            crl_revocation_reason("superseded"),
+            RevocationReason::Superseded
+        );
+        assert_eq!(
+            crl_revocation_reason("cessation_of_operation"),
+            RevocationReason::CessationOfOperation
+        );
+        assert_eq!(
+            crl_revocation_reason("certificate_hold"),
+            RevocationReason::CertificateHold
+        );
+        assert_eq!(
+            crl_revocation_reason("remove_from_crl"),
+            RevocationReason::RemoveFromCrl
+        );
+        assert_eq!(
+            crl_revocation_reason("privilege_withdrawn"),
+            RevocationReason::PrivilegeWithdrawn
+        );
+        assert_eq!(
+            crl_revocation_reason("aa_compromise"),
+            RevocationReason::AaCompromise
+        );
+        assert_eq!(
+            crl_revocation_reason("operator_specific_reason"),
+            RevocationReason::Unspecified
+        );
     }
 
     #[test]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -66,6 +66,10 @@ pub fn create_router(state: AppState) -> Router {
             get(certs::authority::http::trust_bundle),
         )
         .route("/certs/crl", get(certs::http::crl))
+        .route(
+            "/certs/issuers/:issuer_id/crl",
+            get(certs::http::issuer_crl),
+        )
         .route("/certs/ocsp", post(certs::http::ocsp))
         // GraphQL
         .route(

--- a/tests/m36_pki_issuer_crls.rs
+++ b/tests/m36_pki_issuer_crls.rs
@@ -1,0 +1,546 @@
+//! PR-009 per-issuer CRL generation, retention, caching, and interoperability.
+//!
+//! Requires PostgreSQL and OpenSSL. CI runs this ignored binary against its own
+//! freshly migrated database, single-threaded.
+
+mod common;
+
+use std::{fs, process::Command};
+
+use atom::{
+    certs::{
+        authority::{provisioning, repo as authority_repo, AuthorityStatus},
+        pki_core::PkiIssuer,
+        service,
+    },
+    routes::create_router,
+};
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use rcgen::{CertificateParams, DnType, KeyPair};
+use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+#[ignore]
+async fn per_issuer_crls_enforce_the_pr009_contract() {
+    let pool = common::pool().await;
+    let config = common::pki::managed_config(false, false);
+    let root = common::pki::test_root("PR-009 Offline Root");
+    let tenant_a = common::pki::create_tenant(&pool, "pki-crl-a").await;
+    let tenant_b = common::pki::create_tenant(&pool, "pki-crl-b").await;
+    let entity_a = common::pki::create_entity(&pool, tenant_a, "pki-crl-a").await;
+    let entity_b = common::pki::create_entity(&pool, tenant_b, "pki-crl-b").await;
+    let issuer_a = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let issuer_b = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_b).await;
+    let platform_leaf = common::pki::provision_platform_leaf_issuer(&pool, &config, &root).await;
+
+    // An empty CRL is signed by the exact leaf issuer, has bounded update
+    // times, and is reused without another signing/number increment.
+    let empty_a = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(empty_a.crl_number, 1);
+    assert!(!empty_a.cache_hit);
+    assert!(empty_a.next_update > empty_a.this_update);
+    assert!(crl_serials(&empty_a.der).is_empty());
+    assert_openssl_crl(
+        &empty_a.der,
+        issuer_a.certificate_pem.as_deref().unwrap(),
+        None,
+    );
+    let cached_a = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert!(cached_a.cache_hit);
+    assert_eq!(cached_a.crl_number, 1);
+    assert_eq!(cached_a.der, empty_a.der);
+
+    // Adopt a fingerprint-keyed row for the same physical Tenant B CA. The
+    // issuer-keyed representation must continue at 41, never restart at 1.
+    let issuer_b_fingerprint = issuer_b.fingerprint_sha256.as_deref().unwrap();
+    sqlx::query(
+        r#"INSERT INTO certificate_crl_state
+              (issuer_fingerprint_sha256, crl_number, dirty)
+           VALUES ($1, 40, TRUE)"#,
+    )
+    .bind(issuer_b_fingerprint)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let empty_b = service::issuer_crl(&pool, &config, issuer_b.id)
+        .await
+        .unwrap();
+    assert_eq!(empty_b.crl_number, 41);
+    assert!(crl_serials(&empty_b.der).is_empty());
+    let b_state_key: String =
+        sqlx::query_scalar("SELECT state_key FROM certificate_crl_state WHERE issuer_id = $1")
+            .bind(issuer_b.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(b_state_key, format!("issuer:{}", issuer_b.id));
+
+    // The platform leaf issuer publishes too; roots and platform
+    // intermediates never expose leaf-credential CRLs.
+    let platform_crl = service::issuer_crl(&pool, &config, platform_leaf.id)
+        .await
+        .unwrap();
+    assert!(crl_serials(&platform_crl.der).is_empty());
+    assert_openssl_crl(
+        &platform_crl.der,
+        platform_leaf.certificate_pem.as_deref().unwrap(),
+        None,
+    );
+    for authority_id in non_leaf_authority_ids(&pool).await {
+        let error = service::issuer_crl(&pool, &config, authority_id)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("does not publish"));
+    }
+
+    // Public HTTP delivery carries a stable validator and a bounded freshness
+    // lifetime. Conditional polling returns 304 with no body.
+    let app = create_router(common::pki::graphql_state(pool.clone(), config.clone()));
+    // This managed-only fixture deliberately has legacy certificates disabled;
+    // a 400 from the legacy handler (rather than the router's 404) proves the
+    // compatibility route remains registered.
+    let legacy_route = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/certs/crl")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(legacy_route.status(), StatusCode::BAD_REQUEST);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "application/pkix-crl"
+    );
+    assert!(response.headers()[header::CACHE_CONTROL]
+        .to_str()
+        .unwrap()
+        .starts_with("public, max-age="));
+    let etag = response.headers()[header::ETAG]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+        empty_a.der
+    );
+    let not_modified = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
+                .header(header::IF_NONE_MATCH, etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+    assert!(to_bytes(not_modified.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .is_empty());
+
+    let key_compromise = issue_managed(&pool, &config, tenant_a, entity_a, "key-compromise").await;
+    revoke(
+        &pool,
+        key_compromise.credential_id,
+        entity_a,
+        tenant_a,
+        "key_compromise",
+    )
+    .await;
+    let revoked_a = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(revoked_a.crl_number, 2);
+    assert_eq!(
+        crl_serials(&revoked_a.der),
+        vec![hex::decode(&key_compromise.serial_number).unwrap()]
+    );
+    let openssl_text = assert_openssl_crl(
+        &revoked_a.der,
+        issuer_a.certificate_pem.as_deref().unwrap(),
+        Some("key compromise"),
+    );
+    assert!(openssl_text.to_ascii_lowercase().contains("crl number"));
+
+    // Tenant A dirtiness does not touch Tenant B's cached bytes or number.
+    let still_b = service::issuer_crl(&pool, &config, issuer_b.id)
+        .await
+        .unwrap();
+    assert!(still_b.cache_hit);
+    assert_eq!(still_b.crl_number, 41);
+    assert_eq!(still_b.der, empty_b.der);
+    assert_openssl_rejects_crl(&revoked_a.der, issuer_b.certificate_pem.as_deref().unwrap());
+
+    let superseded = issue_managed(&pool, &config, tenant_a, entity_a, "superseded").await;
+    revoke(
+        &pool,
+        superseded.credential_id,
+        entity_a,
+        tenant_a,
+        "superseded",
+    )
+    .await;
+    let numbered = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(numbered.crl_number, 3);
+    assert_eq!(crl_serials(&numbered.der).len(), 2);
+
+    // Concurrent replicas share an issuer-scoped lock. Exactly one request
+    // advances the number; all callers observe the same committed artifact.
+    let concurrent = issue_managed(&pool, &config, tenant_a, entity_a, "concurrent").await;
+    revoke(
+        &pool,
+        concurrent.credential_id,
+        entity_a,
+        tenant_a,
+        "cessation_of_operation",
+    )
+    .await;
+    let mut tasks = Vec::new();
+    let concurrent_issuer_id = issuer_a.id;
+    for _ in 0..8 {
+        let pool = pool.clone();
+        let config = config.clone();
+        tasks.push(tokio::spawn(async move {
+            service::issuer_crl(&pool, &config, concurrent_issuer_id)
+                .await
+                .unwrap()
+        }));
+    }
+    let mut concurrent_results = Vec::new();
+    for task in tasks {
+        concurrent_results.push(task.await.unwrap());
+    }
+    assert!(concurrent_results
+        .iter()
+        .all(|artifact| artifact.crl_number == 4));
+    assert!(concurrent_results
+        .iter()
+        .all(|artifact| artifact.der == concurrent_results[0].der));
+
+    // Corrupt bytes with a matching cache hash still fail ASN.1 validation and
+    // are regenerated from durable revocation state. A subsequent call models
+    // a process restart and reuses the repaired database artifact.
+    sqlx::query(
+        r#"UPDATE certificate_crl_state
+           SET crl_der = decode('010203', 'hex'),
+               crl_sha256 = encode(digest(decode('010203', 'hex'), 'sha256'), 'hex'),
+               dirty = FALSE,
+               next_update = now() + interval '1 hour'
+           WHERE issuer_id = $1"#,
+    )
+    .bind(issuer_a.id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let repaired = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(repaired.crl_number, 5);
+    assert!(!repaired.cache_hit);
+    assert_eq!(crl_serials(&repaired.der).len(), 3);
+    let after_restart = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert!(after_restart.cache_hit);
+    assert_eq!(after_restart.der, repaired.der);
+
+    // Rotation retains old-authority publication. One old leaf is revoked
+    // while the issuer is retiring and another after it is retired; neither
+    // lifecycle state can issue a new leaf, but both can sign their own CRL.
+    let retiring_leaf = issue_managed(&pool, &config, tenant_a, entity_a, "retiring").await;
+    let retired_leaf = issue_managed(&pool, &config, tenant_a, entity_a, "retired").await;
+    let issuer_a_v2 = common::pki::rotate_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let old = authority_repo::authority_by_id(&pool, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(old.status, AuthorityStatus::Retiring);
+    assert!(PkiIssuer::from_managed_authority(&old, &config.pki_ca_keys).is_err());
+    revoke(
+        &pool,
+        retiring_leaf.credential_id,
+        entity_a,
+        tenant_a,
+        "certificate_hold",
+    )
+    .await;
+    let retiring_crl = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(retiring_crl.crl_number, 6);
+    assert!(crl_contains(
+        &retiring_crl.der,
+        &retiring_leaf.serial_number
+    ));
+
+    let mut tx = pool.begin().await.unwrap();
+    provisioning::complete_retirement_in_tx(&mut tx, issuer_a.id)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    let old = authority_repo::authority_by_id(&pool, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(old.status, AuthorityStatus::Retired);
+    revoke(
+        &pool,
+        retired_leaf.credential_id,
+        entity_a,
+        tenant_a,
+        "privilege_withdrawn",
+    )
+    .await;
+    let retired_crl = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(retired_crl.crl_number, 7);
+    assert!(crl_contains(&retired_crl.der, &retired_leaf.serial_number));
+    assert_openssl_crl(
+        &retired_crl.der,
+        issuer_a.certificate_pem.as_deref().unwrap(),
+        Some("privilege withdrawn"),
+    );
+
+    let new_leaf = issue_managed(&pool, &config, tenant_a, entity_a, "new-issuer").await;
+    assert_eq!(new_leaf.issuer_id, Some(issuer_a_v2.id));
+    revoke(
+        &pool,
+        new_leaf.credential_id,
+        entity_a,
+        tenant_a,
+        "affiliation_changed",
+    )
+    .await;
+    let new_crl = service::issuer_crl(&pool, &config, issuer_a_v2.id)
+        .await
+        .unwrap();
+    assert_eq!(new_crl.crl_number, 1);
+    assert_eq!(
+        crl_serials(&new_crl.der),
+        vec![hex::decode(&new_leaf.serial_number).unwrap()]
+    );
+    assert!(!crl_contains(&new_crl.der, &retired_leaf.serial_number));
+    assert_openssl_crl(
+        &new_crl.der,
+        issuer_a_v2.certificate_pem.as_deref().unwrap(),
+        Some("affiliation changed"),
+    );
+    assert_openssl_rejects_crl(&new_crl.der, issuer_a.certificate_pem.as_deref().unwrap());
+
+    // Expired issuers may serve an already-valid retained artifact, but they
+    // cannot regenerate or sign after that artifact is invalidated.
+    sqlx::query(
+        "UPDATE pki_authorities SET status = 'expired', issuance_enabled = FALSE WHERE id = $1",
+    )
+    .bind(issuer_a_v2.id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let retained_expired = service::issuer_crl(&pool, &config, issuer_a_v2.id)
+        .await
+        .unwrap();
+    assert!(retained_expired.cache_hit);
+    assert_eq!(retained_expired.der, new_crl.der);
+    sqlx::query("UPDATE certificate_crl_state SET dirty = TRUE WHERE issuer_id = $1")
+        .bind(issuer_a_v2.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let expired_error = service::issuer_crl(&pool, &config, issuer_a_v2.id)
+        .await
+        .unwrap_err();
+    assert!(expired_error.to_string().contains("no publishable CRL"));
+
+    // Tenant B can independently revoke and publish without changing any old
+    // or new Tenant A artifact.
+    let b_leaf = issue_managed(&pool, &config, tenant_b, entity_b, "tenant-b").await;
+    revoke(
+        &pool,
+        b_leaf.credential_id,
+        entity_b,
+        tenant_b,
+        "affiliation_changed",
+    )
+    .await;
+    let changed_b = service::issuer_crl(&pool, &config, issuer_b.id)
+        .await
+        .unwrap();
+    assert_eq!(changed_b.crl_number, 42);
+    assert_eq!(
+        crl_serials(&changed_b.der),
+        vec![hex::decode(&b_leaf.serial_number).unwrap()]
+    );
+    assert_eq!(
+        service::issuer_crl(&pool, &config, issuer_a.id)
+            .await
+            .unwrap()
+            .der,
+        retired_crl.der
+    );
+}
+
+async fn issue_managed(
+    pool: &PgPool,
+    config: &atom::config::Config,
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    key: &str,
+) -> service::CertificateRecord {
+    service::issue_certificate_from_csr_v2(
+        pool,
+        config,
+        Some(tenant_id),
+        service::IssueCertificateFromCsrV2 {
+            entity_id,
+            ttl_secs: Some(3600),
+            csr_pem: csr(),
+            idempotency_key: format!("pr009-{key}"),
+        },
+    )
+    .await
+    .unwrap()
+    .certificate
+}
+
+async fn revoke(
+    pool: &PgPool,
+    credential_id: Uuid,
+    entity_id: Uuid,
+    tenant_id: Uuid,
+    reason: &str,
+) {
+    service::revoke_certificate_v2(
+        pool,
+        service::RevokeCertificateV2 {
+            selector: service::CertificateRevocationSelector::CredentialId(credential_id),
+            reason: Some(reason.to_string()),
+            actor_entity_id: Some(common::admin_id()),
+            expected_entity_id: entity_id,
+            expected_tenant_id: Some(tenant_id),
+        },
+    )
+    .await
+    .unwrap();
+}
+
+fn csr() -> String {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "pr009-device");
+    params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
+    params.not_after = OffsetDateTime::now_utc() + Duration::hours(2);
+    params.serialize_request(&key).unwrap().pem().unwrap()
+}
+
+fn crl_serials(der: &[u8]) -> Vec<Vec<u8>> {
+    let (remaining, crl) = x509_parser::parse_x509_crl(der).unwrap();
+    assert!(remaining.is_empty());
+    crl.iter_revoked_certificates()
+        .map(|certificate| certificate.raw_serial().to_vec())
+        .collect()
+}
+
+fn crl_contains(der: &[u8], serial_number: &str) -> bool {
+    let serial = hex::decode(serial_number).unwrap();
+    crl_serials(der)
+        .iter()
+        .any(|candidate| candidate == &serial)
+}
+
+async fn non_leaf_authority_ids(pool: &PgPool) -> Vec<Uuid> {
+    sqlx::query_scalar(
+        "SELECT id FROM pki_authorities
+         WHERE kind IN ('root', 'platform_intermediate') ORDER BY kind",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap()
+}
+
+fn assert_openssl_crl(der: &[u8], issuer_pem: &str, expected_reason: Option<&str>) -> String {
+    let directory = std::env::temp_dir().join(format!("atom-pr009-crl-{}", Uuid::new_v4()));
+    fs::create_dir_all(&directory).unwrap();
+    let crl_path = directory.join("issuer.crl");
+    let issuer_path = directory.join("issuer.pem");
+    fs::write(&crl_path, der).unwrap();
+    fs::write(&issuer_path, issuer_pem).unwrap();
+    let output = Command::new("openssl")
+        .args(["crl", "-inform", "DER", "-in"])
+        .arg(&crl_path)
+        .arg("-CAfile")
+        .arg(&issuer_path)
+        .args(["-noout", "-verify", "-text"])
+        .output()
+        .expect("OpenSSL must be installed for PR-009 verification");
+    fs::remove_dir_all(directory).unwrap();
+    assert!(
+        output.status.success(),
+        "OpenSSL CRL verification failed: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(text.to_ascii_lowercase().contains("verify ok"));
+    if let Some(reason) = expected_reason {
+        assert!(
+            text.to_ascii_lowercase()
+                .contains(&reason.to_ascii_lowercase()),
+            "missing CRL reason {reason}: {text}"
+        );
+    }
+    text
+}
+
+fn assert_openssl_rejects_crl(der: &[u8], wrong_issuer_pem: &str) {
+    let directory = std::env::temp_dir().join(format!("atom-pr009-wrong-{}", Uuid::new_v4()));
+    fs::create_dir_all(&directory).unwrap();
+    let crl_path = directory.join("issuer.crl");
+    let issuer_path = directory.join("wrong-issuer.pem");
+    fs::write(&crl_path, der).unwrap();
+    fs::write(&issuer_path, wrong_issuer_pem).unwrap();
+    let output = Command::new("openssl")
+        .args(["crl", "-inform", "DER", "-in"])
+        .arg(&crl_path)
+        .arg("-CAfile")
+        .arg(&issuer_path)
+        .args(["-noout", "-verify"])
+        .output()
+        .expect("OpenSSL must be installed for PR-009 verification");
+    fs::remove_dir_all(directory).unwrap();
+    assert!(
+        !output.status.success(),
+        "wrong issuer unexpectedly verified CRL"
+    );
+}

--- a/tests/m36_pki_issuer_crls.rs
+++ b/tests/m36_pki_issuer_crls.rs
@@ -282,6 +282,18 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         .unwrap();
     assert_eq!(old.status, AuthorityStatus::Retiring);
     assert!(PkiIssuer::from_managed_authority(&old, &config.pki_ca_keys).is_err());
+    // Retained artifact signing must not depend on discovery-route metadata
+    // added after the original authority could have been provisioned.
+    sqlx::query(
+        r#"UPDATE pki_authorities
+           SET ocsp_url = NULL, ca_issuers_url = NULL,
+               crl_distribution_point_url = NULL
+           WHERE id = $1"#,
+    )
+    .bind(issuer_a.id)
+    .execute(&pool)
+    .await
+    .unwrap();
     revoke(
         &pool,
         retiring_leaf.credential_id,


### PR DESCRIPTION
## Objective

Implement PR-009 per-issuer, standards-compliant CRL publication while preserving the legacy file-issuer artifact and every retired issuer's retained CRL.

## Dependencies

- PR-008: merged into `certificates` as #53 (`e89670fe27d4ae6912a16d7a0808b9084931a0ea`).
- This branch is based directly on that merge commit.

## Changes

- Adds issuer-keyed CRL state with a database-generated compatibility key, durable cache hashes, and migration/adoption of legacy fingerprint state without resetting the CRL number.
- Adds exact-issuer revocation queries, RFC 5280 reason-code encoding, lifecycle-aware publication, issuer-scoped advisory locking, and cache validation/regeneration.
- Adds a restricted artifact-only signer over the existing opaque authority key provider. It allows valid active/retiring/retired leaf issuers, cannot be used for leaf issuance, and does not require discovery metadata that older retained issuers may lack.
- Adds public `GET /certs/issuers/{issuer_id}/crl` delivery with DER content type, ETag, bounded cache lifetime, and conditional 304 responses.
- Preserves `GET /certs/crl` for the legacy file issuer.
- Documents rotation, expiry, caching, and the role of CRLs as compliance/interoperability artifacts rather than Atom's primary revocation control.

## Acceptance criteria validation

- [x] Tenant A revocation never changes Tenant B CRL — exact `issuer_id` ledger query; integration test asserts Tenant B's number and DER remain unchanged.
- [x] CRL signature verifies under the exact issuer — artifact signer plus positive exact-issuer and negative wrong-issuer OpenSSL verification.
- [x] Root/platform non-leaf authorities do not expose leaf CRLs — authority-kind gate and integration assertions; the platform leaf issuer remains eligible.
- [x] Retiring/retired issuers publish but cannot issue new leaves — distinct artifact-only signer and rotation test, including a retained issuer with discovery URLs removed.
- [x] Cache invalidation/regeneration survives restart — database-backed hash/timestamps/dirty state; corrupt DER is regenerated and a later call reuses the repaired durable artifact.
- [x] CRL numbers never decrease across state cutover — the fingerprint row is adopted in place; integration test continues 40 to 41.
- [x] Recorded reasons appear in entries — complete RFC mapping unit test plus independent OpenSSL reason assertions.
- [x] Legacy global route remains — route is unchanged and explicitly exercised.
- [x] Operator documentation states CRLs are compliance/interoperability artifacts; immediate resolver denial plus short lifetimes remain primary.

## Mandatory tests

All passed in Rust workflow run #294 on head `c64836fb117f8761fdc2d199594db950c65c1c3e`:

- [x] Empty CRL.
- [x] Revoked entries.
- [x] Reason codes.
- [x] Number increment and fingerprint-to-issuer cutover monotonicity.
- [x] Eight concurrent requests sharing one issuer-scoped generation.
- [x] Rotation with independently retained old/new CRLs.
- [x] Expired issuer cached-serving/no-regeneration policy.
- [x] Cache corruption and durable recovery.
- [x] Positive and wrong-issuer OpenSSL verification.
- [x] Cross-issuer exclusion and independent dirtiness.

The dedicated `m36_pki_issuer_crls` binary passed: 1 passed, 0 failed. The workflow also ran all existing test binaries against separately recreated databases; all passed.

## Additional validation

Passed locally:

- `rustfmt --check --edition 2021 src/certs/repo.rs src/certs/pki_core.rs src/certs/service.rs src/certs/http.rs src/routes.rs tests/m36_pki_issuer_crls.rs`
- `git diff --check`
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm run build`
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm audit --prod --audit-level high` (exit 0; one moderate advisory, below the configured high threshold)

Passed in repository CI:

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --no-run --locked`
- `cargo test <target> -- --include-ignored --test-threads=1` for the library and every eligible integration binary, each against a fresh PostgreSQL database
- API Docs workflow run #235

## Non-goals

- No delta CRLs.
- No OCSP implementation (PR-010).
- No unrelated API or authority lifecycle redesign.

## Compatibility and risks

- The legacy route and fingerprint lookup remain operational.
- `state_key` is database-generated, so existing legacy inserts remain compatible while managed rows are keyed by issuer UUID.
- Existing cached DER is backfilled with SHA-256; corrupt or stale cache data is regenerated from immutable revocation evidence.
- Retiring and retired keys remain usable only through a signer type that exposes publication signing, not leaf issuance. Revoked, expired, provisioning, pending, failed, non-leaf, and out-of-validity authorities cannot regenerate.
- The CRL transaction and issuer row lock ensure a concurrent revocation is either included immediately or leaves the just-published artifact dirty for the next request.
- No private key, CSR, certificate signing material, credentials, or tenant secrets are logged or newly exposed.
