### PR TITLE
[PKI PR-010] Implement per-issuer OCSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,12 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1_der"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +420,8 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "const-oid",
+ "der",
  "dotenvy",
  "hex",
  "insta",
@@ -437,7 +433,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "minijinja",
- "ocsp",
  "openidconnect",
  "p256",
  "prost",
@@ -447,6 +442,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "spki",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -459,6 +455,8 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "x509-cert",
+ "x509-ocsp",
  "x509-parser",
  "zeroize",
 ]
@@ -2615,21 +2613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ocsp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef2010711f55f8ed2627630936202af42741336bc1ceaf1b0b256e02e821f18"
-dependencies = [
- "asn1_der",
- "chrono",
- "hex",
- "lazy_static",
- "thiserror 1.0.69",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4633,16 +4616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5462,6 +5435,18 @@ dependencies = [
  "const-oid",
  "der",
  "spki",
+]
+
+[[package]]
+name = "x509-ocsp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e54e695a31f0fecb826cf59ae2093c941d7ef932a1f8508185dd23b29ce2e2e"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = "1"
 jsonschema = { version = "0.18", default-features = false }
 uuid = { version = "1", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+const-oid = { version = "0.9", features = ["db"] }
+der = { version = "0.7", features = ["alloc", "derive", "oid"] }
 jsonwebtoken = "9"
 openidconnect = "4.0.1"
 argon2 = { version = "0.5", features = ["std"] }
@@ -42,9 +44,11 @@ lettre = { version = "0.11.21", default-features = false, features = ["builder",
 minijinja = { version = "2", default-features = false, features = ["serde"] }
 url = "2"
 rcgen = { version = "0.14.8", features = ["pem", "x509-parser", "aws_lc_rs"] }
-ocsp = "0.4.0"
 ring = "0.17"
+spki = { version = "0.7", features = ["alloc"] }
 time = "0.3"
+x509-cert = "0.2"
+x509-ocsp = "0.2.1"
 x509-parser = "0.18.1"
 yasna = "0.6"
 zeroize = "1"

--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -205,10 +205,11 @@ as unusable, disable or revoke it, and perform a new bootstrap; they must never
 log response bodies while investigating.
 
 This route is gated by `ATOM_PKI_GENERATED_KEY_ISSUANCE_ENABLED`, which defaults
-to `false` in code, examples, and Compose. Keep it disabled in production until
-PR-010 completes per-issuer CRL and OCSP publication. The legacy
-`issueCertificate` mutation remains available as the explicit v1 migration
-path and is not silently redirected to managed authorities.
+to `false` in code, examples, and Compose. Per-issuer CRL and OCSP publication
+is available; operators may enable generated-key bootstrap only after verifying
+that every relying party consumes the managed issuer URLs and trust bundle. The
+legacy `issueCertificate` mutation remains available as the explicit v1
+migration path and is not silently redirected to managed authorities.
 
 ## Issuer-aware renewal (v2)
 
@@ -349,6 +350,37 @@ credential and subject state. Deployments should combine that resolver denial
 with short certificate lifetimes instead of waiting for a relying party's next
 CRL poll.
 
+## Per-issuer OCSP
+
+Each managed leaf issuer answers DER OCSP requests at
+`POST /certs/issuers/{issuer_id}/ocsp`. The responder accepts SHA-1 and SHA-256
+CertIDs, resolves the exact issuer plus serial, and returns signed `good`,
+`revoked`, or `unknown` status. A serial issued by another authority is always
+`unknown`. Revoked responses carry the immutable revocation time and the
+recorded RFC 5280 reason.
+
+Responses are signed directly by the route issuer and embed its validated chain
+to the retained root. The signature algorithm identifier is selected from the
+actual signing key. `retiring` and `retired` issuers remain available until
+their certificate expires, so relying parties must retain old issuer URLs and
+trust material for their full validation window. Atom does not use a delegated
+OCSP responder in this release.
+
+`producedAt` and `thisUpdate` describe the current database evaluation;
+`nextUpdate` is no more than five minutes later and never exceeds issuer expiry.
+Responses use `Cache-Control: no-store, max-age=0`, because revocation becomes
+authoritative immediately. A single request-level nonce of 1–32 bytes is
+echoed; absent nonces stay absent. Unsupported hashes, malformed DER, duplicate
+or misplaced nonces, more than 16 CertIDs, and requests larger than 16 KiB are
+rejected with bounded processing. Unknown issuer identifiers produce the same
+RFC `unauthorized` response without tenant detail.
+
+The original `POST /certs/ocsp` endpoint remains the compatibility route for
+the configured file-backed v1 issuer. It now uses the same bounded parser,
+nonce policy, response timing, and key-derived signature encoding, but it keeps
+the legacy global-serial data model. Managed certificates and all new
+integrations must use the per-issuer endpoint carried in the certificate AIA.
+
 ## Legacy CA files
 
 The original v1 issuer remains available for backward compatibility and loads
@@ -402,6 +434,7 @@ GET  /certs/trust-bundle.pem
 GET  /certs/crl
 GET  /certs/issuers/{issuer_id}/crl
 POST /certs/ocsp
+POST /certs/issuers/{issuer_id}/ocsp
 ```
 
 `/certs/trust-bundle.pem` is assembled from current database authority state on
@@ -412,7 +445,8 @@ Atom restart.
 
 `/certs/crl` remains the compatibility route for the legacy file-backed issuer.
 Managed-authority clients should use the issuer-specific route carried by their
-certificate's CRL distribution point.
+certificate's CRL distribution point. Likewise, `/certs/ocsp` is the legacy
+file-backed route; managed clients use their issuer-specific AIA URL.
 
 ## Runtime Lookup
 

--- a/docs/content/docs/authentication/index.mdx
+++ b/docs/content/docs/authentication/index.mdx
@@ -37,6 +37,8 @@ GET  /.well-known/jwks.json
 GET  /certs/ca-chain
 GET  /certs/crl
 POST /certs/ocsp
+GET  /certs/issuers/{issuer_id}/crl
+POST /certs/issuers/{issuer_id}/ocsp
 ```
 
 All other endpoints require a valid Bearer token. Public signup creates a

--- a/product-docs/development/pki/pr-010-ocsp.md
+++ b/product-docs/development/pki/pr-010-ocsp.md
@@ -1,5 +1,9 @@
 # PR-010 — Per-Issuer OCSP
 
+## Status
+
+Implemented by the PR-010 delivery branch.
+
 ## Objective
 
 Provide standards-compliant OCSP good, revoked, and unknown responses for tenant issuers.

--- a/src/certs/http.rs
+++ b/src/certs/http.rs
@@ -83,18 +83,52 @@ pub async fn ocsp(State(state): State<AppState>, body: Bytes) -> Result<Response
     .await
     {
         Ok(der) => der,
-        Err(AppError::BadRequest(_)) => {
-            service::unsuccessful_ocsp(ocsp::response::OcspRespStatus::MalformedReq)?
+        Err(AppError::BadRequest(_)) | Err(AppError::PayloadTooLarge(_)) => {
+            service::unsuccessful_ocsp(x509_ocsp::OcspResponseStatus::MalformedRequest)?
+        }
+        Err(AppError::NotFound(_)) | Err(AppError::Unauthorized(_)) | Err(AppError::Forbidden) => {
+            service::unsuccessful_ocsp(x509_ocsp::OcspResponseStatus::Unauthorized)?
         }
         Err(err) => {
-            tracing::error!("OCSP response generation failed: {err}");
-            service::unsuccessful_ocsp(ocsp::response::OcspRespStatus::InternalError)?
+            tracing::error!(error = %err, "legacy OCSP response generation failed");
+            service::unsuccessful_ocsp(x509_ocsp::OcspResponseStatus::InternalError)?
         }
     };
+    ocsp_http_response(der)
+}
+
+pub async fn issuer_ocsp(
+    Path(issuer_id): Path<Uuid>,
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let der = match service::issuer_ocsp_response(&state.pool, &state.config, issuer_id, &body)
+        .await
+    {
+        Ok(der) => der,
+        Err(AppError::BadRequest(_)) | Err(AppError::PayloadTooLarge(_)) => {
+            service::unsuccessful_ocsp(x509_ocsp::OcspResponseStatus::MalformedRequest)?
+        }
+        Err(AppError::NotFound(_)) | Err(AppError::Unauthorized(_)) | Err(AppError::Forbidden) => {
+            service::unsuccessful_ocsp(x509_ocsp::OcspResponseStatus::Unauthorized)?
+        }
+        Err(err) => {
+            tracing::error!(issuer_id = %issuer_id, error = %err, "issuer OCSP response generation failed");
+            service::unsuccessful_ocsp(x509_ocsp::OcspResponseStatus::InternalError)?
+        }
+    };
+    ocsp_http_response(der)
+}
+
+fn ocsp_http_response(der: Vec<u8>) -> Result<Response, AppError> {
     let mut headers = HeaderMap::new();
     headers.insert(
         header::CONTENT_TYPE,
         HeaderValue::from_static("application/ocsp-response"),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, max-age=0"),
     );
     Ok((StatusCode::OK, headers, der).into_response())
 }

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -1256,7 +1256,7 @@ mod tests {
     }
 
     #[test]
-    fn artifact_signature_algorithm_is_derived_for_every_supported_key() {
+    fn artifact_signature_algorithm_maps_every_rcgen_variant() {
         let cases = [
             (&PKCS_RSA_SHA256, PkiSignatureAlgorithm::RsaPkcs1Sha256),
             (&PKCS_RSA_SHA384, PkiSignatureAlgorithm::RsaPkcs1Sha384),

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -12,7 +12,9 @@ use rcgen::{
     CertificateParams, CertificateRevocationListParams, CertificateSigningRequestParams,
     CrlDistributionPoint, CustomExtension, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
     KeyUsagePurpose, PublicKeyData, RsaKeySize, SanType, SerialNumber, SignatureAlgorithm,
-    SigningKey, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ED25519, PKCS_RSA_SHA256,
+    SigningKey, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ECDSA_P521_SHA256,
+    PKCS_ECDSA_P521_SHA384, PKCS_ECDSA_P521_SHA512, PKCS_ED25519, PKCS_RSA_SHA256, PKCS_RSA_SHA384,
+    PKCS_RSA_SHA512,
 };
 use ring::{digest, rand, rand::SecureRandom};
 use time::{Duration, OffsetDateTime};
@@ -103,7 +105,38 @@ pub struct PkiIssuer {
 /// certificate issuance helpers.
 pub struct PkiArtifactSigner {
     certificate_pem: String,
+    chain_pem: String,
     signing_key: PkiSigningKey,
+}
+
+/// Signature algorithm selected by the authority key itself. Consumers use
+/// this value to encode artifact signature identifiers without guessing from
+/// the certificate that signed the authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PkiSignatureAlgorithm {
+    RsaPkcs1Sha256,
+    RsaPkcs1Sha384,
+    RsaPkcs1Sha512,
+    EcdsaSha256,
+    EcdsaSha384,
+    EcdsaSha512,
+    Ed25519,
+}
+
+/// A signature produced through the restricted retained-artifact surface.
+pub struct PkiArtifactSignature {
+    algorithm: PkiSignatureAlgorithm,
+    bytes: Vec<u8>,
+}
+
+impl PkiArtifactSignature {
+    pub fn algorithm(&self) -> PkiSignatureAlgorithm {
+        self.algorithm
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
 }
 
 struct ManagedAuthorityMaterial {
@@ -243,6 +276,7 @@ impl PkiArtifactSigner {
         let material = managed_authority_material(authority, ca_keys)?;
         Ok(Self {
             certificate_pem: material.certificate_pem,
+            chain_pem: material.chain_pem,
             signing_key: material.signing_key,
         })
     }
@@ -253,6 +287,51 @@ impl PkiArtifactSigner {
         let crl = params.signed_by(&signer).map_err(core_encoding_error)?;
         Ok(crl.der().to_vec())
     }
+
+    /// Return the already-public, validated issuer chain for embedding in a
+    /// signed OCSP response. The first certificate is always the signer.
+    pub fn certificate_chain_der(&self) -> Result<Vec<Vec<u8>>, AppError> {
+        certificate_chain_der(&self.chain_pem)
+    }
+
+    /// Sign only the DER-encoded OCSP ResponseData value. This deliberately
+    /// does not expose the underlying CA key or a general certificate issuer.
+    pub fn sign_ocsp_response_data(
+        &self,
+        response_data_der: &[u8],
+    ) -> Result<PkiArtifactSignature, AppError> {
+        let algorithm = pki_signature_algorithm(self.signing_key.algorithm())?;
+        let bytes = self
+            .signing_key
+            .sign(response_data_der)
+            .map_err(core_encoding_error)?;
+        Ok(PkiArtifactSignature { algorithm, bytes })
+    }
+}
+
+pub(crate) fn pki_signature_algorithm(
+    algorithm: &SignatureAlgorithm,
+) -> Result<PkiSignatureAlgorithm, AppError> {
+    let algorithm = if algorithm == &PKCS_RSA_SHA256 {
+        PkiSignatureAlgorithm::RsaPkcs1Sha256
+    } else if algorithm == &PKCS_RSA_SHA384 {
+        PkiSignatureAlgorithm::RsaPkcs1Sha384
+    } else if algorithm == &PKCS_RSA_SHA512 {
+        PkiSignatureAlgorithm::RsaPkcs1Sha512
+    } else if algorithm == &PKCS_ECDSA_P256_SHA256 || algorithm == &PKCS_ECDSA_P521_SHA256 {
+        PkiSignatureAlgorithm::EcdsaSha256
+    } else if algorithm == &PKCS_ECDSA_P384_SHA384 || algorithm == &PKCS_ECDSA_P521_SHA384 {
+        PkiSignatureAlgorithm::EcdsaSha384
+    } else if algorithm == &PKCS_ECDSA_P521_SHA512 {
+        PkiSignatureAlgorithm::EcdsaSha512
+    } else if algorithm == &PKCS_ED25519 {
+        PkiSignatureAlgorithm::Ed25519
+    } else {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "unsupported authority signature algorithm"
+        )));
+    };
+    Ok(algorithm)
 }
 
 fn managed_authority_material(
@@ -1174,5 +1253,24 @@ mod tests {
         let private_key = generated.into_private_key_pem();
         let key_pair = KeyPair::from_pem(private_key.as_str()).unwrap();
         assert!(std::ptr::eq(key_pair.algorithm(), &PKCS_ECDSA_P384_SHA384));
+    }
+
+    #[test]
+    fn artifact_signature_algorithm_is_derived_for_every_supported_key() {
+        let cases = [
+            (&PKCS_RSA_SHA256, PkiSignatureAlgorithm::RsaPkcs1Sha256),
+            (&PKCS_RSA_SHA384, PkiSignatureAlgorithm::RsaPkcs1Sha384),
+            (&PKCS_RSA_SHA512, PkiSignatureAlgorithm::RsaPkcs1Sha512),
+            (&PKCS_ECDSA_P256_SHA256, PkiSignatureAlgorithm::EcdsaSha256),
+            (&PKCS_ECDSA_P384_SHA384, PkiSignatureAlgorithm::EcdsaSha384),
+            (&PKCS_ECDSA_P521_SHA256, PkiSignatureAlgorithm::EcdsaSha256),
+            (&PKCS_ECDSA_P521_SHA384, PkiSignatureAlgorithm::EcdsaSha384),
+            (&PKCS_ECDSA_P521_SHA512, PkiSignatureAlgorithm::EcdsaSha512),
+            (&PKCS_ED25519, PkiSignatureAlgorithm::Ed25519),
+        ];
+
+        for (algorithm, expected) in cases {
+            assert_eq!(pki_signature_algorithm(algorithm).unwrap(), expected);
+        }
     }
 }

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -1,12 +1,8 @@
-use chrono::{DateTime, Datelike, Timelike, Utc};
-use ocsp::{
-    common::asn1::{GeneralizedTime, Oid},
-    oid::{ALGO_SHA1_DOT, ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT, OCSP_RESPONSE_BASIC_DOT},
-    request::OcspRequest,
-    response::{
-        CertStatus, CertStatusCode, CrlReason, OcspRespStatus, OcspResponse, OneResp, ResponderId,
-        ResponseData, RevokedInfo,
-    },
+use chrono::{DateTime, Utc};
+use const_oid::{db::rfc6960::ID_PKIX_OCSP_NONCE, ObjectIdentifier};
+use der::{
+    asn1::{BitString, GeneralizedTime, Null, OctetString},
+    Decode, Encode,
 };
 use rcgen::{
     CertificateParams, CertificateRevocationListParams, CertificateSigningRequestParams, DnType,
@@ -16,10 +12,19 @@ use rcgen::{
 use ring::{digest, rand, rand::SecureRandom};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use spki::AlgorithmIdentifierOwned;
 use sqlx::Acquire;
 use std::fs;
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
+use x509_cert::{
+    ext::{pkix::CrlReason as X509CrlReason, Extension},
+    Certificate as X509Certificate,
+};
+use x509_ocsp::{
+    ext::Nonce, BasicOcspResponse, CertStatus, OcspGeneralizedTime, OcspRequest, OcspResponse,
+    OcspResponseStatus, ResponderId, ResponseData, RevokedInfo, SingleResponse, Version,
+};
 use x509_parser::pem::parse_x509_pem;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -39,6 +44,9 @@ const ISSUER_CRL_LOCK_DOMAIN: i64 = 0x504b_4939_4352_4c00;
 const LEAF_CLOCK_SKEW_SECS: i64 = 300;
 const CRL_TTL_HOURS: i64 = 24;
 const SERIAL_INSERT_ATTEMPTS: usize = 3;
+pub const OCSP_REQUEST_MAX_BYTES: usize = 16 * 1024;
+const OCSP_MAX_SINGLE_REQUESTS: usize = 16;
+const OCSP_VALIDITY_SECONDS: i64 = 300;
 
 #[derive(Debug, Clone)]
 pub struct IssueCertificate {
@@ -275,8 +283,6 @@ pub struct CertificateIssuer {
     issuer: Issuer<'static, KeyPair>,
     key_pair: KeyPair,
     certificate_der: Vec<u8>,
-    issuer_name_hash_sha1: Vec<u8>,
-    issuer_key_hash_sha1: Vec<u8>,
 }
 
 struct PersistCertificate {
@@ -377,7 +383,6 @@ fn build_issuer(
     let issuer =
         Issuer::from_ca_cert_pem(&cert.pem, KeyPair::from_pem(key_pem).map_err(rcgen_err)?)
             .map_err(rcgen_err)?;
-    let (issuer_name_hash_sha1, issuer_key_hash_sha1) = issuer_sha1_hashes_from_der(&cert.der)?;
     Ok(CertificateIssuer {
         issuer_kind,
         chain_pem,
@@ -388,8 +393,6 @@ fn build_issuer(
         issuer,
         key_pair,
         certificate_der: cert.der,
-        issuer_name_hash_sha1,
-        issuer_key_hash_sha1,
     })
 }
 
@@ -1599,61 +1602,133 @@ pub async fn ocsp_response(
     request_der: &[u8],
 ) -> Result<Vec<u8>, AppError> {
     let loaded = require_issuer(config, issuer)?;
-    let request = OcspRequest::parse(request_der)
-        .map_err(|_| AppError::bad_request("invalid OCSP request"))?;
+    let request = parse_ocsp_request(request_der)?;
+    let nonce = request_nonce(&request)?;
     let now = Utc::now();
-    let this_update = generalized_time(now)?;
-    let next_update = Some(generalized_time(now + chrono::Duration::hours(1))?);
-    let mut one_responses = Vec::with_capacity(request.tbs_request.request_list.len());
+    let next_update =
+        (now + chrono::Duration::seconds(OCSP_VALIDITY_SECONDS)).min(loaded.issuer_not_after);
+    if next_update <= now {
+        return Err(AppError::not_found("legacy OCSP issuer is expired"));
+    }
+    let this_update = ocsp_time(now)?;
+    let next_update = ocsp_time(next_update)?;
+    let mut responses = Vec::with_capacity(request.tbs_request.request_list.len());
     for one in &request.tbs_request.request_list {
-        let issuer_matches = certid_issuer_matches(
-            &one.certid,
-            &loaded.issuer_name_hash_sha1,
-            &loaded.issuer_key_hash_sha1,
-        )?;
+        let issuer_matches = certid_issuer_matches(&one.req_cert, &loaded.certificate_der)?;
         let status = if issuer_matches {
-            let serial = serial_from_ocsp_request(&one.certid.serial_num)?;
+            let serial = serial_from_ocsp_request(&one.req_cert)?;
             match repo::certificate_by_serial(pool, &serial).await {
-                Ok(cert) if cert.status == "active" => CertStatus::new(CertStatusCode::Good, None),
+                Ok(cert) if cert.status == "active" => CertStatus::good(),
                 Ok(cert) => {
                     let metadata = metadata_from_value(&cert.metadata)?;
                     let revoked_at = metadata.revoked_at.unwrap_or_else(Utc::now);
-                    CertStatus::new(
-                        CertStatusCode::Revoked,
-                        Some(RevokedInfo::new(
-                            generalized_time(revoked_at)?,
-                            Some(CrlReason::OcspRevokeUnspecified),
+                    CertStatus::revoked(RevokedInfo {
+                        revocation_time: ocsp_time(revoked_at)?,
+                        revocation_reason: Some(ocsp_revocation_reason(
+                            metadata
+                                .revocation_reason
+                                .as_deref()
+                                .unwrap_or("unspecified"),
                         )),
-                    )
+                    })
                 }
-                Err(AppError::NotFound(_)) => CertStatus::new(CertStatusCode::Unknown, None),
+                Err(AppError::NotFound(_)) => CertStatus::unknown(),
                 Err(err) => return Err(err),
             }
         } else {
-            CertStatus::new(CertStatusCode::Unknown, None)
+            CertStatus::unknown()
         };
-        one_responses.push(OneResp {
-            cid: one.certid.clone(),
+        responses.push(SingleResponse {
+            cert_id: one.req_cert.clone(),
             cert_status: status,
             this_update,
-            next_update,
-            one_resp_ext: None,
+            next_update: Some(next_update),
+            single_extensions: None,
         });
     }
+    let certificate_chain = certificate_chain_from_pem(&loaded.chain_pem)?;
+    encode_signed_ocsp(
+        certificate_chain,
+        responses,
+        nonce.as_deref(),
+        this_update,
+        |response_data_der| {
+            let algorithm = pki_core::pki_signature_algorithm(loaded.key_pair.algorithm())?;
+            let signature = loaded.key_pair.sign(response_data_der).map_err(rcgen_err)?;
+            Ok((algorithm, signature))
+        },
+    )
+}
 
-    let responder = ResponderId::new_key_hash(&loaded.issuer_key_hash_sha1);
-    let data = ResponseData::new(responder, this_update, one_responses, None);
-    let data_der = data.to_der().map_err(ocsp_err)?;
-    let signature = loaded.key_pair.sign(&data_der).map_err(rcgen_err)?;
-    let oid = Oid::new_from_dot(ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT).map_err(ocsp_err)?;
-    let response_type = Oid::new_from_dot(OCSP_RESPONSE_BASIC_DOT).map_err(ocsp_err)?;
-    let basic = basic_ocsp_response_der(
-        &data_der,
-        &oid,
-        &signature,
-        &[loaded.certificate_der.as_slice()],
-    )?;
-    successful_ocsp_response_der(&response_type, &basic)
+/// Build an issuer-scoped OCSP response from the exact issuer/serial identity.
+/// The request is parsed before issuer lookup so malformed input has identical
+/// behavior for known and unknown route identifiers.
+pub async fn issuer_ocsp_response(
+    pool: &sqlx::PgPool,
+    config: &Config,
+    issuer_id: Uuid,
+    request_der: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    let request = parse_ocsp_request(request_der)?;
+    let nonce = request_nonce(&request)?;
+    let authority = authority_repo::authority_by_id(pool, issuer_id).await?;
+    validate_ocsp_authority(&authority, Utc::now())?;
+    let signer =
+        pki_core::PkiArtifactSigner::from_managed_authority(&authority, &config.pki_ca_keys)
+            .map_err(|error| {
+                AppError::Internal(anyhow::anyhow!(
+                    "managed OCSP signer is unavailable: {error}"
+                ))
+            })?;
+    let certificate_chain = signer.certificate_chain_der().map_err(|error| {
+        AppError::Internal(anyhow::anyhow!(
+            "managed OCSP signer chain is unavailable: {error}"
+        ))
+    })?;
+    let issuer_der = certificate_chain
+        .first()
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("managed OCSP issuer chain is empty")))?;
+    let now = Utc::now();
+    let issuer_not_after = authority
+        .not_after
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("managed OCSP issuer has no expiry")))?;
+    let next_update =
+        (now + chrono::Duration::seconds(OCSP_VALIDITY_SECONDS)).min(issuer_not_after);
+    if next_update <= now {
+        return Err(AppError::not_found("OCSP responder is unavailable"));
+    }
+    let this_update = ocsp_time(now)?;
+    let next_update = ocsp_time(next_update)?;
+    let mut responses = Vec::with_capacity(request.tbs_request.request_list.len());
+    for one in &request.tbs_request.request_list {
+        let issuer_matches = certid_issuer_matches(&one.req_cert, issuer_der)?;
+        let cert_status = if issuer_matches {
+            let serial = serial_from_ocsp_request(&one.req_cert)?;
+            managed_ocsp_status(pool, issuer_id, &serial).await?
+        } else {
+            // A CertID for another issuer is deliberately indistinguishable
+            // from an unissued serial under this public responder.
+            CertStatus::unknown()
+        };
+        responses.push(SingleResponse {
+            cert_id: one.req_cert.clone(),
+            cert_status,
+            this_update,
+            next_update: Some(next_update),
+            single_extensions: None,
+        });
+    }
+    encode_signed_ocsp(
+        certificate_chain,
+        responses,
+        nonce.as_deref(),
+        this_update,
+        |response_data_der| {
+            let signature = signer.sign_ocsp_response_data(response_data_der)?;
+            let algorithm = signature.algorithm();
+            Ok((algorithm, signature.into_bytes()))
+        },
+    )
 }
 
 pub async fn resolve_certificate_identity(
@@ -2245,17 +2320,118 @@ fn certificate_der_from_pem(certificate_pem: &str) -> Result<Vec<u8>, AppError> 
         .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid certificate PEM")))
 }
 
-fn issuer_sha1_hashes_from_der(certificate_der: &[u8]) -> Result<(Vec<u8>, Vec<u8>), AppError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OcspHashAlgorithm {
+    Sha1,
+    Sha256,
+}
+
+const SHA1_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
+const SHA256_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.1");
+
+fn parse_ocsp_request(request_der: &[u8]) -> Result<OcspRequest, AppError> {
+    if request_der.is_empty() {
+        return Err(AppError::bad_request("empty OCSP request"));
+    }
+    if request_der.len() > OCSP_REQUEST_MAX_BYTES {
+        return Err(AppError::payload_too_large("OCSP request is too large"));
+    }
+    let request = OcspRequest::from_der(request_der)
+        .map_err(|_| AppError::bad_request("malformed OCSP request"))?;
+    if request.tbs_request.request_list.is_empty()
+        || request.tbs_request.request_list.len() > OCSP_MAX_SINGLE_REQUESTS
+    {
+        return Err(AppError::bad_request(
+            "OCSP request must contain between one and sixteen CertIDs",
+        ));
+    }
+    for one in &request.tbs_request.request_list {
+        if let Some(extensions) = &one.single_request_extensions {
+            for extension in extensions {
+                if extension.extn_id == ID_PKIX_OCSP_NONCE || extension.critical {
+                    return Err(AppError::bad_request(
+                        "unsupported OCSP single-request extension",
+                    ));
+                }
+            }
+        }
+        // Resolve the algorithm while the request is still in the bounded
+        // validation phase. This rejects unsupported hashes before any issuer
+        // or certificate lookup can reveal state.
+        ocsp_hash_algorithm(&one.req_cert)?;
+    }
+    if let Some(extensions) = &request.tbs_request.request_extensions {
+        for extension in extensions {
+            if extension.extn_id != ID_PKIX_OCSP_NONCE && extension.critical {
+                return Err(AppError::bad_request(
+                    "unsupported critical OCSP request extension",
+                ));
+            }
+        }
+    }
+    Ok(request)
+}
+
+fn request_nonce(request: &OcspRequest) -> Result<Option<Vec<u8>>, AppError> {
+    let Some(extensions) = &request.tbs_request.request_extensions else {
+        return Ok(None);
+    };
+    let mut nonce = None;
+    for extension in extensions
+        .iter()
+        .filter(|extension| extension.extn_id == ID_PKIX_OCSP_NONCE)
+    {
+        if nonce.is_some() {
+            return Err(AppError::bad_request("duplicate OCSP nonce extension"));
+        }
+        let decoded = Nonce::from_der(extension.extn_value.as_bytes())
+            .map_err(|_| AppError::bad_request("malformed OCSP nonce extension"))?;
+        let bytes = decoded.0.as_bytes();
+        if !(1..=32).contains(&bytes.len()) {
+            return Err(AppError::bad_request(
+                "OCSP nonce must contain between one and thirty-two bytes",
+            ));
+        }
+        nonce = Some(bytes.to_vec());
+    }
+    Ok(nonce)
+}
+
+fn ocsp_hash_algorithm(certid: &x509_ocsp::CertId) -> Result<OcspHashAlgorithm, AppError> {
+    let parameters_supported = match &certid.hash_algorithm.parameters {
+        None => true,
+        Some(parameters) => parameters
+            .to_der()
+            .map(|encoded| encoded.as_slice() == [0x05, 0x00])
+            .unwrap_or(false),
+    };
+    if !parameters_supported {
+        return Err(AppError::bad_request(
+            "unsupported OCSP hash algorithm parameters",
+        ));
+    }
+    match certid.hash_algorithm.oid {
+        SHA1_OID => Ok(OcspHashAlgorithm::Sha1),
+        SHA256_OID => Ok(OcspHashAlgorithm::Sha256),
+        _ => Err(AppError::bad_request("unsupported OCSP CertID hash")),
+    }
+}
+
+fn issuer_hashes_from_der(
+    certificate_der: &[u8],
+    algorithm: OcspHashAlgorithm,
+) -> Result<(Vec<u8>, Vec<u8>), AppError> {
     let (_, cert) = x509_parser::parse_x509_certificate(certificate_der)
         .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid issuer certificate DER")))?;
-    let name_hash = digest::digest(
-        &digest::SHA1_FOR_LEGACY_USE_ONLY,
-        cert.tbs_certificate.subject.as_raw(),
-    )
-    .as_ref()
-    .to_vec();
+    let digest_algorithm = match algorithm {
+        OcspHashAlgorithm::Sha1 => &digest::SHA1_FOR_LEGACY_USE_ONLY,
+        OcspHashAlgorithm::Sha256 => &digest::SHA256,
+    };
+    let name_hash = digest::digest(digest_algorithm, cert.tbs_certificate.subject.as_raw())
+        .as_ref()
+        .to_vec();
     let key_hash = digest::digest(
-        &digest::SHA1_FOR_LEGACY_USE_ONLY,
+        digest_algorithm,
         cert.tbs_certificate
             .subject_pki
             .subject_public_key
@@ -2267,27 +2443,91 @@ fn issuer_sha1_hashes_from_der(certificate_der: &[u8]) -> Result<(Vec<u8>, Vec<u
     Ok((name_hash, key_hash))
 }
 
-fn certid_issuer_matches(
-    certid: &ocsp::common::asn1::CertId,
-    issuer_name_hash_sha1: &[u8],
-    issuer_key_hash_sha1: &[u8],
-) -> Result<bool, AppError> {
-    let sha1 = Oid::new_from_dot(ALGO_SHA1_DOT).map_err(ocsp_err)?;
-    Ok(certid.hash_algo == sha1
-        && certid.issuer_name_hash == issuer_name_hash_sha1
-        && certid.issuer_key_hash == issuer_key_hash_sha1)
+fn certid_issuer_matches(certid: &x509_ocsp::CertId, issuer_der: &[u8]) -> Result<bool, AppError> {
+    let algorithm = ocsp_hash_algorithm(certid)?;
+    let (issuer_name_hash, issuer_key_hash) = issuer_hashes_from_der(issuer_der, algorithm)?;
+    Ok(certid.issuer_name_hash.as_bytes() == issuer_name_hash
+        && certid.issuer_key_hash.as_bytes() == issuer_key_hash)
 }
 
-fn serial_from_ocsp_request(serial: &[u8]) -> Result<String, AppError> {
-    let trimmed = serial
-        .iter()
-        .skip_while(|byte| **byte == 0)
-        .copied()
-        .collect::<Vec<_>>();
-    if trimmed.is_empty() {
+fn serial_from_ocsp_request(certid: &x509_ocsp::CertId) -> Result<String, AppError> {
+    let serial = certid.serial_number.as_bytes();
+    if serial.is_empty() {
         return Err(AppError::bad_request("invalid certificate serial number"));
     }
-    normalize_serial(&hex::encode(trimmed))
+    normalize_serial(&hex::encode(serial))
+}
+
+fn validate_ocsp_authority(
+    authority: &AuthorityRecord,
+    now: DateTime<Utc>,
+) -> Result<(), AppError> {
+    let lifecycle_retained = matches!(
+        authority.status,
+        AuthorityStatus::Active | AuthorityStatus::Retiring | AuthorityStatus::Retired
+    );
+    if !authority.kind.can_issue_leaf_credentials()
+        || !lifecycle_retained
+        || !authority.key_backend.can_sign()
+        || authority
+            .not_before
+            .is_none_or(|not_before| not_before > now)
+        || authority.not_after.is_none_or(|not_after| not_after <= now)
+    {
+        return Err(AppError::not_found("OCSP responder is unavailable"));
+    }
+    Ok(())
+}
+
+async fn managed_ocsp_status(
+    pool: &sqlx::PgPool,
+    issuer_id: Uuid,
+    serial_number: &str,
+) -> Result<CertStatus, AppError> {
+    let certificate = match repo::certificate_by_issuer_serial(pool, issuer_id, serial_number).await
+    {
+        Ok(certificate) => certificate,
+        Err(AppError::NotFound(_)) => return Ok(CertStatus::unknown()),
+        Err(error) => return Err(error),
+    };
+    match certificate.status.as_str() {
+        "active" => Ok(CertStatus::good()),
+        "revoked" => {
+            let revocation = repo::certificate_revocation_by_id(pool, certificate.id)
+                .await
+                .map_err(|error| {
+                    AppError::Internal(anyhow::anyhow!(
+                        "revoked certificate has no immutable revocation record: {error}"
+                    ))
+                })?;
+            if revocation.issuer_id != Some(issuer_id) || revocation.serial_number != serial_number
+            {
+                return Err(AppError::Internal(anyhow::anyhow!(
+                    "certificate revocation record does not match its issuer identity"
+                )));
+            }
+            Ok(CertStatus::revoked(RevokedInfo {
+                revocation_time: ocsp_time(revocation.revoked_at)?,
+                revocation_reason: Some(ocsp_revocation_reason(&revocation.reason)),
+            }))
+        }
+        _ => Ok(CertStatus::unknown()),
+    }
+}
+
+fn ocsp_revocation_reason(reason: &str) -> X509CrlReason {
+    match reason {
+        "key_compromise" => X509CrlReason::KeyCompromise,
+        "ca_compromise" => X509CrlReason::CaCompromise,
+        "affiliation_changed" => X509CrlReason::AffiliationChanged,
+        "superseded" => X509CrlReason::Superseded,
+        "cessation_of_operation" => X509CrlReason::CessationOfOperation,
+        "certificate_hold" => X509CrlReason::CertificateHold,
+        "remove_from_crl" => X509CrlReason::RemoveFromCRL,
+        "privilege_withdrawn" => X509CrlReason::PrivilegeWithdrawn,
+        "aa_compromise" => X509CrlReason::AaCompromise,
+        _ => X509CrlReason::Unspecified,
+    }
 }
 
 fn should_regenerate_crl(state: &repo::CrlState, now: DateTime<Utc>) -> bool {
@@ -2435,16 +2675,12 @@ fn to_offset(value: DateTime<Utc>) -> Result<OffsetDateTime, AppError> {
         .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid certificate timestamp")))
 }
 
-fn generalized_time(value: DateTime<Utc>) -> Result<GeneralizedTime, AppError> {
-    GeneralizedTime::new(
-        value.year(),
-        value.month(),
-        value.day(),
-        value.hour(),
-        value.minute(),
-        value.second(),
-    )
-    .map_err(ocsp_err)
+fn ocsp_time(value: DateTime<Utc>) -> Result<OcspGeneralizedTime, AppError> {
+    let seconds = u64::try_from(value.timestamp())
+        .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid OCSP timestamp")))?;
+    GeneralizedTime::from_unix_duration(std::time::Duration::from_secs(seconds))
+        .map(OcspGeneralizedTime)
+        .map_err(der_err)
 }
 
 fn normalize_fingerprint(value: &str) -> String {
@@ -2455,84 +2691,139 @@ fn normalize_fingerprint(value: &str) -> String {
         .collect()
 }
 
-fn basic_ocsp_response_der(
-    response_data_der: &[u8],
-    signature_oid: &Oid,
-    signature: &[u8],
-    certs: &[&[u8]],
-) -> Result<Vec<u8>, AppError> {
-    let mut body = response_data_der.to_vec();
-    body.extend(signature_oid.to_der_with_null().map_err(ocsp_err)?);
-    body.extend(der_bit_string(signature));
-    if !certs.is_empty() {
-        let cert_list = certs
-            .iter()
-            .flat_map(|cert| cert.iter().copied())
-            .collect::<Vec<_>>();
-        body.extend(der_tlv(0xa0, der_tlv(0x30, cert_list)));
+fn certificate_chain_from_pem(chain_pem: &str) -> Result<Vec<Vec<u8>>, AppError> {
+    let mut remaining = chain_pem.as_bytes();
+    let mut certificates = Vec::new();
+    while !remaining.iter().all(u8::is_ascii_whitespace) {
+        let (rest, pem) = parse_x509_pem(remaining)
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid OCSP signer chain PEM")))?;
+        if pem.label != "CERTIFICATE" {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "OCSP signer chain contains non-certificate material"
+            )));
+        }
+        certificates.push(pem.contents);
+        remaining = rest;
     }
-    Ok(der_tlv(0x30, body))
-}
-
-fn successful_ocsp_response_der(
-    response_type: &Oid,
-    basic_der: &[u8],
-) -> Result<Vec<u8>, AppError> {
-    let mut response_bytes = response_type.to_der_raw().map_err(ocsp_err)?;
-    response_bytes.extend(der_tlv(0x04, basic_der.to_vec()));
-    let mut body = vec![0x0a, 0x01, OcspRespStatus::Successful as u8];
-    body.extend(der_tlv(0xa0, der_tlv(0x30, response_bytes)));
-    Ok(der_tlv(0x30, body))
-}
-
-fn der_bit_string(data: &[u8]) -> Vec<u8> {
-    let mut body = Vec::with_capacity(data.len() + 1);
-    body.push(0);
-    body.extend_from_slice(data);
-    der_tlv(0x03, body)
-}
-
-fn der_tlv(tag: u8, value: Vec<u8>) -> Vec<u8> {
-    let mut out = Vec::with_capacity(1 + 5 + value.len());
-    out.push(tag);
-    out.extend(der_len(value.len()));
-    out.extend(value);
-    out
-}
-
-fn der_len(len: usize) -> Vec<u8> {
-    if len <= 127 {
-        return vec![len as u8];
+    if certificates.is_empty() {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "OCSP signer chain is empty"
+        )));
     }
-    let bytes = len
-        .to_be_bytes()
-        .into_iter()
-        .skip_while(|byte| *byte == 0)
-        .collect::<Vec<_>>();
-    let mut out = Vec::with_capacity(bytes.len() + 1);
-    out.push(0x80 | bytes.len() as u8);
-    out.extend(bytes);
-    out
+    Ok(certificates)
+}
+
+fn encode_signed_ocsp<F>(
+    certificate_chain_der: Vec<Vec<u8>>,
+    responses: Vec<SingleResponse>,
+    nonce: Option<&[u8]>,
+    produced_at: OcspGeneralizedTime,
+    sign: F,
+) -> Result<Vec<u8>, AppError>
+where
+    F: FnOnce(&[u8]) -> Result<(pki_core::PkiSignatureAlgorithm, Vec<u8>), AppError>,
+{
+    let certificates = certificate_chain_der
+        .iter()
+        .map(|certificate_der| {
+            X509Certificate::from_der(certificate_der).map_err(|_| {
+                AppError::Internal(anyhow::anyhow!(
+                    "OCSP signer chain contains invalid certificate DER"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let responder_name = certificates
+        .first()
+        .ok_or_else(|| AppError::Internal(anyhow::anyhow!("OCSP signer chain is empty")))?
+        .tbs_certificate
+        .subject
+        .clone();
+    let response_extensions = nonce
+        .map(|nonce| {
+            let nonce_der = Nonce::new(nonce.to_vec())
+                .map_err(der_err)?
+                .to_der()
+                .map_err(der_err)?;
+            Ok(vec![Extension {
+                extn_id: ID_PKIX_OCSP_NONCE,
+                critical: false,
+                extn_value: OctetString::new(nonce_der).map_err(der_err)?,
+            }])
+        })
+        .transpose()?;
+    let response_data = ResponseData {
+        version: Version::default(),
+        responder_id: ResponderId::ByName(responder_name),
+        produced_at,
+        responses,
+        response_extensions,
+    };
+    let response_data_der = response_data.to_der().map_err(der_err)?;
+    let (algorithm, signature) = sign(&response_data_der)?;
+    let basic = BasicOcspResponse {
+        tbs_response_data: response_data,
+        signature_algorithm: ocsp_signature_algorithm_identifier(algorithm),
+        signature: BitString::from_bytes(&signature).map_err(der_err)?,
+        certs: Some(certificates),
+    };
+    OcspResponse::successful(basic)
+        .map_err(der_err)?
+        .to_der()
+        .map_err(der_err)
+}
+
+fn ocsp_signature_algorithm_identifier(
+    algorithm: pki_core::PkiSignatureAlgorithm,
+) -> AlgorithmIdentifierOwned {
+    use pki_core::PkiSignatureAlgorithm;
+
+    let (oid, rsa_parameters) = match algorithm {
+        PkiSignatureAlgorithm::RsaPkcs1Sha256 => {
+            (ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11"), true)
+        }
+        PkiSignatureAlgorithm::RsaPkcs1Sha384 => {
+            (ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12"), true)
+        }
+        PkiSignatureAlgorithm::RsaPkcs1Sha512 => {
+            (ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13"), true)
+        }
+        PkiSignatureAlgorithm::EcdsaSha256 => {
+            (ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2"), false)
+        }
+        PkiSignatureAlgorithm::EcdsaSha384 => {
+            (ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"), false)
+        }
+        PkiSignatureAlgorithm::EcdsaSha512 => {
+            (ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.4"), false)
+        }
+        PkiSignatureAlgorithm::Ed25519 => (ObjectIdentifier::new_unwrap("1.3.101.112"), false),
+    };
+    AlgorithmIdentifierOwned {
+        oid,
+        parameters: rsa_parameters.then(|| Null.into()),
+    }
 }
 
 fn rcgen_err(err: rcgen::Error) -> AppError {
     AppError::Internal(anyhow::anyhow!("certificate error: {err}"))
 }
 
-fn ocsp_err(err: ocsp::err::OcspError) -> AppError {
-    AppError::Internal(anyhow::anyhow!("OCSP error: {err:?}"))
+fn der_err(error: der::Error) -> AppError {
+    AppError::Internal(anyhow::anyhow!("OCSP DER error: {error}"))
 }
 
-pub fn unsuccessful_ocsp(status: OcspRespStatus) -> Result<Vec<u8>, AppError> {
-    OcspResponse::new_non_success(status)
-        .map_err(ocsp_err)?
-        .to_der()
-        .map_err(ocsp_err)
+pub fn unsuccessful_ocsp(status: OcspResponseStatus) -> Result<Vec<u8>, AppError> {
+    OcspResponse {
+        response_status: status,
+        response_bytes: None,
+    }
+    .to_der()
+    .map_err(der_err)
 }
 
 #[cfg(test)]
 mod tests {
-    use ocsp::common::asn1::CertId;
     use rcgen::BasicConstraints;
     use std::{fs, path::PathBuf};
 
@@ -2816,14 +3107,30 @@ mod tests {
         params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
         let cert = params.self_signed(&key).expect("cert");
         let der = certificate_der_from_pem(&cert.pem()).expect("der");
-        let (name_hash, key_hash) = issuer_sha1_hashes_from_der(&der).expect("hashes");
-        let oid = Oid::new_from_dot(ALGO_SHA1_DOT).expect("oid");
-        let serial = vec![1, 2, 3, 4];
-        let good = CertId::new(oid.clone(), &name_hash, &key_hash, &serial);
-        let bad = CertId::new(oid, &[0; 20], &key_hash, &serial);
+        for (algorithm, oid) in [
+            (OcspHashAlgorithm::Sha1, SHA1_OID),
+            (OcspHashAlgorithm::Sha256, SHA256_OID),
+        ] {
+            let (name_hash, key_hash) = issuer_hashes_from_der(&der, algorithm).expect("hashes");
+            let serial = [1, 2, 3, 4];
+            let good = x509_ocsp::CertId {
+                hash_algorithm: AlgorithmIdentifierOwned {
+                    oid,
+                    parameters: Some(Null.into()),
+                },
+                issuer_name_hash: OctetString::new(name_hash).expect("name hash"),
+                issuer_key_hash: OctetString::new(key_hash.clone()).expect("key hash"),
+                serial_number: x509_cert::serial_number::SerialNumber::new(&serial)
+                    .expect("serial"),
+            };
+            let bad = x509_ocsp::CertId {
+                issuer_name_hash: OctetString::new(vec![0; key_hash.len()]).expect("bad hash"),
+                ..good.clone()
+            };
 
-        assert!(certid_issuer_matches(&good, &name_hash, &key_hash).unwrap());
-        assert!(!certid_issuer_matches(&bad, &name_hash, &key_hash).unwrap());
+            assert!(certid_issuer_matches(&good, &der).unwrap());
+            assert!(!certid_issuer_matches(&bad, &der).unwrap());
+        }
     }
 
     #[test]

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -2739,19 +2739,19 @@ where
         .tbs_certificate
         .subject
         .clone();
-    let response_extensions = nonce
-        .map(|nonce| {
-            let nonce_der = Nonce::new(nonce.to_vec())
-                .map_err(der_err)?
-                .to_der()
-                .map_err(der_err)?;
-            Ok(vec![Extension {
-                extn_id: ID_PKIX_OCSP_NONCE,
-                critical: false,
-                extn_value: OctetString::new(nonce_der).map_err(der_err)?,
-            }])
-        })
-        .transpose()?;
+    let response_extensions = if let Some(nonce) = nonce {
+        let nonce_der = Nonce::new(nonce.to_vec())
+            .map_err(der_err)?
+            .to_der()
+            .map_err(der_err)?;
+        Some(vec![Extension {
+            extn_id: ID_PKIX_OCSP_NONCE,
+            critical: false,
+            extn_value: OctetString::new(nonce_der).map_err(der_err)?,
+        }])
+    } else {
+        None
+    };
     let response_data = ResponseData {
         version: Version::default(),
         responder_id: ResponderId::ByName(responder_name),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -70,7 +70,18 @@ pub fn create_router(state: AppState) -> Router {
             "/certs/issuers/:issuer_id/crl",
             get(certs::http::issuer_crl),
         )
-        .route("/certs/ocsp", post(certs::http::ocsp))
+        .route(
+            "/certs/ocsp",
+            post(certs::http::ocsp).layer(DefaultBodyLimit::max(
+                certs::service::OCSP_REQUEST_MAX_BYTES,
+            )),
+        )
+        .route(
+            "/certs/issuers/:issuer_id/ocsp",
+            post(certs::http::issuer_ocsp).layer(DefaultBodyLimit::max(
+                certs::service::OCSP_REQUEST_MAX_BYTES,
+            )),
+        )
         // GraphQL
         .route(
             "/graphql",

--- a/tests/m17_certificates.rs
+++ b/tests/m17_certificates.rs
@@ -9,17 +9,19 @@ use atom::{
     keys::{ActiveKeys, LoadedKey},
     state::AppState,
 };
-use ocsp::{
-    common::asn1::{CertId, Oid},
-    oid::ALGO_SHA1_DOT,
-    request::OneReq,
+use const_oid::ObjectIdentifier;
+use der::{
+    asn1::{Null, OctetString},
+    Encode,
 };
 use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose};
 use ring::digest;
+use spki::AlgorithmIdentifierOwned;
 use sqlx::PgPool;
 use std::{fs, path::PathBuf};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
+use x509_ocsp::{CertId, OcspRequest, Request as OcspSingleRequest, TbsRequest};
 use x509_parser::pem::parse_x509_pem;
 
 fn cert_config() -> Config {
@@ -453,19 +455,29 @@ fn ocsp_request_for_serial(ca_chain_pem: &str, serial_hex: &str) -> Vec<u8> {
             .data
             .as_ref(),
     );
-    let certid = CertId::new(
-        Oid::new_from_dot(ALGO_SHA1_DOT).unwrap(),
-        name_hash.as_ref(),
-        key_hash.as_ref(),
-        &hex::decode(serial_hex).unwrap(),
-    );
-    let one = OneReq {
-        certid,
-        one_req_ext: None,
-    };
-    let request_list = der_sequence(one.to_der().unwrap());
-    let tbs_request = der_sequence(request_list);
-    der_sequence(tbs_request)
+    let serial = hex::decode(serial_hex).unwrap();
+    OcspRequest {
+        tbs_request: TbsRequest {
+            version: Default::default(),
+            requestor_name: None,
+            request_list: vec![OcspSingleRequest {
+                req_cert: CertId {
+                    hash_algorithm: AlgorithmIdentifierOwned {
+                        oid: ObjectIdentifier::new_unwrap("1.3.14.3.2.26"),
+                        parameters: Some(Null.into()),
+                    },
+                    issuer_name_hash: OctetString::new(name_hash.as_ref()).unwrap(),
+                    issuer_key_hash: OctetString::new(key_hash.as_ref()).unwrap(),
+                    serial_number: x509_cert::serial_number::SerialNumber::new(&serial).unwrap(),
+                },
+                single_request_extensions: None,
+            }],
+            request_extensions: None,
+        },
+        optional_signature: None,
+    }
+    .to_der()
+    .unwrap()
 }
 
 fn first_certificate_der(pem: &str) -> Vec<u8> {
@@ -477,27 +489,4 @@ fn assert_ocsp_success(response: &[u8]) {
     assert!(response
         .windows(3)
         .any(|window| window == [0x0a, 0x01, 0x00]));
-}
-
-fn der_sequence(value: Vec<u8>) -> Vec<u8> {
-    let mut out = Vec::with_capacity(value.len() + 6);
-    out.push(0x30);
-    out.extend(der_len(value.len()));
-    out.extend(value);
-    out
-}
-
-fn der_len(len: usize) -> Vec<u8> {
-    if len <= 127 {
-        return vec![len as u8];
-    }
-    let bytes = len
-        .to_be_bytes()
-        .into_iter()
-        .skip_while(|byte| *byte == 0)
-        .collect::<Vec<_>>();
-    let mut out = Vec::with_capacity(bytes.len() + 1);
-    out.push(0x80 | bytes.len() as u8);
-    out.extend(bytes);
-    out
 }

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -684,7 +684,7 @@ fn assert_openssl_serial_ocsp(response_der: &[u8], issuer_pem: &str, serial: &st
         .arg("-issuer")
         .arg(&issuer_path)
         .arg("-serial")
-        .arg(serial)
+        .arg(format!("0x{serial}"))
         .arg("-CAfile")
         .arg(&issuer_path)
         .args(["-no_nonce", "-text"])

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -213,7 +213,7 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
     unsupported_parameters.tbs_request.request_list[0]
         .req_cert
         .hash_algorithm
-        .parameters = Some(OctetString::new([1]).unwrap().into());
+        .parameters = Some(der::asn1::Any::from_der(&[0x04, 0x01, 0x01]).unwrap());
     assert_bad_request(
         service::issuer_ocsp_response(
             &pool,

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -27,9 +27,8 @@ use der::{
 };
 use rcgen::{
     BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose,
-    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ECDSA_P521_SHA256,
-    PKCS_ECDSA_P521_SHA384, PKCS_ECDSA_P521_SHA512, PKCS_ED25519, PKCS_RSA_SHA256, PKCS_RSA_SHA384,
-    PKCS_RSA_SHA512,
+    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ECDSA_P521_SHA512,
+    PKCS_ED25519, PKCS_RSA_SHA256,
 };
 use ring::digest;
 use spki::AlgorithmIdentifierOwned;
@@ -366,30 +365,18 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
 #[ignore]
 async fn legacy_ocsp_verifies_every_supported_issuer_key_algorithm() {
     let pool = common::pool().await;
-    let cases: [(&SignatureAlgorithm, ObjectIdentifier); 9] = [
+    // These are the five signing policies rcgen can recover unambiguously
+    // from Atom's persisted PEM key material. RSA and P-521 keys are also
+    // compatible with other digests, whose identifier mappings are covered
+    // in pki_core unit tests, but the persisted keys do not encode that choice.
+    let cases: [(&SignatureAlgorithm, ObjectIdentifier); 5] = [
         (
             &PKCS_RSA_SHA256,
             ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11"),
         ),
-        (
-            &PKCS_RSA_SHA384,
-            ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12"),
-        ),
-        (
-            &PKCS_RSA_SHA512,
-            ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13"),
-        ),
         (&PKCS_ECDSA_P256_SHA256, ECDSA_SHA256_OID),
         (
             &PKCS_ECDSA_P384_SHA384,
-            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"),
-        ),
-        (
-            &PKCS_ECDSA_P521_SHA256,
-            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2"),
-        ),
-        (
-            &PKCS_ECDSA_P521_SHA384,
             ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"),
         ),
         (

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -27,8 +27,8 @@ use der::{
 };
 use rcgen::{
     BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose,
-    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ECDSA_P521_SHA512,
-    PKCS_ED25519, PKCS_RSA_SHA256,
+    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ED25519,
+    PKCS_RSA_SHA256,
 };
 use ring::digest;
 use spki::AlgorithmIdentifierOwned;
@@ -365,11 +365,11 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
 #[ignore]
 async fn legacy_ocsp_verifies_every_supported_issuer_key_algorithm() {
     let pool = common::pool().await;
-    // These are the five signing policies rcgen can recover unambiguously
-    // from Atom's persisted PEM key material. RSA and P-521 keys are also
-    // compatible with other digests, whose identifier mappings are covered
-    // in pki_core unit tests, but the persisted keys do not encode that choice.
-    let cases: [(&SignatureAlgorithm, ObjectIdentifier); 5] = [
+    // These are the four issuer-key families accepted by Atom's persisted-key
+    // loader and certificate-chain verifier. RSA keys are compatible with
+    // other digests, whose identifier mappings are covered in pki_core unit
+    // tests, but persisted RSA key material does not encode a digest choice.
+    let cases: [(&SignatureAlgorithm, ObjectIdentifier); 4] = [
         (
             &PKCS_RSA_SHA256,
             ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11"),
@@ -378,10 +378,6 @@ async fn legacy_ocsp_verifies_every_supported_issuer_key_algorithm() {
         (
             &PKCS_ECDSA_P384_SHA384,
             ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"),
-        ),
-        (
-            &PKCS_ECDSA_P521_SHA512,
-            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.4"),
         ),
         (&PKCS_ED25519, ObjectIdentifier::new_unwrap("1.3.101.112")),
     ];

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -1,0 +1,707 @@
+//! PR-010 per-issuer OCSP status, retention, bounds, and interoperability.
+//!
+//! Requires PostgreSQL and OpenSSL. CI runs this ignored binary against its own
+//! freshly migrated database, single-threaded.
+
+mod common;
+
+use std::{fs, process::Command, time::Duration as StdDuration};
+
+use atom::{
+    certs::{
+        authority::{provisioning, repo as authority_repo, AuthorityStatus},
+        service,
+    },
+    config::{CertsCaMode, Config},
+    routes::create_router,
+};
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use chrono::{DateTime, Utc};
+use const_oid::{db::rfc6960::ID_PKIX_OCSP_NONCE, ObjectIdentifier};
+use der::{
+    asn1::{Null, OctetString},
+    Decode, Encode,
+};
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose,
+    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_ECDSA_P521_SHA256,
+    PKCS_ECDSA_P521_SHA384, PKCS_ECDSA_P521_SHA512, PKCS_ED25519, PKCS_RSA_SHA256, PKCS_RSA_SHA384,
+    PKCS_RSA_SHA512,
+};
+use ring::digest;
+use spki::AlgorithmIdentifierOwned;
+use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
+use tower::ServiceExt;
+use uuid::Uuid;
+use x509_cert::{
+    ext::{pkix::CrlReason, Extension},
+    serial_number::SerialNumber,
+    Certificate as X509Certificate,
+};
+use x509_ocsp::{
+    ext::Nonce, BasicOcspResponse, CertId, CertStatus, OcspRequest, OcspResponse,
+    OcspResponseStatus, Request as OcspSingleRequest, TbsRequest,
+};
+use x509_parser::pem::parse_x509_pem;
+
+const SHA1_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.14.3.2.26");
+const SHA256_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.1");
+const SHA384_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.2");
+const ECDSA_SHA256_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2");
+
+#[derive(Clone, Copy)]
+enum RequestHash {
+    Sha1,
+    Sha256,
+}
+
+#[tokio::test]
+#[ignore]
+async fn per_issuer_ocsp_enforces_the_pr010_contract() {
+    let pool = common::pool().await;
+    let config = common::pki::managed_config(false, false);
+    let root = common::pki::test_root("PR-010 Offline Root");
+    let tenant_a = common::pki::create_tenant(&pool, "pki-ocsp-a").await;
+    let tenant_b = common::pki::create_tenant(&pool, "pki-ocsp-b").await;
+    let entity_a = common::pki::create_entity(&pool, tenant_a, "pki-ocsp-a").await;
+    let entity_b = common::pki::create_entity(&pool, tenant_b, "pki-ocsp-b").await;
+    let issuer_a = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let issuer_b = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_b).await;
+    let leaf_a = issue_managed(&pool, &config, tenant_a, entity_a, "leaf-a").await;
+    let leaf_b = issue_managed(&pool, &config, tenant_b, entity_b, "leaf-b").await;
+    let issuer_a_pem = issuer_a.certificate_pem.as_deref().unwrap();
+    let issuer_b_pem = issuer_b.certificate_pem.as_deref().unwrap();
+
+    // Both RFC-required SHA-1 CertIDs and reviewed SHA-256 CertIDs resolve to
+    // good. The managed issuer currently supports ECDSA P-256, and the
+    // response algorithm is derived from that key rather than hard-coded.
+    let request_a_sha1 = ocsp_request(issuer_a_pem, &leaf_a.serial_number, RequestHash::Sha1, None);
+    let request_a_sha256 = ocsp_request(
+        issuer_a_pem,
+        &leaf_a.serial_number,
+        RequestHash::Sha256,
+        None,
+    );
+    let good_a = service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+        .await
+        .unwrap();
+    assert_status(&good_a, CertStatus::good());
+    let good_sha256 = service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha256)
+        .await
+        .unwrap();
+    assert_status(&good_sha256, CertStatus::good());
+    let basic_good = basic_response(&good_a);
+    assert_eq!(basic_good.signature_algorithm.oid, ECDSA_SHA256_OID);
+    assert!(basic_good.signature_algorithm.parameters.is_none());
+    assert_response_times(&basic_good);
+    assert_direct_issuer_chain(&basic_good, issuer_a_pem, &root.pem);
+    assert_openssl_ocsp(
+        &good_a,
+        issuer_a_pem,
+        &leaf_a.certificate_pem,
+        &root.pem,
+        "good",
+    );
+
+    // Re-evaluation advances producedAt/thisUpdate and is not a cached replay.
+    tokio::time::sleep(StdDuration::from_millis(1_100)).await;
+    let fresh_a = service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+        .await
+        .unwrap();
+    let first_time = unix_seconds(basic_good.tbs_response_data.produced_at);
+    let second_time = unix_seconds(basic_response(&fresh_a).tbs_response_data.produced_at);
+    assert!(second_time > first_time);
+    assert_ne!(fresh_a, good_a);
+
+    // Unknown serials and requests whose issuer hashes target another CA are
+    // signed `unknown` responses from the route issuer, never serial-only hits.
+    let unknown_request = ocsp_request(issuer_a_pem, "0102030405060708", RequestHash::Sha1, None);
+    let unknown = service::issuer_ocsp_response(&pool, &config, issuer_a.id, &unknown_request)
+        .await
+        .unwrap();
+    assert_status(&unknown, CertStatus::unknown());
+    let wrong_issuer = service::issuer_ocsp_response(&pool, &config, issuer_b.id, &request_a_sha1)
+        .await
+        .unwrap();
+    assert_status(&wrong_issuer, CertStatus::unknown());
+
+    // A valid 1..32-byte request nonce is echoed exactly once. Missing nonces
+    // remain absent; duplicate, empty, oversized, or misplaced nonces fail.
+    let nonce = (0_u8..32).collect::<Vec<_>>();
+    let nonce_request = ocsp_request(
+        issuer_a_pem,
+        &leaf_a.serial_number,
+        RequestHash::Sha1,
+        Some(&nonce),
+    );
+    let nonce_response = service::issuer_ocsp_response(&pool, &config, issuer_a.id, &nonce_request)
+        .await
+        .unwrap();
+    assert_eq!(
+        basic_response(&nonce_response)
+            .nonce()
+            .unwrap()
+            .0
+            .as_bytes(),
+        nonce
+    );
+    assert!(basic_response(&good_a).nonce().is_none());
+    for invalid in [Vec::new(), vec![7; 33]] {
+        let request = ocsp_request(
+            issuer_a_pem,
+            &leaf_a.serial_number,
+            RequestHash::Sha1,
+            Some(&invalid),
+        );
+        assert_bad_request(
+            service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request).await,
+        );
+    }
+    let mut duplicate_nonce = OcspRequest::from_der(&nonce_request).unwrap();
+    duplicate_nonce
+        .tbs_request
+        .request_extensions
+        .as_mut()
+        .unwrap()
+        .push(nonce_extension(&[9]));
+    assert_bad_request(
+        service::issuer_ocsp_response(
+            &pool,
+            &config,
+            issuer_a.id,
+            &duplicate_nonce.to_der().unwrap(),
+        )
+        .await,
+    );
+    let mut misplaced_nonce = OcspRequest::from_der(&request_a_sha1).unwrap();
+    misplaced_nonce.tbs_request.request_list[0].single_request_extensions =
+        Some(vec![nonce_extension(&[1, 2, 3])]);
+    assert_bad_request(
+        service::issuer_ocsp_response(
+            &pool,
+            &config,
+            issuer_a.id,
+            &misplaced_nonce.to_der().unwrap(),
+        )
+        .await,
+    );
+
+    // Malformed DER, unsupported hashes, unsupported algorithm parameters,
+    // and an excessive number of SingleRequests all fail without lookup.
+    assert_bad_request(
+        service::issuer_ocsp_response(&pool, &config, issuer_a.id, &[0x30, 0x82, 0xff]).await,
+    );
+    let mut unsupported_hash = OcspRequest::from_der(&request_a_sha1).unwrap();
+    unsupported_hash.tbs_request.request_list[0]
+        .req_cert
+        .hash_algorithm
+        .oid = SHA384_OID;
+    assert_bad_request(
+        service::issuer_ocsp_response(
+            &pool,
+            &config,
+            issuer_a.id,
+            &unsupported_hash.to_der().unwrap(),
+        )
+        .await,
+    );
+    let mut unsupported_parameters = OcspRequest::from_der(&request_a_sha1).unwrap();
+    unsupported_parameters.tbs_request.request_list[0]
+        .req_cert
+        .hash_algorithm
+        .parameters = Some(OctetString::new([1]).unwrap().into());
+    assert_bad_request(
+        service::issuer_ocsp_response(
+            &pool,
+            &config,
+            issuer_a.id,
+            &unsupported_parameters.to_der().unwrap(),
+        )
+        .await,
+    );
+    let mut too_many = OcspRequest::from_der(&request_a_sha1).unwrap();
+    too_many.tbs_request.request_list = vec![too_many.tbs_request.request_list[0].clone(); 17];
+    assert_bad_request(
+        service::issuer_ocsp_response(&pool, &config, issuer_a.id, &too_many.to_der().unwrap())
+            .await,
+    );
+
+    // HTTP delivery is an RFC response with explicit no-store policy. Unknown
+    // issuer identifiers are indistinguishable, malformed input is diagnosed
+    // before issuer lookup, and transport size is bounded before allocation.
+    let app = create_router(common::pki::graphql_state(pool.clone(), config.clone()));
+    let http_good = post_ocsp(&app, issuer_a.id, request_a_sha1.clone()).await;
+    assert_eq!(http_good.status(), StatusCode::OK);
+    assert_eq!(
+        http_good.headers()[header::CONTENT_TYPE],
+        "application/ocsp-response"
+    );
+    assert_eq!(
+        http_good.headers()[header::CACHE_CONTROL],
+        "no-store, max-age=0"
+    );
+    assert_status(
+        &to_bytes(http_good.into_body(), usize::MAX).await.unwrap(),
+        CertStatus::good(),
+    );
+    let unknown_one = post_ocsp(&app, Uuid::new_v4(), request_a_sha1.clone()).await;
+    let unknown_two = post_ocsp(&app, Uuid::new_v4(), request_a_sha1.clone()).await;
+    let unknown_one_body = to_bytes(unknown_one.into_body(), usize::MAX).await.unwrap();
+    let unknown_two_body = to_bytes(unknown_two.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(unknown_one_body, unknown_two_body);
+    assert_response_status(&unknown_one_body, OcspResponseStatus::Unauthorized);
+    let malformed_unknown = post_ocsp(&app, Uuid::new_v4(), vec![1, 2, 3]).await;
+    assert_response_status(
+        &to_bytes(malformed_unknown.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        OcspResponseStatus::MalformedRequest,
+    );
+    let oversized = post_ocsp(
+        &app,
+        issuer_a.id,
+        vec![0; service::OCSP_REQUEST_MAX_BYTES + 1],
+    )
+    .await;
+    assert_eq!(oversized.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+    // Simulate the same serial under two issuers (PR-011 later changes the
+    // production uniqueness model). Exact issuer+serial lookup keeps A and B
+    // independent even after A is revoked.
+    sqlx::query("DROP INDEX idx_credentials_certificate_serial")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE credentials SET identifier = $1 WHERE id = $2")
+        .bind(&leaf_a.serial_number)
+        .bind(leaf_b.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let duplicate_b_request =
+        ocsp_request(issuer_b_pem, &leaf_a.serial_number, RequestHash::Sha1, None);
+    let duplicate_b =
+        service::issuer_ocsp_response(&pool, &config, issuer_b.id, &duplicate_b_request)
+            .await
+            .unwrap();
+    assert_status(&duplicate_b, CertStatus::good());
+
+    revoke(
+        &pool,
+        leaf_a.credential_id,
+        entity_a,
+        tenant_a,
+        "key_compromise",
+    )
+    .await;
+    let revoked_a = service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+        .await
+        .unwrap();
+    let basic_revoked = basic_response(&revoked_a);
+    let revoked = match basic_revoked.tbs_response_data.responses[0].cert_status {
+        CertStatus::Revoked(info) => info,
+        ref other => panic!("expected revoked status, got {other:?}"),
+    };
+    assert_eq!(revoked.revocation_reason, Some(CrlReason::KeyCompromise));
+    let (recorded_at, recorded_reason): (DateTime<Utc>, String) = sqlx::query_as(
+        "SELECT revoked_at, reason FROM certificate_revocations WHERE credential_id = $1",
+    )
+    .bind(leaf_a.credential_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(recorded_reason, "key_compromise");
+    assert_eq!(
+        unix_seconds(revoked.revocation_time) as i64,
+        recorded_at.timestamp()
+    );
+    let duplicate_b_after_revoke =
+        service::issuer_ocsp_response(&pool, &config, issuer_b.id, &duplicate_b_request)
+            .await
+            .unwrap();
+    assert_status(&duplicate_b_after_revoke, CertStatus::good());
+
+    // Rotation retains responder availability while the old authority is
+    // retiring and after it is retired. No delegated responder is used: the
+    // retained issuer key signs directly and its complete chain is embedded.
+    let issuer_a_v2 = common::pki::rotate_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let old = authority_repo::authority_by_id(&pool, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(old.status, AuthorityStatus::Retiring);
+    let retiring_response =
+        service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+            .await
+            .unwrap();
+    assert_status(&retiring_response, CertStatus::revoked(revoked));
+    let mut tx = pool.begin().await.unwrap();
+    provisioning::complete_retirement_in_tx(&mut tx, issuer_a.id)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    let retired_response =
+        service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+            .await
+            .unwrap();
+    assert_status(&retired_response, CertStatus::revoked(revoked));
+    let new_leaf = issue_managed(&pool, &config, tenant_a, entity_a, "rotated").await;
+    assert_eq!(new_leaf.issuer_id, Some(issuer_a_v2.id));
+    let new_request = ocsp_request(
+        issuer_a_v2.certificate_pem.as_deref().unwrap(),
+        &new_leaf.serial_number,
+        RequestHash::Sha1,
+        None,
+    );
+    let new_response = service::issuer_ocsp_response(&pool, &config, issuer_a_v2.id, &new_request)
+        .await
+        .unwrap();
+    assert_status(&new_response, CertStatus::good());
+}
+
+#[tokio::test]
+#[ignore]
+async fn legacy_ocsp_verifies_every_supported_issuer_key_algorithm() {
+    let pool = common::pool().await;
+    let cases: [(&SignatureAlgorithm, ObjectIdentifier); 9] = [
+        (
+            &PKCS_RSA_SHA256,
+            ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11"),
+        ),
+        (
+            &PKCS_RSA_SHA384,
+            ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12"),
+        ),
+        (
+            &PKCS_RSA_SHA512,
+            ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13"),
+        ),
+        (&PKCS_ECDSA_P256_SHA256, ECDSA_SHA256_OID),
+        (
+            &PKCS_ECDSA_P384_SHA384,
+            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"),
+        ),
+        (
+            &PKCS_ECDSA_P521_SHA256,
+            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2"),
+        ),
+        (
+            &PKCS_ECDSA_P521_SHA384,
+            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.3"),
+        ),
+        (
+            &PKCS_ECDSA_P521_SHA512,
+            ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.4"),
+        ),
+        (&PKCS_ED25519, ObjectIdentifier::new_unwrap("1.3.101.112")),
+    ];
+
+    for (index, (algorithm, expected_oid)) in cases.into_iter().enumerate() {
+        let directory =
+            std::env::temp_dir().join(format!("atom-pr010-alg-{index}-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let key = KeyPair::generate_for(algorithm).unwrap();
+        let key_pem = key.serialize_pem();
+        let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, format!("PR-010 Algorithm {index}"));
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
+        params.not_after = OffsetDateTime::now_utc() + Duration::days(1);
+        let issuer_pem = params.self_signed(&key).unwrap().pem();
+        let certificate_path = directory.join("issuer.pem");
+        let key_path = directory.join("issuer.key");
+        fs::write(&certificate_path, &issuer_pem).unwrap();
+        fs::write(&key_path, key_pem).unwrap();
+
+        let mut config = Config::for_tests();
+        config.certs_enabled = true;
+        config.certs_ca_mode = CertsCaMode::FileRootIssuer;
+        config.certs_root_ca_cert_path = Some(certificate_path.to_string_lossy().into_owned());
+        config.certs_root_ca_key_path = Some(key_path.to_string_lossy().into_owned());
+        let issuer = service::load_file_issuer_if_enabled(&config)
+            .unwrap()
+            .unwrap();
+        let request = ocsp_request(&issuer_pem, "010203", RequestHash::Sha1, None);
+        let response = service::ocsp_response(&pool, &config, Some(&issuer), &request)
+            .await
+            .unwrap();
+        let basic = basic_response(&response);
+        assert_eq!(basic.signature_algorithm.oid, expected_oid);
+        assert_status(&response, CertStatus::unknown());
+        assert_openssl_serial_ocsp(&response, &issuer_pem, "010203");
+        fs::remove_dir_all(directory).unwrap();
+    }
+}
+
+async fn issue_managed(
+    pool: &PgPool,
+    config: &atom::config::Config,
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    label: &str,
+) -> service::CertificateRecord {
+    service::issue_certificate_from_csr_v2(
+        pool,
+        config,
+        Some(tenant_id),
+        service::IssueCertificateFromCsrV2 {
+            entity_id,
+            ttl_secs: Some(3600),
+            csr_pem: csr(label),
+            idempotency_key: format!("pr010-{label}-{}", Uuid::new_v4()),
+        },
+    )
+    .await
+    .unwrap()
+    .certificate
+}
+
+async fn revoke(
+    pool: &PgPool,
+    credential_id: Uuid,
+    entity_id: Uuid,
+    tenant_id: Uuid,
+    reason: &str,
+) {
+    service::revoke_certificate_v2(
+        pool,
+        service::RevokeCertificateV2 {
+            selector: service::CertificateRevocationSelector::CredentialId(credential_id),
+            reason: Some(reason.to_string()),
+            actor_entity_id: Some(common::admin_id()),
+            expected_entity_id: entity_id,
+            expected_tenant_id: Some(tenant_id),
+        },
+    )
+    .await
+    .unwrap();
+}
+
+fn csr(label: &str) -> String {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params.distinguished_name.push(DnType::CommonName, label);
+    params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
+    params.not_after = OffsetDateTime::now_utc() + Duration::hours(2);
+    params.serialize_request(&key).unwrap().pem().unwrap()
+}
+
+fn ocsp_request(
+    issuer_pem: &str,
+    serial_hex: &str,
+    hash: RequestHash,
+    nonce: Option<&[u8]>,
+) -> Vec<u8> {
+    let issuer_der = parse_x509_pem(issuer_pem.as_bytes()).unwrap().1.contents;
+    let (_, issuer) = x509_parser::parse_x509_certificate(&issuer_der).unwrap();
+    let (oid, digest_algorithm) = match hash {
+        RequestHash::Sha1 => (SHA1_OID, &digest::SHA1_FOR_LEGACY_USE_ONLY),
+        RequestHash::Sha256 => (SHA256_OID, &digest::SHA256),
+    };
+    let name_hash = digest::digest(digest_algorithm, issuer.tbs_certificate.subject.as_raw());
+    let key_hash = digest::digest(
+        digest_algorithm,
+        issuer
+            .tbs_certificate
+            .subject_pki
+            .subject_public_key
+            .data
+            .as_ref(),
+    );
+    let cert_id = CertId {
+        hash_algorithm: AlgorithmIdentifierOwned {
+            oid,
+            parameters: Some(Null.into()),
+        },
+        issuer_name_hash: OctetString::new(name_hash.as_ref().to_vec()).unwrap(),
+        issuer_key_hash: OctetString::new(key_hash.as_ref().to_vec()).unwrap(),
+        serial_number: SerialNumber::new(&hex::decode(serial_hex).unwrap()).unwrap(),
+    };
+    OcspRequest {
+        tbs_request: TbsRequest {
+            version: Default::default(),
+            requestor_name: None,
+            request_list: vec![OcspSingleRequest {
+                req_cert: cert_id,
+                single_request_extensions: None,
+            }],
+            request_extensions: nonce.map(|nonce| vec![nonce_extension(nonce)]),
+        },
+        optional_signature: None,
+    }
+    .to_der()
+    .unwrap()
+}
+
+fn nonce_extension(bytes: &[u8]) -> Extension {
+    let encoded = Nonce::new(bytes.to_vec()).unwrap().to_der().unwrap();
+    Extension {
+        extn_id: ID_PKIX_OCSP_NONCE,
+        critical: false,
+        extn_value: OctetString::new(encoded).unwrap(),
+    }
+}
+
+fn basic_response(response_der: &[u8]) -> BasicOcspResponse {
+    let response = OcspResponse::from_der(response_der).unwrap();
+    assert_eq!(response.response_status, OcspResponseStatus::Successful);
+    BasicOcspResponse::from_der(response.response_bytes.unwrap().response.as_bytes()).unwrap()
+}
+
+fn assert_status(response_der: &[u8], expected: CertStatus) {
+    let basic = basic_response(response_der);
+    assert_eq!(basic.tbs_response_data.responses.len(), 1);
+    assert_eq!(basic.tbs_response_data.responses[0].cert_status, expected);
+}
+
+fn assert_response_status(response_der: &[u8], expected: OcspResponseStatus) {
+    let response = OcspResponse::from_der(response_der).unwrap();
+    assert_eq!(response.response_status, expected);
+    assert!(response.response_bytes.is_none());
+}
+
+fn assert_response_times(response: &BasicOcspResponse) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let produced_at = unix_seconds(response.tbs_response_data.produced_at);
+    assert!(produced_at.abs_diff(now) <= 10);
+    for single in &response.tbs_response_data.responses {
+        let this_update = unix_seconds(single.this_update);
+        let next_update = unix_seconds(single.next_update.unwrap());
+        assert_eq!(this_update, produced_at);
+        assert!(next_update > this_update);
+        assert!(next_update - this_update <= 300);
+    }
+}
+
+fn unix_seconds(time: x509_ocsp::OcspGeneralizedTime) -> u64 {
+    time.0.to_unix_duration().as_secs()
+}
+
+fn assert_direct_issuer_chain(response: &BasicOcspResponse, issuer_pem: &str, root_pem: &str) {
+    let certificates = response.certs.as_ref().expect("embedded responder chain");
+    assert!(certificates.len() >= 2);
+    let issuer_der = parse_x509_pem(issuer_pem.as_bytes()).unwrap().1.contents;
+    let root_der = parse_x509_pem(root_pem.as_bytes()).unwrap().1.contents;
+    assert_eq!(certificates.first().unwrap().to_der().unwrap(), issuer_der);
+    assert_eq!(certificates.last().unwrap().to_der().unwrap(), root_der);
+    let typed_issuer = X509Certificate::from_der(&issuer_der).unwrap();
+    assert!(matches!(
+        response.tbs_response_data.responder_id,
+        x509_ocsp::ResponderId::ByName(ref name)
+            if name == &typed_issuer.tbs_certificate.subject
+    ));
+}
+
+async fn post_ocsp(app: &axum::Router, issuer_id: Uuid, body: Vec<u8>) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/certs/issuers/{issuer_id}/ocsp"))
+                .header(header::CONTENT_TYPE, "application/ocsp-request")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+fn assert_bad_request<T>(result: Result<T, atom::error::AppError>) {
+    assert!(matches!(result, Err(atom::error::AppError::BadRequest(_))));
+}
+
+fn assert_openssl_ocsp(
+    response_der: &[u8],
+    issuer_pem: &str,
+    certificate_pem: &str,
+    root_pem: &str,
+    expected_status: &str,
+) {
+    let directory = std::env::temp_dir().join(format!("atom-pr010-ocsp-{}", Uuid::new_v4()));
+    fs::create_dir_all(&directory).unwrap();
+    let response_path = directory.join("response.der");
+    let issuer_path = directory.join("issuer.pem");
+    let certificate_path = directory.join("certificate.pem");
+    let root_path = directory.join("root.pem");
+    fs::write(&response_path, response_der).unwrap();
+    fs::write(&issuer_path, issuer_pem).unwrap();
+    fs::write(&certificate_path, certificate_pem).unwrap();
+    fs::write(&root_path, root_pem).unwrap();
+    let output = Command::new("openssl")
+        .arg("ocsp")
+        .arg("-respin")
+        .arg(&response_path)
+        .arg("-issuer")
+        .arg(&issuer_path)
+        .arg("-cert")
+        .arg(&certificate_path)
+        .arg("-CAfile")
+        .arg(&root_path)
+        .args(["-no_nonce", "-text"])
+        .output()
+        .expect("OpenSSL must be installed for PR-010 verification");
+    fs::remove_dir_all(directory).unwrap();
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "OpenSSL OCSP verification failed: {text}"
+    );
+    assert!(
+        text.to_ascii_lowercase()
+            .contains(&format!(": {expected_status}").to_ascii_lowercase()),
+        "OpenSSL did not report {expected_status}: {text}"
+    );
+    assert!(
+        text.to_ascii_lowercase().contains("response verify ok"),
+        "OpenSSL did not independently verify the response: {text}"
+    );
+}
+
+fn assert_openssl_serial_ocsp(response_der: &[u8], issuer_pem: &str, serial: &str) {
+    let directory = std::env::temp_dir().join(format!("atom-pr010-serial-{}", Uuid::new_v4()));
+    fs::create_dir_all(&directory).unwrap();
+    let response_path = directory.join("response.der");
+    let issuer_path = directory.join("issuer.pem");
+    fs::write(&response_path, response_der).unwrap();
+    fs::write(&issuer_path, issuer_pem).unwrap();
+    let output = Command::new("openssl")
+        .arg("ocsp")
+        .arg("-respin")
+        .arg(&response_path)
+        .arg("-issuer")
+        .arg(&issuer_path)
+        .arg("-serial")
+        .arg(serial)
+        .arg("-CAfile")
+        .arg(&issuer_path)
+        .args(["-no_nonce", "-text"])
+        .output()
+        .expect("OpenSSL must be installed for PR-010 verification");
+    fs::remove_dir_all(directory).unwrap();
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "OpenSSL OCSP verification failed: {text}"
+    );
+    assert!(
+        text.to_ascii_lowercase().contains("response verify ok"),
+        "OpenSSL did not independently verify the response: {text}"
+    );
+}


### PR DESCRIPTION
## Objective

Implement PR-010 per-issuer OCSP so each managed leaf issuer answers exact issuer-plus-serial status requests with standards-compliant, independently verifiable responses.

## Dependencies

- PR-008 — merged as #53 into `certificates`.
- PR-009 — merged as #54 into `certificates`.
- Branch starts from the current `certificates` merge commit `87c72ecd3143e616be0a791614e7103a54b8228e`.

## Changes

- Adds `POST /certs/issuers/{issuer_id}/ocsp` with a 16 KiB transport and service bound.
- Replaces the legacy panic-prone OCSP parser/hand-written DER with maintained RustCrypto ASN.1 types.
- Resolves managed status by exact issuer plus serial and reads immutable revocation time/reason.
- Supports reviewed SHA-1 and SHA-256 CertIDs, bounded multi-request parsing, and a strict 1–32 byte request-level nonce policy.
- Produces five-minute freshness windows capped by issuer expiry with `Cache-Control: no-store, max-age=0`.
- Signs with the retained issuer key, derives the signature AlgorithmIdentifier from that key, and embeds the validated signer chain.
- Retains OCSP service for retiring and retired issuers until certificate expiry.
- Keeps and documents the legacy file-backed endpoint while upgrading its encoder, bounds, nonce handling, timing, chain, and key-derived signature algorithm.
- Adds focused unit coverage and a PostgreSQL/OpenSSL integration suite.

## Acceptance criteria validation

- [x] **Issuer isolation / duplicate serial:** `certificate_by_issuer_serial` is the only managed status lookup; the PR-010 test gives two issuers the same serial, revokes one, and proves the other remains `good`.
- [x] **Every supported signing algorithm:** key-derived encoding covers every rcgen signature variant; independent OpenSSL verification covers every issuer-key family Atom’s persisted-key loader and chain verifier accept (RSA/SHA-256, ECDSA P-256/SHA-256, ECDSA P-384/SHA-384, and Ed25519). RSA digest variants and P-521 mappings remain unit-tested but are not falsely presented as accepted persisted issuer configurations.
- [x] **Unknown behavior without tenant leaks:** mismatched issuer hashes and unknown serials return signed `unknown`; unknown route issuers return the same RFC `unauthorized` response, and malformed input is parsed before issuer lookup.
- [x] **Immediate database revocation:** responses are evaluated on every request with no status cache; the integration test revokes a credential and verifies the next response contains the immutable recorded timestamp and `keyCompromise` reason.
- [x] **Signer authorization and chain:** only retained leaf-issuing authority roles with signing material and a current certificate are accepted; responses identify the direct issuer by name, embed the complete chain, and pass OpenSSL trust verification.
- [x] **Bounded malformed handling:** 16 KiB body/service limits, at most 16 CertIDs, typed DER decoding, reviewed algorithms/parameters, and strict extension/nonce checks are covered by malformed, oversized, excessive-list, unsupported-hash, unsupported-parameter, duplicate/misplaced nonce tests.
- [x] **Legacy compatibility documented:** certificate documentation distinguishes the legacy file-backed endpoint from the managed issuer route and records migration, caching, timing, nonce, lifecycle, and trust behavior.

## Mandatory tests

Implemented in `tests/m37_pki_issuer_ocsp.rs`:

- [x] Good response (SHA-1 and SHA-256 CertID)
- [x] Revoked response with recorded time/reason
- [x] Unknown serial
- [x] Wrong issuer
- [x] Duplicate serial across issuers
- [x] Malformed DER and oversized input
- [x] Unsupported hash and parameters
- [x] Nonce absent/echoed/empty/oversized/duplicate/misplaced
- [x] Replay/cache freshness and no-store headers
- [x] Delegated responder: not applicable; direct retained issuer signing is explicitly verified
- [x] OpenSSL verification for managed responses and every supported issuer key algorithm

CI passed in GitHub Actions Rust run #300:

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --no-run --locked`
- `DATABASE_URL=postgres://atom:atom@localhost:5432/atom_test cargo test --lib -- --include-ignored --test-threads=1` against a newly created database
- `DATABASE_URL=postgres://atom:atom@localhost:5432/atom_test cargo test --test "$name" -- --include-ignored --test-threads=1` for every integration-test binary against a newly recreated database (excluding only the two documented live-AMQP suites)
- `DATABASE_URL=postgres://atom:atom@localhost:5432/atom_test cargo test --test m37_pki_issuer_ocsp -- --include-ignored --test-threads=1`

API Docs run #241 also passed `buf lint`, generated-reference drift checking, and OpenAPI validation.

## Additional validation

Passed locally:

- Direct rustfmt 1.88 over every changed Rust source/test file
- `git diff --check`
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm run build` (from `docs/`)
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm audit --prod --audit-level high` (from `docs/`; no high/critical finding)

The local sandbox has no Rust crate index/cache, so compilation and database/OpenSSL execution are intentionally validated by the repository's draft-PR CI rather than reported as local passes.

## Non-goals

No general-purpose public responder, unreviewed CertID hash support, or delegated responder was added. No unrelated API, database, or authority-lifecycle refactor is included.

## Compatibility and risks

- The legacy `POST /certs/ocsp` route remains available and keeps its global-serial compatibility model.
- The new route is additive and uses the issuer-specific AIA URL already emitted by managed issuance.
- No migration is required; status uses the existing issuer identity and immutable revocation ledger.
- Responses intentionally use no-store semantics so revocation is authoritative immediately.
- Retained issuer private material remains accessible only through the restricted artifact-signing surface; key bytes and request bodies are never logged.
