### PR TITLE
[PKI PR-011] Implement certificate runtime resolver v2

### DIFF
--- a/apidocs/grpc-reference.md
+++ b/apidocs/grpc-reference.md
@@ -232,6 +232,7 @@ Unambiguous runtime resolution. At least one of certificate_der,
 fingerprint_sha256, or the issuer-fingerprint/serial pair is required. When
 multiple selectors are supplied they must all identify the same credential.
 
+
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | certificate_der | [bytes](#bytes) |  |  |
@@ -374,3 +375,4 @@ runtime services that terminate mTLS outside Atom.
 | <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
+

--- a/apidocs/grpc-reference.md
+++ b/apidocs/grpc-reference.md
@@ -15,6 +15,8 @@
     - [ResolveAliasResponse](#atom-v1-ResolveAliasResponse)
     - [ResolveCertificateRequest](#atom-v1-ResolveCertificateRequest)
     - [ResolveCertificateResponse](#atom-v1-ResolveCertificateResponse)
+    - [ResolveCertificateV2Request](#atom-v1-ResolveCertificateV2Request)
+    - [ResolveCertificateV2Response](#atom-v1-ResolveCertificateV2Response)
     - [RevokeEntityCertificatesRequest](#atom-v1-RevokeEntityCertificatesRequest)
     - [RevokeEntityCertificatesResponse](#atom-v1-RevokeEntityCertificatesResponse)
   
@@ -223,6 +225,46 @@
 
 
 
+<a name="atom-v1-ResolveCertificateV2Request"></a>
+
+### ResolveCertificateV2Request
+Unambiguous runtime resolution. At least one of certificate_der,
+fingerprint_sha256, or the issuer-fingerprint/serial pair is required. When
+multiple selectors are supplied they must all identify the same credential.
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| certificate_der | [bytes](#bytes) |  |  |
+| fingerprint_sha256 | [string](#string) |  |  |
+| issuer_fingerprint_sha256 | [string](#string) |  |  |
+| serial_number | [string](#string) |  |  |
+| expected_tenant_id | [string](#string) |  | Optional tenant binding. Empty means no expected tenant; a global entity still resolves with an empty tenant_id and never acquires tenant scope. |
+
+
+
+
+
+
+<a name="atom-v1-ResolveCertificateV2Response"></a>
+
+### ResolveCertificateV2Response
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entity_id | [string](#string) |  |  |
+| tenant_id | [string](#string) |  |  |
+| credential_id | [string](#string) |  |  |
+| issuer_id | [string](#string) |  |  |
+| expires_at | [string](#string) |  |  |
+| status | [string](#string) |  |  |
+
+
+
+
+
+
 <a name="atom-v1-RevokeEntityCertificatesRequest"></a>
 
 ### RevokeEntityCertificatesRequest
@@ -305,7 +347,8 @@ runtime services that terminate mTLS outside Atom.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ResolveCertificate | [ResolveCertificateRequest](#atom-v1-ResolveCertificateRequest) | [ResolveCertificateResponse](#atom-v1-ResolveCertificateResponse) |  |
+| ResolveCertificate | [ResolveCertificateRequest](#atom-v1-ResolveCertificateRequest) | [ResolveCertificateResponse](#atom-v1-ResolveCertificateResponse) | Legacy file-issuer resolver. Managed issuers must use ResolveCertificateV2. |
+| ResolveCertificateV2 | [ResolveCertificateV2Request](#atom-v1-ResolveCertificateV2Request) | [ResolveCertificateV2Response](#atom-v1-ResolveCertificateV2Response) |  |
 | RevokeEntityCertificates | [RevokeEntityCertificatesRequest](#atom-v1-RevokeEntityCertificatesRequest) | [RevokeEntityCertificatesResponse](#atom-v1-RevokeEntityCertificatesResponse) |  |
 
  
@@ -331,4 +374,3 @@ runtime services that terminate mTLS outside Atom.
 | <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
-

--- a/apidocs/grpc.md
+++ b/apidocs/grpc.md
@@ -18,7 +18,7 @@ Runtime services should call Atom over the service network. The default containe
 
 ### Authentication Metadata
 
-`AuthzService.Check`, `AliasService.ResolveAlias`, `CertificateService.ResolveCertificate`, and `CertificateService.RevokeEntityCertificates` require gRPC metadata:
+`AuthzService.Check`, `AliasService.ResolveAlias`, both certificate resolver versions, and `CertificateService.RevokeEntityCertificates` require gRPC metadata:
 
 ```text
 authorization: Bearer <jwt-or-api-key>
@@ -205,13 +205,71 @@ grpcurl -plaintext \
 
 Certificate runtime lookup and entity-wide certificate revocation for services that terminate mTLS outside Atom.
 
+#### `ResolveCertificateV2`
+
+```text
+rpc ResolveCertificateV2(ResolveCertificateV2Request) returns (ResolveCertificateV2Response)
+```
+
+Resolves an authoritative certificate identity without relying on a globally unique serial. Supply at least one of leaf DER, leaf SHA-256 fingerprint, or the managed issuer-fingerprint/serial pair. If more than one selector is supplied, every selector must identify the same credential.
+
+Atom denies credentials that are unknown, `revocation_pending`, revoked, expired, owned by an inactive/deleted entity, owned by a frozen/deleted tenant, or issued by an authority that is unavailable for verification. Certificates from retiring and retained retired issuers continue to verify until expiry. An optional expected tenant is compared before the caller proceeds to authorization; a global entity always returns an empty tenant.
+
+Requires `authorization: Bearer <token>` metadata. The caller must have `authz.check` permission for the resolved certificate tenant or platform.
+
+**Request: `ResolveCertificateV2Request`**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `certificate_der` | `bytes` | conditional | Complete leaf certificate DER, limited to 64 KiB. Atom derives its SHA-256 fingerprint. |
+| `fingerprint_sha256` | `string` | conditional | SHA-256 over leaf DER; separators and case are normalized. |
+| `issuer_fingerprint_sha256` | `string` | conditional | Managed issuer certificate SHA-256. Must be paired with `serial_number`. |
+| `serial_number` | `string` | conditional | Normalized certificate serial. Must be paired with `issuer_fingerprint_sha256`. |
+| `expected_tenant_id` | `string` UUID | no | Tenant the relying party expects. A mismatch, including global versus tenant-owned, is denied. |
+
+**Response: `ResolveCertificateV2Response`**
+
+| Field | Type | Description |
+|---|---|---|
+| `entity_id` | `string` UUID | Entity that owns the certificate. |
+| `tenant_id` | `string` UUID | Owning tenant; empty for a global entity. |
+| `credential_id` | `string` UUID | Exact certificate credential. |
+| `issuer_id` | `string` UUID | Exact managed issuer; empty only for a legacy file-issuer credential resolved by DER/fingerprint. |
+| `expires_at` | `string` RFC3339 | Certificate expiry. |
+| `status` | `string` | Verified credential status (`active`). |
+
+**gRPC status codes**
+
+| Code | Condition |
+|---|---|
+| `OK` | All selectors agree, every lifecycle check passes, and the caller is authorized. |
+| `INVALID_ARGUMENT` | Selector shape, UUID, fingerprint, serial, or DER is invalid or oversized. |
+| `NOT_FOUND` | The sole exact selector does not identify a credential. |
+| `UNAUTHENTICATED` | Caller metadata is invalid, selectors disagree, or certificate lifecycle validation fails. |
+| `PERMISSION_DENIED` | Expected tenant mismatches or the caller lacks `authz.check` authority. |
+| `INTERNAL` | Database or internal error. |
+
+**Example**
+
+```bash
+grpcurl -plaintext \
+  -H 'authorization: Bearer '"$ATOM_TOKEN" \
+  -d '{
+    "fingerprint_sha256": "0f2d...",
+    "issuer_fingerprint_sha256": "8a91...",
+    "serial_number": "01af23",
+    "expected_tenant_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+  }' \
+  atom:8081 atom.v1.CertificateService/ResolveCertificateV2
+```
+
 #### `ResolveCertificate`
 
 ```text
 rpc ResolveCertificate(ResolveCertificateRequest) returns (ResolveCertificateResponse)
 ```
 
-Resolves an active Atom certificate credential by serial number, optionally checking the SHA-256 certificate fingerprint. Use this after a runtime service extracts a client certificate from mTLS.
+Deprecated compatibility API for the legacy file issuer only. It resolves by serial inside the separately unique `issuer_id IS NULL` namespace and optionally corroborates the SHA-256 certificate fingerprint. Managed credentials are never returned; new consumers must use `ResolveCertificateV2`.
 
 Requires `authorization: Bearer <token>` metadata. The caller must have `authz.check` permission for the resolved certificate tenant or platform.
 
@@ -236,9 +294,9 @@ Requires `authorization: Bearer <token>` metadata. The caller must have `authz.c
 | Code | Condition |
 |---|---|
 | `OK` | Certificate resolved and caller is authorized. |
-| `UNAUTHENTICATED` | Authorization metadata is missing, malformed, expired, or invalid. |
+| `UNAUTHENTICATED` | Authorization metadata is invalid, the credential is inactive/expired, its owner scope is inactive, or the fingerprint does not match. |
 | `PERMISSION_DENIED` | Caller lacks `authz.check` authority for the resolved tenant or platform. |
-| `NOT_FOUND` | Certificate serial is unknown, revoked, expired, or fingerprint does not match. |
+| `NOT_FOUND` | The legacy serial is unknown. |
 | `INTERNAL` | Database or internal error. |
 
 **Example**
@@ -252,6 +310,10 @@ grpcurl -plaintext \
   }' \
   atom:8081 atom.v1.CertificateService/ResolveCertificate
 ```
+
+#### Cache invalidation events
+
+When event publishing is configured, the existing `certificate.issue`, `certificate.renew`, `certificate.revoke`, and `certificate.revoke_entity` outbox events are the resolver cache-invalidation contract. Resolver caches should store the returned `credential_id`, `issuer_id`, and tenant alongside their lookup key so these exact lifecycle events can evict entries. Entity, tenant, and authority lifecycle events must also invalidate entries for their affected scope. Event delivery is at least once; consumers must make invalidation idempotent.
 
 #### `RevokeEntityCertificates`
 

--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -269,8 +269,9 @@ generated-key request; a revoked subject must use fresh enrollment. This
 recovery never treats an expired or revoked certificate as authentication.
 
 The original serial-based `renewCertificate` mutation remains the explicit v1
-compatibility path until resolver-v2 migration is complete. New integrations
-must use the exact-credential v2 mutations.
+compatibility path for `issuerId: null` file-issuer credentials. It is isolated
+to that separately unique legacy namespace; new integrations use the
+exact-credential v2 mutations.
 
 ## Issuer-aware revocation (v2)
 
@@ -284,7 +285,7 @@ these selectors:
 Serial alone is deliberately not a managed-certificate selector. The original
 `revokeCertificate` mutation is retained only for legacy `issuerId: null`
 credentials; it rejects managed certificates so new callers cannot create an
-ambiguous mutation dependency before the resolver-v2 cutover.
+ambiguous mutation dependency after the resolver-v2 cutover.
 
 ```graphql
 mutation RevokeManagedCertificate($input: RevokeCertificateV2Input!) {
@@ -450,6 +451,34 @@ file-backed route; managed clients use their issuer-specific AIA URL.
 
 ## Runtime Lookup
 
-Runtime services should prefer certificate fingerprint plus serial number when asking Atom to resolve a certificate. Atom returns identity only for active, known, non-expired, non-revoked certificates.
+Runtime services use `CertificateService.ResolveCertificateV2`. Supply at least
+one exact selector:
 
-If the certificate is unknown, expired, revoked, or issued by the wrong issuer, Atom returns a negative result.
+- the complete leaf DER, from which Atom derives SHA-256;
+- the leaf DER SHA-256 fingerprint; or
+- a managed issuer fingerprint together with the normalized leaf serial.
+
+When more than one selector is supplied, every selector must identify the same
+credential. Atom returns the entity, tenant, credential, issuer, expiry, and
+status. A global entity returns an empty tenant and never acquires tenant scope.
+Use `expectedTenantId` to bind a resolution to the relying party's requested
+scope before normal authorization.
+
+Resolution denies unknown, `revocation_pending`, revoked, expired,
+inactive/deleted-entity, frozen/deleted-tenant, and unavailable-issuer state.
+Retiring and retained retired issuers continue to verify existing leaves until
+expiry. Managed serial uniqueness is scoped to `issuerId`; independent issuers
+may safely use the same serial.
+
+`CertificateService.ResolveCertificate` is deprecated and can see only the
+separately unique legacy file-issuer namespace where `issuerId` is null. It can
+never select a managed credential.
+
+When event publishing is configured, invalidate resolver caches from
+`certificate.issue`, `certificate.renew`, `certificate.revoke`, and
+`certificate.revoke_entity`, plus entity, tenant, and authority lifecycle
+events. Cache the returned credential, issuer, entity, and tenant IDs with the
+lookup key so invalidation is exact and idempotent under at-least-once delivery.
+
+CRL and OCSP remain interoperability artifacts. Immediate resolver denial plus
+short certificate lifetimes are the primary revocation control.

--- a/migrations/012_pki_runtime_resolver_v2.sql
+++ b/migrations/012_pki_runtime_resolver_v2.sql
@@ -1,0 +1,32 @@
+-- Unambiguous certificate runtime identity and issuer-scoped serials.
+--
+-- Application readers in PR-011 resolve managed credentials by fingerprint or
+-- issuer identity plus serial. The only serial-only compatibility reader is
+-- explicitly restricted to issuer_id IS NULL, the legacy file-issuer namespace.
+-- Build both replacement unique indexes before removing the old global one so
+-- the migration never exposes an unconstrained serial window.
+
+ALTER TABLE credentials
+    DROP CONSTRAINT credentials_status_check;
+
+ALTER TABLE credentials
+    ADD CONSTRAINT credentials_status_check
+    CHECK (
+        status IN ('active', 'revoked')
+        OR (kind = 'certificate' AND status = 'revocation_pending')
+    );
+
+CREATE UNIQUE INDEX idx_credentials_certificate_issuer_serial
+    ON credentials(issuer_id, identifier)
+    WHERE kind = 'certificate'
+      AND issuer_id IS NOT NULL
+      AND identifier IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_credentials_certificate_legacy_serial
+    ON credentials(identifier)
+    WHERE kind = 'certificate'
+      AND issuer_id IS NULL
+      AND identifier IS NOT NULL;
+
+DROP INDEX idx_credentials_certificate_serial;
+DROP INDEX idx_credentials_certificate_issuer_serial_lookup;

--- a/product-docs/12-certificates.md
+++ b/product-docs/12-certificates.md
@@ -216,12 +216,27 @@ Public PKI endpoints expose standard unauthenticated artifacts:
 
 Runtime services use Atom gRPC:
 
-- `CertificateService.ResolveCertificate`
+- `CertificateService.ResolveCertificateV2`
+- `CertificateService.ResolveCertificate` (deprecated legacy file-issuer namespace only)
 - `CertificateService.RevokeEntityCertificates`
 
-HTTP GraphQL remains bearer-token based. Client TLS termination and certificate extraction are handled by the runtime service, which then asks Atom to resolve the serial and optional fingerprint.
+HTTP GraphQL remains bearer-token based. Client TLS termination and certificate extraction are handled by the runtime service, which passes the leaf DER/fingerprint and, when available, the issuer fingerprint plus serial to Atom.
 
-Runtime certificate lookup is authorization-gated. A caller of `ResolveCertificate` must authenticate to Atom and hold `authz.check` on the resolved certificate tenant or platform.
+`ResolveCertificateV2` treats the SHA-256 fingerprint over leaf DER as the preferred runtime identity. A managed issuer fingerprint plus normalized serial is an exact alternative. Multiple supplied selectors must all identify the same credential. The response includes entity, tenant, credential, issuer, expiry, and status; a global entity returns an empty tenant and does not acquire tenant scope.
+
+Runtime resolution fails closed for `revocation_pending`, revoked, expired, inactive/deleted-entity, frozen/deleted-tenant, and unavailable-issuer state. Retiring and retained retired issuers remain valid for verification until certificate expiry. The optional expected tenant is compared before authorization. The authenticated caller must then hold `authz.check` on the resolved tenant or platform.
+
+The deprecated `ResolveCertificate` method can resolve only `issuer_id IS NULL` legacy file-issuer credentials. Its serial-only query is isolated by a dedicated legacy unique index and can never select a managed credential.
+
+### Runtime identity and serial uniqueness
+
+Independent issuers may reuse a serial. Managed certificate identity is therefore `(issuer_id, normalized serial_number)`, with a separate unique constraint for each issuer. Legacy file-issuer credentials retain one unique global namespace where `issuer_id IS NULL`. Fingerprints remain globally unique.
+
+No managed GraphQL, renewal, revocation, CRL, OCSP, or identity path selects a certificate by serial alone. Compatibility GraphQL/renewal/revocation and the global CRL/OCSP routes are explicitly limited to the legacy namespace.
+
+### Resolver cache invalidation
+
+When event publishing is configured, consumers use `certificate.issue`, `certificate.renew`, `certificate.revoke`, and `certificate.revoke_entity` outbox events to invalidate cached resolutions. Cache entries should retain the returned credential, issuer, entity, and tenant identifiers so invalidation is exact. Entity, tenant, and authority lifecycle events invalidate their affected scope. Delivery is at least once, so invalidation is idempotent; polling is not the revocation strategy.
 
 ---
 

--- a/product-docs/15-pki-implementation-roadmap.md
+++ b/product-docs/15-pki-implementation-roadmap.md
@@ -176,7 +176,9 @@ the window is expected and fine.
 ## Migration policy
 
 1. Existing v1 credentials retain `issuer_id = NULL`.
-2. Global serial uniqueness remains until PR-011 migrates all serial-only readers.
+2. PR-011 migrates managed readers to fingerprint or issuer-plus-serial, then
+   replaces global uniqueness with issuer-scoped uniqueness while preserving a
+   separately unique `issuer_id = NULL` legacy namespace.
 3. New tenant issuance starts only after issuer-aware service paths are merged and the production flag is lifted.
 4. Existing certificates migrate by renewal, not by rewriting issued certificates.
 5. The legacy CA chain, CRL, and OCSP remain available until the last legacy leaf expires plus retention.

--- a/product-docs/development/pki/pr-011-runtime-resolver-v2.md
+++ b/product-docs/development/pki/pr-011-runtime-resolver-v2.md
@@ -1,5 +1,9 @@
 # PR-011 — Certificate Runtime Resolver v2
 
+## Status
+
+Implemented by the PR-011 delivery branch.
+
 ## Objective
 
 Make runtime certificate identity unambiguous and unlock safe duplicate serials across tenant issuers.

--- a/proto/atom/v1/atom.proto
+++ b/proto/atom/v1/atom.proto
@@ -18,7 +18,11 @@ service AuthService {
 // CertificateService resolves and revokes Atom certificate credentials for
 // runtime services that terminate mTLS outside Atom.
 service CertificateService {
-  rpc ResolveCertificate(ResolveCertificateRequest) returns (ResolveCertificateResponse);
+  // Legacy file-issuer resolver. Managed issuers must use ResolveCertificateV2.
+  rpc ResolveCertificate(ResolveCertificateRequest) returns (ResolveCertificateResponse) {
+    option deprecated = true;
+  }
+  rpc ResolveCertificateV2(ResolveCertificateV2Request) returns (ResolveCertificateV2Response);
   rpc RevokeEntityCertificates(RevokeEntityCertificatesRequest) returns (RevokeEntityCertificatesResponse);
 }
 
@@ -99,6 +103,28 @@ message ResolveCertificateResponse {
   string tenant_id = 2;
   string credential_id = 3;
   string expires_at = 4;
+}
+
+// Unambiguous runtime resolution. At least one of certificate_der,
+// fingerprint_sha256, or the issuer-fingerprint/serial pair is required. When
+// multiple selectors are supplied they must all identify the same credential.
+message ResolveCertificateV2Request {
+  bytes certificate_der = 1;
+  string fingerprint_sha256 = 2;
+  string issuer_fingerprint_sha256 = 3;
+  string serial_number = 4;
+  // Optional tenant binding. Empty means no expected tenant; a global entity
+  // still resolves with an empty tenant_id and never acquires tenant scope.
+  string expected_tenant_id = 5;
+}
+
+message ResolveCertificateV2Response {
+  string entity_id = 1;
+  string tenant_id = 2;
+  string credential_id = 3;
+  string issuer_id = 4;
+  string expires_at = 5;
+  string status = 6;
 }
 
 message RevokeEntityCertificatesRequest {

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -78,7 +78,7 @@ impl CertificateQuery {
                     .await
                     .map_err(gql_error)?
             }
-            (None, Some(serial)) => service::certificate_by_serial(&state.pool, &serial)
+            (None, Some(serial)) => service::legacy_certificate_by_serial(&state.pool, &serial)
                 .await
                 .map_err(gql_error)?,
             _ => {
@@ -323,7 +323,7 @@ impl CertificateMutation {
     ) -> Result<IssuedCertificate> {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
-        let old = service::certificate_by_serial(&state.pool, &input.serial_number)
+        let old = service::legacy_certificate_by_serial(&state.pool, &input.serial_number)
             .await
             .map_err(gql_error)?;
         require_certificate_rotate(state, &auth, &old).await?;
@@ -404,7 +404,7 @@ impl CertificateMutation {
         input: RevokeCertificateInput,
     ) -> Result<Certificate> {
         let state = ctx.data::<AppState>()?;
-        let cert = service::certificate_by_serial(&state.pool, &input.serial_number)
+        let cert = service::legacy_certificate_by_serial(&state.pool, &input.serial_number)
             .await
             .map_err(gql_error)?;
         if cert.issuer_id.is_some() {

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -18,6 +18,30 @@ pub struct CertificateCredential {
     pub created_at: DateTime<Utc>,
 }
 
+/// Certificate row plus every lifecycle state needed by the authoritative
+/// runtime resolver. Keeping this projection separate prevents management
+/// queries from accidentally treating their less restrictive joins as an
+/// authentication decision.
+#[derive(Debug, Clone, FromRow)]
+pub struct RuntimeCertificateCredential {
+    pub id: Uuid,
+    pub issuer_id: Option<Uuid>,
+    pub entity_id: Uuid,
+    pub tenant_id: Option<Uuid>,
+    pub identifier: String,
+    pub credential_status: String,
+    pub metadata: Value,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub entity_status: String,
+    pub entity_deleted_at: Option<DateTime<Utc>>,
+    pub tenant_status: Option<String>,
+    pub tenant_deleted_at: Option<DateTime<Utc>>,
+    pub issuer_status: Option<String>,
+    pub issuer_issuance_enabled: Option<bool>,
+    pub issuer_not_before: Option<DateTime<Utc>>,
+    pub issuer_not_after: Option<DateTime<Utc>>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CertificateIssuanceRequestClaim {
     New { request_id: Uuid },
@@ -304,7 +328,10 @@ pub async fn complete_certificate_renewal(
     Ok(())
 }
 
-pub async fn certificate_by_serial<'e, E>(
+/// Legacy file-issuer lookup. Managed credentials are deliberately excluded:
+/// after PR-011 only the `issuer_id IS NULL` namespace has serial-only
+/// compatibility, and that namespace retains its own unique index.
+pub async fn legacy_certificate_by_serial<'e, E>(
     executor: E,
     serial_number: &str,
 ) -> Result<CertificateCredential, AppError>
@@ -317,11 +344,104 @@ where
                c.expires_at, c.created_at
         FROM credentials c
         JOIN entities e ON e.id = c.entity_id
-        WHERE c.kind = 'certificate' AND c.identifier = $1
+        WHERE c.kind = 'certificate'
+          AND c.issuer_id IS NULL
+          AND c.identifier = $1
         "#,
     )
     .bind(serial_number)
     .fetch_one(executor)
+    .await
+    .map_err(db_err)
+}
+
+pub async fn runtime_certificate_by_fingerprint(
+    pool: &PgPool,
+    fingerprint_sha256: &str,
+) -> Result<RuntimeCertificateCredential, AppError> {
+    sqlx::query_as::<_, RuntimeCertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier,
+               c.status AS credential_status, c.metadata, c.expires_at,
+               e.status AS entity_status, e.deleted_at AS entity_deleted_at,
+               t.status AS tenant_status, t.deleted_at AS tenant_deleted_at,
+               a.status AS issuer_status,
+               a.issuance_enabled AS issuer_issuance_enabled,
+               a.not_before AS issuer_not_before,
+               a.not_after AS issuer_not_after
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        LEFT JOIN tenants t ON t.id = e.tenant_id
+        LEFT JOIN pki_authorities a ON a.id = c.issuer_id
+        WHERE c.kind = 'certificate'
+          AND c.metadata->>'fingerprint_sha256' = $1
+        "#,
+    )
+    .bind(fingerprint_sha256)
+    .fetch_one(pool)
+    .await
+    .map_err(db_err)
+}
+
+/// Managed-issuer selector. Legacy file-issuer rows have no authoritative
+/// `issuer_id` to return and remain reachable through DER/fingerprint v2
+/// selectors or the deprecated legacy resolver.
+pub async fn runtime_certificate_by_issuer_fingerprint_serial(
+    pool: &PgPool,
+    issuer_fingerprint_sha256: &str,
+    serial_number: &str,
+) -> Result<RuntimeCertificateCredential, AppError> {
+    sqlx::query_as::<_, RuntimeCertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier,
+               c.status AS credential_status, c.metadata, c.expires_at,
+               e.status AS entity_status, e.deleted_at AS entity_deleted_at,
+               t.status AS tenant_status, t.deleted_at AS tenant_deleted_at,
+               a.status AS issuer_status,
+               a.issuance_enabled AS issuer_issuance_enabled,
+               a.not_before AS issuer_not_before,
+               a.not_after AS issuer_not_after
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        LEFT JOIN tenants t ON t.id = e.tenant_id
+        LEFT JOIN pki_authorities a ON a.id = c.issuer_id
+        WHERE c.kind = 'certificate'
+          AND c.issuer_id IS NOT NULL
+          AND c.identifier = $2
+          AND a.fingerprint_sha256 = $1
+        "#,
+    )
+    .bind(issuer_fingerprint_sha256)
+    .bind(serial_number)
+    .fetch_one(pool)
+    .await
+    .map_err(db_err)
+}
+
+pub async fn runtime_legacy_certificate_by_serial(
+    pool: &PgPool,
+    serial_number: &str,
+) -> Result<RuntimeCertificateCredential, AppError> {
+    sqlx::query_as::<_, RuntimeCertificateCredential>(
+        r#"
+        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier,
+               c.status AS credential_status, c.metadata, c.expires_at,
+               e.status AS entity_status, e.deleted_at AS entity_deleted_at,
+               t.status AS tenant_status, t.deleted_at AS tenant_deleted_at,
+               NULL::text AS issuer_status,
+               NULL::boolean AS issuer_issuance_enabled,
+               NULL::timestamptz AS issuer_not_before,
+               NULL::timestamptz AS issuer_not_after
+        FROM credentials c
+        JOIN entities e ON e.id = c.entity_id
+        LEFT JOIN tenants t ON t.id = e.tenant_id
+        WHERE c.kind = 'certificate'
+          AND c.issuer_id IS NULL
+          AND c.identifier = $1
+        "#,
+    )
+    .bind(serial_number)
+    .fetch_one(pool)
     .await
     .map_err(db_err)
 }

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -47,6 +47,7 @@ const SERIAL_INSERT_ATTEMPTS: usize = 3;
 pub const OCSP_REQUEST_MAX_BYTES: usize = 16 * 1024;
 const OCSP_MAX_SINGLE_REQUESTS: usize = 16;
 const OCSP_VALIDITY_SECONDS: i64 = 300;
+pub const RUNTIME_CERTIFICATE_DER_MAX_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct IssueCertificate {
@@ -107,6 +108,15 @@ pub struct RenewCertificateV2 {
     pub key_source: RenewalKeySource,
     pub revoke_old: bool,
     pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolveCertificateV2 {
+    pub certificate_der: Option<Vec<u8>>,
+    pub fingerprint_sha256: Option<String>,
+    pub issuer_fingerprint_sha256: Option<String>,
+    pub serial_number: Option<String>,
+    pub expected_tenant_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -270,7 +280,9 @@ pub struct CertificateIdentity {
     pub entity_id: Uuid,
     pub tenant_id: Option<Uuid>,
     pub credential_id: Uuid,
+    pub issuer_id: Option<Uuid>,
     pub expires_at: DateTime<Utc>,
+    pub status: String,
 }
 
 pub struct CertificateIssuer {
@@ -921,7 +933,7 @@ pub async fn renew_certificate_in_tx(
     input: RenewCertificate,
 ) -> Result<IssuedCertificate, AppError> {
     let serial = normalize_serial(&input.serial_number)?;
-    let old = record_from_row(repo::certificate_by_serial(&mut **tx, &serial).await?)?;
+    let old = record_from_row(repo::legacy_certificate_by_serial(&mut **tx, &serial).await?)?;
     if old.status == "revoked" {
         return Err(AppError::bad_request("cannot renew a revoked certificate"));
     }
@@ -1192,7 +1204,7 @@ pub async fn revoke_certificate_in_tx(
     reason: Option<String>,
 ) -> Result<CertificateRecord, AppError> {
     let serial = normalize_serial(serial_number)?;
-    let current = repo::certificate_by_serial(&mut **tx, &serial).await?;
+    let current = repo::legacy_certificate_by_serial(&mut **tx, &serial).await?;
     if current.issuer_id.is_some() {
         return Err(AppError::bad_request(
             "managed certificate revocation requires an exact v2 selector",
@@ -1376,13 +1388,22 @@ pub async fn revoke_entity_certificates_v2_in_tx(
     })
 }
 
+pub async fn legacy_certificate_by_serial(
+    pool: &sqlx::PgPool,
+    serial_number: &str,
+) -> Result<CertificateRecord, AppError> {
+    repo::legacy_certificate_by_serial(pool, &normalize_serial(serial_number)?)
+        .await
+        .and_then(record_from_row)
+}
+
+/// Backward-compatible alias for the legacy file-issuer management lookup.
+/// New managed paths must use an exact credential, fingerprint, or issuer pair.
 pub async fn certificate_by_serial(
     pool: &sqlx::PgPool,
     serial_number: &str,
 ) -> Result<CertificateRecord, AppError> {
-    repo::certificate_by_serial(pool, &normalize_serial(serial_number)?)
-        .await
-        .and_then(record_from_row)
+    legacy_certificate_by_serial(pool, serial_number).await
 }
 
 pub async fn certificate_by_id(
@@ -1617,7 +1638,7 @@ pub async fn ocsp_response(
         let issuer_matches = certid_issuer_matches(&one.req_cert, &loaded.certificate_der)?;
         let status = if issuer_matches {
             let serial = serial_from_ocsp_request(&one.req_cert)?;
-            match repo::certificate_by_serial(pool, &serial).await {
+            match repo::legacy_certificate_by_serial(pool, &serial).await {
                 Ok(cert) if cert.status == "active" => CertStatus::good(),
                 Ok(cert) => {
                     let metadata = metadata_from_value(&cert.metadata)?;
@@ -1731,35 +1752,225 @@ pub async fn issuer_ocsp_response(
     )
 }
 
+/// Deprecated runtime compatibility resolver for the legacy file issuer.
+///
+/// Serial-only resolution is safe solely inside the `issuer_id IS NULL`
+/// namespace, which retains a dedicated unique index. Managed certificates are
+/// intentionally invisible here and must use [`resolve_certificate_identity_v2`].
 pub async fn resolve_certificate_identity(
     pool: &sqlx::PgPool,
     serial_number: &str,
     fingerprint_sha256: Option<&str>,
 ) -> Result<CertificateIdentity, AppError> {
-    let record = certificate_by_serial(pool, serial_number).await?;
-    if record.status != "active" {
-        return Err(AppError::Unauthorized("certificate revoked".into()));
-    }
-    let expires_at = record
-        .expires_at
-        .ok_or_else(|| AppError::Unauthorized("certificate has no expiry".into()))?;
-    if expires_at <= Utc::now() {
-        return Err(AppError::Unauthorized("certificate expired".into()));
-    }
+    let serial = normalize_serial(serial_number)?;
+    let record = repo::runtime_legacy_certificate_by_serial(pool, &serial).await?;
     if let Some(expected) = fingerprint_sha256 {
-        if normalize_fingerprint(expected) != normalize_fingerprint(&record.fingerprint_sha256) {
+        let expected = validated_fingerprint(expected)?;
+        if expected != runtime_stored_fingerprint(&record)? {
             return Err(AppError::Unauthorized(
                 "certificate fingerprint mismatch".into(),
             ));
         }
     }
-    repo::entity_tenant_id(pool, record.entity_id).await?;
+    runtime_identity_from_row(record, None)
+}
+
+/// Authoritative, issuer-aware certificate resolver. Every supplied selector
+/// is independently verified and, when more than one is present, all selectors
+/// must identify the same credential.
+pub async fn resolve_certificate_identity_v2(
+    pool: &sqlx::PgPool,
+    input: ResolveCertificateV2,
+) -> Result<CertificateIdentity, AppError> {
+    let der_fingerprint = input
+        .certificate_der
+        .as_deref()
+        .map(runtime_der_fingerprint)
+        .transpose()?;
+    let supplied_fingerprint = input
+        .fingerprint_sha256
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(validated_fingerprint)
+        .transpose()?;
+    if let (Some(derived), Some(supplied)) = (&der_fingerprint, &supplied_fingerprint) {
+        if derived != supplied {
+            return Err(runtime_selector_mismatch());
+        }
+    }
+    let fingerprint = der_fingerprint.or(supplied_fingerprint);
+
+    let issuer_fingerprint = input
+        .issuer_fingerprint_sha256
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(validated_fingerprint)
+        .transpose()?;
+    let serial = input
+        .serial_number
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(normalize_serial)
+        .transpose()?;
+    let issuer_serial = match (issuer_fingerprint, serial) {
+        (Some(issuer_fingerprint), Some(serial)) => Some((issuer_fingerprint, serial)),
+        (None, None) => None,
+        _ => {
+            return Err(AppError::bad_request(
+                "issuer_fingerprint_sha256 and serial_number must be supplied together",
+            ))
+        }
+    };
+
+    if fingerprint.is_none() && issuer_serial.is_none() {
+        return Err(AppError::bad_request(
+            "provide certificate_der, fingerprint_sha256, or issuer fingerprint plus serial",
+        ));
+    }
+
+    let record = match (fingerprint.as_deref(), issuer_serial.as_ref()) {
+        (Some(fingerprint), None) => {
+            repo::runtime_certificate_by_fingerprint(pool, fingerprint).await?
+        }
+        (None, Some((issuer_fingerprint, serial))) => {
+            repo::runtime_certificate_by_issuer_fingerprint_serial(pool, issuer_fingerprint, serial)
+                .await?
+        }
+        (Some(fingerprint), Some((issuer_fingerprint, serial))) => {
+            let by_fingerprint = repo::runtime_certificate_by_fingerprint(pool, fingerprint).await;
+            let by_issuer = repo::runtime_certificate_by_issuer_fingerprint_serial(
+                pool,
+                issuer_fingerprint,
+                serial,
+            )
+            .await;
+            match by_fingerprint {
+                Ok(by_fingerprint) => match by_issuer {
+                    Ok(by_issuer) if by_fingerprint.id == by_issuer.id => by_fingerprint,
+                    Ok(_) | Err(AppError::NotFound(_)) => return Err(runtime_selector_mismatch()),
+                    Err(error) => return Err(error),
+                },
+                Err(AppError::NotFound(_)) => match by_issuer {
+                    Ok(_) | Err(AppError::NotFound(_)) => return Err(runtime_selector_mismatch()),
+                    Err(error) => return Err(error),
+                },
+                Err(error) => return Err(error),
+            }
+        }
+        (None, None) => {
+            return Err(AppError::bad_request(
+                "certificate resolver selector is missing",
+            ))
+        }
+    };
+
+    runtime_identity_from_row(record, input.expected_tenant_id)
+}
+
+fn runtime_der_fingerprint(certificate_der: &[u8]) -> Result<String, AppError> {
+    if certificate_der.is_empty() {
+        return Err(AppError::bad_request("certificate_der must not be empty"));
+    }
+    if certificate_der.len() > RUNTIME_CERTIFICATE_DER_MAX_BYTES {
+        return Err(AppError::payload_too_large(format!(
+            "certificate_der exceeds {} bytes",
+            RUNTIME_CERTIFICATE_DER_MAX_BYTES
+        )));
+    }
+    let (remaining, _) = x509_parser::parse_x509_certificate(certificate_der)
+        .map_err(|_| AppError::bad_request("invalid X.509 certificate DER"))?;
+    if !remaining.is_empty() {
+        return Err(AppError::bad_request(
+            "certificate_der contains trailing data",
+        ));
+    }
+    Ok(hex::encode(
+        digest::digest(&digest::SHA256, certificate_der).as_ref(),
+    ))
+}
+
+fn runtime_stored_fingerprint(
+    record: &repo::RuntimeCertificateCredential,
+) -> Result<String, AppError> {
+    let value = record
+        .metadata
+        .get("fingerprint_sha256")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::Unauthorized("certificate fingerprint is unavailable".into()))?;
+    validated_fingerprint(value)
+        .map_err(|_| AppError::Unauthorized("certificate fingerprint is invalid".into()))
+}
+
+fn runtime_identity_from_row(
+    record: repo::RuntimeCertificateCredential,
+    expected_tenant_id: Option<Uuid>,
+) -> Result<CertificateIdentity, AppError> {
+    if record.credential_status != "active" {
+        return Err(AppError::Unauthorized(
+            "certificate credential is not active".into(),
+        ));
+    }
+    let now = Utc::now();
+    let expires_at = record
+        .expires_at
+        .ok_or_else(|| AppError::Unauthorized("certificate has no expiry".into()))?;
+    if expires_at <= now {
+        return Err(AppError::Unauthorized("certificate expired".into()));
+    }
+    runtime_stored_fingerprint(&record)?;
+
+    if record.entity_status != "active" || record.entity_deleted_at.is_some() {
+        return Err(AppError::Unauthorized(
+            "certificate entity is not active".into(),
+        ));
+    }
+    if record.tenant_id.is_some()
+        && (record.tenant_status.as_deref() != Some("active") || record.tenant_deleted_at.is_some())
+    {
+        return Err(AppError::Unauthorized(
+            "certificate tenant is not active".into(),
+        ));
+    }
+    if expected_tenant_id.is_some() && expected_tenant_id != record.tenant_id {
+        return Err(AppError::Forbidden);
+    }
+
+    if record.issuer_id.is_some() {
+        let issuer_enabled = match record.issuer_status.as_deref() {
+            Some("active") => record.issuer_issuance_enabled == Some(true),
+            Some("retiring" | "retired") => true,
+            _ => false,
+        };
+        if !issuer_enabled {
+            return Err(AppError::Unauthorized(
+                "certificate issuer is not enabled for verification".into(),
+            ));
+        }
+        if record
+            .issuer_not_before
+            .is_none_or(|not_before| not_before > now)
+            || record
+                .issuer_not_after
+                .is_none_or(|not_after| not_after <= now)
+        {
+            return Err(AppError::Unauthorized(
+                "certificate issuer is outside its validity period".into(),
+            ));
+        }
+    }
+
     Ok(CertificateIdentity {
         entity_id: record.entity_id,
         tenant_id: record.tenant_id,
-        credential_id: record.credential_id,
+        credential_id: record.id,
+        issuer_id: record.issuer_id,
         expires_at,
+        status: record.credential_status,
     })
+}
+
+fn runtime_selector_mismatch() -> AppError {
+    AppError::Unauthorized("certificate selectors do not identify the same credential".into())
 }
 
 pub fn normalize_serial(serial_number: &str) -> Result<String, AppError> {
@@ -2243,9 +2454,9 @@ fn leaf_ttl(config: &Config, ttl_secs: Option<u64>) -> Result<u64, AppError> {
 
 fn validate_certificate_status(status: String) -> Result<String, AppError> {
     match status.as_str() {
-        "active" | "revoked" => Ok(status),
+        "active" | "revocation_pending" | "revoked" => Ok(status),
         _ => Err(AppError::bad_request(
-            "certificate status must be active or revoked",
+            "certificate status must be active, revocation_pending, or revoked",
         )),
     }
 }

--- a/src/graphql/credentials.rs
+++ b/src/graphql/credentials.rs
@@ -442,9 +442,12 @@ fn parse_credential_status(
     match status {
         None => Ok(None),
         Some("active") => Ok(Some(crate::models::enums::CredentialStatus::Active)),
+        Some("revocation_pending") => Ok(Some(
+            crate::models::enums::CredentialStatus::RevocationPending,
+        )),
         Some("revoked") => Ok(Some(crate::models::enums::CredentialStatus::Revoked)),
         Some(other) => Err(gql_error(crate::error::AppError::bad_request(format!(
-            "invalid status filter: {other} (expected 'active' or 'revoked')"
+            "invalid status filter: {other} (expected 'active', 'revocation_pending', or 'revoked')"
         )))),
     }
 }

--- a/src/graphql/types/mod.rs
+++ b/src/graphql/types/mod.rs
@@ -2881,6 +2881,7 @@ impl From<&CredentialKind> for GqlCredentialKind {
 fn credential_status_as_str(status: &CredentialStatus) -> &'static str {
     match status {
         CredentialStatus::Active => "active",
+        CredentialStatus::RevocationPending => "revocation_pending",
         CredentialStatus::Revoked => "revoked",
     }
 }

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -35,7 +35,8 @@ use proto::{
     certificate_service_server::{CertificateService, CertificateServiceServer},
     AuthenticateCredentialRequest, AuthenticateCredentialResponse, AuthenticateRequest,
     AuthenticateResponse, CheckRequest, CheckResponse, ResolveAliasRequest, ResolveAliasResponse,
-    ResolveCertificateRequest, ResolveCertificateResponse, RevokeEntityCertificatesRequest,
+    ResolveCertificateRequest, ResolveCertificateResponse, ResolveCertificateV2Request,
+    ResolveCertificateV2Response, RevokeEntityCertificatesRequest,
     RevokeEntityCertificatesResponse,
 };
 
@@ -337,6 +338,55 @@ impl CertificateService for AtomCertificates {
                 .unwrap_or_default(),
             credential_id: identity.credential_id.to_string(),
             expires_at: identity.expires_at.to_rfc3339(),
+        }))
+    }
+
+    async fn resolve_certificate_v2(
+        &self,
+        request: Request<ResolveCertificateV2Request>,
+    ) -> Result<Response<ResolveCertificateV2Response>, Status> {
+        let auth = auth_context_from_metadata(&self.state, request.metadata()).await?;
+        let req = request.into_inner();
+        let expected_tenant_id = parse_optional_uuid(&req.expected_tenant_id, "expected_tenant_id")
+            .map_err(Status::from)?;
+        let identity = certs::service::resolve_certificate_identity_v2(
+            &self.state.pool,
+            certs::service::ResolveCertificateV2 {
+                certificate_der: (!req.certificate_der.is_empty()).then_some(req.certificate_der),
+                fingerprint_sha256: (!req.fingerprint_sha256.trim().is_empty())
+                    .then_some(req.fingerprint_sha256),
+                issuer_fingerprint_sha256: (!req.issuer_fingerprint_sha256.trim().is_empty())
+                    .then_some(req.issuer_fingerprint_sha256),
+                serial_number: (!req.serial_number.trim().is_empty()).then_some(req.serial_number),
+                expected_tenant_id,
+            },
+        )
+        .await
+        .map_err(Status::from)?;
+        require_any_capability(
+            &self.state.pool,
+            &auth,
+            &[
+                ("authz.check", scope_for_tenant(identity.tenant_id)),
+                ("authz.check", Scope::Platform),
+            ],
+        )
+        .await
+        .map_err(Status::from)?;
+
+        Ok(Response::new(ResolveCertificateV2Response {
+            entity_id: identity.entity_id.to_string(),
+            tenant_id: identity
+                .tenant_id
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+            credential_id: identity.credential_id.to_string(),
+            issuer_id: identity
+                .issuer_id
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+            expires_at: identity.expires_at.to_rfc3339(),
+            status: identity.status,
         }))
     }
 

--- a/src/models/enums.rs
+++ b/src/models/enums.rs
@@ -56,10 +56,11 @@ impl CredentialKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
-#[sqlx(type_name = "text", rename_all = "lowercase")]
-#[serde(rename_all = "lowercase")]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum CredentialStatus {
     Active,
+    RevocationPending,
     Revoked,
 }
 

--- a/tests/m29_pki_authorities.rs
+++ b/tests/m29_pki_authorities.rs
@@ -247,9 +247,9 @@ async fn authorities_are_scope_safe_and_rotation_ready() {
     .unwrap_err();
     assert!(is_database_code(&duplicate_fingerprint, "23505"));
 
-    // Serial-only v1 readers remain safe until resolver-v2: the existing global
-    // uniqueness rule still rejects the same serial under a different issuer.
-    let duplicate_serial = insert_certificate(
+    // Resolver v2 scopes managed serials by issuer, so a second issuer may use
+    // the same serial while each issuer-local key remains unique.
+    insert_certificate(
         &pool,
         entity_b,
         tenant_b_v1.id,
@@ -257,8 +257,15 @@ async fn authorities_are_scope_safe_and_rotation_ready() {
         &fingerprint(105),
     )
     .await
-    .unwrap_err();
-    assert!(is_database_code(&duplicate_serial, "23505"));
+    .unwrap();
+    let shared_serial_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM credentials WHERE kind = 'certificate' AND identifier = $1",
+    )
+    .bind("01020304")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(shared_serial_count, 2);
 
     let null_entity = sqlx::query(
         r#"INSERT INTO credentials

--- a/tests/m35_pki_revocation.rs
+++ b/tests/m35_pki_revocation.rs
@@ -189,13 +189,13 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
         "requires revokeCertificateV2"
     ));
 
-    // The selector remains unambiguous once PR-011 removes global serial
-    // uniqueness. Exercise that future database shape inside a rolled-back DDL
-    // transaction so this PR does not perform the resolver-v2 cutover early.
+    // PR-011's issuer-scoped uniqueness permits this duplicate across issuers;
+    // keep the fixture in a rolled-back transaction so later assertions in
+    // this test binary retain their original data set.
     let duplicate_a = issue_managed(&pool, &config, tenant_a, entity_a, "duplicate-a").await;
     let duplicate_b = issue_managed(&pool, &config, tenant_b, entity_b, "duplicate-b").await;
     let mut duplicate_tx = pool.begin().await.unwrap();
-    sqlx::query("DROP INDEX idx_credentials_certificate_serial")
+    sqlx::query("DROP INDEX IF EXISTS idx_credentials_certificate_serial")
         .execute(&mut *duplicate_tx)
         .await
         .unwrap();

--- a/tests/m35_pki_revocation.rs
+++ b/tests/m35_pki_revocation.rs
@@ -184,10 +184,12 @@ async fn issuer_aware_revocation_enforces_the_pr008_contract() {
             .data(auth(common::admin_id(), None)),
         )
         .await;
-    assert!(errors_contain(
-        &legacy_managed.errors,
-        "requires revokeCertificateV2"
-    ));
+    assert!(errors_contain(&legacy_managed.errors, "not found"));
+    assert_eq!(
+        certificate_status(&pool, unaffected.credential_id).await,
+        "active",
+        "the legacy serial-only mutation must not see a managed credential"
+    );
 
     // PR-011's issuer-scoped uniqueness permits this duplicate across issuers;
     // keep the fixture in a rolled-back transaction so later assertions in

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -268,10 +268,10 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
     .await;
     assert_eq!(oversized.status(), StatusCode::PAYLOAD_TOO_LARGE);
 
-    // Simulate the same serial under two issuers (PR-011 later changes the
-    // production uniqueness model). Exact issuer+serial lookup keeps A and B
-    // independent even after A is revoked.
-    sqlx::query("DROP INDEX idx_credentials_certificate_serial")
+    // PR-011's production uniqueness model permits the same serial under two
+    // issuers. Exact issuer+serial lookup keeps A and B independent even after
+    // A is revoked.
+    sqlx::query("DROP INDEX IF EXISTS idx_credentials_certificate_serial")
         .execute(&pool)
         .await
         .unwrap();

--- a/tests/m38_pki_runtime_resolver_v2.rs
+++ b/tests/m38_pki_runtime_resolver_v2.rs
@@ -741,7 +741,11 @@ async fn set_issuer_status(pool: &PgPool, issuer_id: Uuid, status: &str, enabled
         "UPDATE pki_authorities
          SET status = $2, issuance_enabled = $3,
              retiring_at = CASE WHEN $2 = 'retiring' THEN now() ELSE NULL END,
-             retired_at = CASE WHEN $2 = 'retired' THEN now() ELSE NULL END
+             retired_at = CASE WHEN $2 = 'retired' THEN now() ELSE NULL END,
+             failure_reason = CASE
+                 WHEN $2 = 'failed' THEN 'PR-011 lifecycle test'
+                 ELSE NULL
+             END
          WHERE id = $1",
     )
     .bind(issuer_id)

--- a/tests/m38_pki_runtime_resolver_v2.rs
+++ b/tests/m38_pki_runtime_resolver_v2.rs
@@ -1,0 +1,846 @@
+//! DB-gated contract tests for PR-011 certificate runtime resolution.
+//!
+//! Run with:
+//! ```bash
+//! DATABASE_URL=postgres://... cargo test --test m38_pki_runtime_resolver_v2 -- --ignored
+//! ```
+
+// Legacy compatibility is a mandatory PR-011 test, so this binary deliberately
+// invokes the protobuf method marked deprecated by the new contract.
+#![allow(deprecated)]
+
+mod common;
+
+use async_graphql::{Request as GraphqlRequest, Variables};
+use atom::{
+    auth::{encode_jwt, AuthContext},
+    certs::service::{self, CertificateRecord, ResolveCertificateV2},
+    error::AppError,
+    graphql::build_schema,
+    grpc::{
+        self,
+        proto::{
+            certificate_service_client::CertificateServiceClient, ResolveCertificateRequest,
+            ResolveCertificateV2Request,
+        },
+    },
+    identity::repo as identity_repo,
+    keys::{self, ActiveKeys},
+    state::AppState,
+};
+use chrono::{Duration as ChronoDuration, Utc};
+use rcgen::{CertificateParams, DnType, KeyPair};
+use ring::digest;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use time::{Duration as TimeDuration, OffsetDateTime};
+use tokio::{
+    task::JoinSet,
+    time::{sleep, timeout, Duration},
+};
+use tonic::{metadata::MetadataValue, transport::Channel, Code, Request as GrpcRequest};
+use uuid::Uuid;
+use x509_parser::pem::parse_x509_pem;
+
+#[tokio::test]
+#[ignore]
+async fn runtime_resolver_v2_enforces_the_pr011_cutover_contract() {
+    let pool = common::pool().await;
+    let config = common::pki::managed_config(false, true);
+    let root = common::pki::test_root("PR-011 Offline Root");
+    let tenant_a = common::pki::create_tenant(&pool, "pki-resolver-a").await;
+    let tenant_b = common::pki::create_tenant(&pool, "pki-resolver-b").await;
+    let entity_a = common::pki::create_entity(&pool, tenant_a, "pki-resolver-a").await;
+    let entity_b = common::pki::create_entity(&pool, tenant_b, "pki-resolver-b").await;
+    let issuer_a = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_a).await;
+    let issuer_b = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_b).await;
+    let leaf_a = issue_managed(&pool, &config, tenant_a, entity_a, "resolver-a").await;
+    let leaf_b = issue_managed(&pool, &config, tenant_b, entity_b, "resolver-b").await;
+    let legacy = insert_legacy_certificate(&pool, entity_a).await;
+
+    // Simulate the production roll-forward with representative legacy and
+    // managed rows already present. Both replacement indexes are built before
+    // the global index is removed, and all existing rows survive the cutover.
+    let mut migration = pool.begin().await.unwrap();
+    sqlx::query("DROP INDEX idx_credentials_certificate_issuer_serial")
+        .execute(&mut *migration)
+        .await
+        .unwrap();
+    sqlx::query("DROP INDEX idx_credentials_certificate_legacy_serial")
+        .execute(&mut *migration)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE UNIQUE INDEX idx_credentials_certificate_serial
+         ON credentials(identifier)
+         WHERE kind = 'certificate' AND identifier IS NOT NULL",
+    )
+    .execute(&mut *migration)
+    .await
+    .unwrap();
+    let preserved: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM credentials WHERE id = ANY($1::uuid[])")
+            .bind(vec![
+                leaf_a.credential_id,
+                leaf_b.credential_id,
+                legacy.credential_id,
+            ])
+            .fetch_one(&mut *migration)
+            .await
+            .unwrap();
+    assert_eq!(preserved, 3);
+    sqlx::query(
+        "CREATE UNIQUE INDEX idx_credentials_certificate_issuer_serial
+         ON credentials(issuer_id, identifier)
+         WHERE kind = 'certificate' AND issuer_id IS NOT NULL AND identifier IS NOT NULL",
+    )
+    .execute(&mut *migration)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE UNIQUE INDEX idx_credentials_certificate_legacy_serial
+         ON credentials(identifier)
+         WHERE kind = 'certificate' AND issuer_id IS NULL AND identifier IS NOT NULL",
+    )
+    .execute(&mut *migration)
+    .await
+    .unwrap();
+    sqlx::query("DROP INDEX idx_credentials_certificate_serial")
+        .execute(&mut *migration)
+        .await
+        .unwrap();
+    migration.commit().await.unwrap();
+
+    // The same serial can now exist under two managed issuers and in the
+    // isolated legacy namespace. A duplicate inside one issuer is still a
+    // database-level conflict.
+    sqlx::query("UPDATE credentials SET identifier = $1 WHERE id = $2")
+        .bind(&leaf_a.serial_number)
+        .bind(leaf_b.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE credentials SET identifier = $1 WHERE id = $2")
+        .bind(&leaf_a.serial_number)
+        .bind(legacy.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let same_issuer_conflict = sqlx::query(
+        "INSERT INTO credentials
+             (id, entity_id, kind, identifier, issuer_id, metadata, expires_at)
+         VALUES ($1, $2, 'certificate', $3, $4, $5, now() + interval '1 hour')",
+    )
+    .bind(Uuid::new_v4())
+    .bind(entity_a)
+    .bind(&leaf_a.serial_number)
+    .bind(issuer_a.id)
+    .bind(json!({"fingerprint_sha256": random_fingerprint()}))
+    .execute(&pool)
+    .await
+    .expect_err("one issuer cannot reuse a certificate serial");
+    assert_eq!(
+        database_code(&same_issuer_conflict).as_deref(),
+        Some("23505")
+    );
+
+    let issuer_a_fingerprint = issuer_a.fingerprint_sha256.as_deref().unwrap();
+    let issuer_b_fingerprint = issuer_b.fingerprint_sha256.as_deref().unwrap();
+    let by_fingerprint = resolve(
+        &pool,
+        ResolveCertificateV2 {
+            certificate_der: None,
+            fingerprint_sha256: Some(leaf_a.fingerprint_sha256.clone()),
+            issuer_fingerprint_sha256: None,
+            serial_number: None,
+            expected_tenant_id: Some(tenant_a),
+        },
+    )
+    .await;
+    assert_identity(&by_fingerprint, &leaf_a, issuer_a.id, Some(tenant_a));
+
+    let by_issuer_a = resolve(
+        &pool,
+        issuer_serial_input(issuer_a_fingerprint, &leaf_a.serial_number, Some(tenant_a)),
+    )
+    .await;
+    assert_identity(&by_issuer_a, &leaf_a, issuer_a.id, Some(tenant_a));
+    let by_issuer_b = resolve(
+        &pool,
+        issuer_serial_input(issuer_b_fingerprint, &leaf_a.serial_number, Some(tenant_b)),
+    )
+    .await;
+    assert_identity(&by_issuer_b, &leaf_b, issuer_b.id, Some(tenant_b));
+
+    let leaf_a_der = certificate_der(&leaf_a.certificate_pem);
+    let by_der = resolve(
+        &pool,
+        ResolveCertificateV2 {
+            certificate_der: Some(leaf_a_der.clone()),
+            fingerprint_sha256: Some(colon_fingerprint(&leaf_a.fingerprint_sha256)),
+            issuer_fingerprint_sha256: Some(issuer_a_fingerprint.to_string()),
+            serial_number: Some(leaf_a.serial_number.clone()),
+            expected_tenant_id: Some(tenant_a),
+        },
+    )
+    .await;
+    assert_identity(&by_der, &leaf_a, issuer_a.id, Some(tenant_a));
+
+    assert_unauthorized(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            ResolveCertificateV2 {
+                certificate_der: Some(leaf_a_der.clone()),
+                fingerprint_sha256: Some(leaf_b.fingerprint_sha256.clone()),
+                issuer_fingerprint_sha256: None,
+                serial_number: None,
+                expected_tenant_id: None,
+            },
+        )
+        .await,
+    );
+    assert_unauthorized(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            ResolveCertificateV2 {
+                certificate_der: None,
+                fingerprint_sha256: Some(leaf_a.fingerprint_sha256.clone()),
+                issuer_fingerprint_sha256: Some(issuer_b_fingerprint.to_string()),
+                serial_number: Some(leaf_a.serial_number.clone()),
+                expected_tenant_id: None,
+            },
+        )
+        .await,
+    );
+    assert!(matches!(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            fingerprint_input(&leaf_a.fingerprint_sha256, Some(tenant_b)),
+        )
+        .await,
+        Err(AppError::Forbidden)
+    ));
+    assert!(matches!(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            fingerprint_input(&random_fingerprint(), None),
+        )
+        .await,
+        Err(AppError::NotFound(_))
+    ));
+    assert!(matches!(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            ResolveCertificateV2 {
+                certificate_der: None,
+                fingerprint_sha256: None,
+                issuer_fingerprint_sha256: None,
+                serial_number: None,
+                expected_tenant_id: None,
+            },
+        )
+        .await,
+        Err(AppError::BadRequest(_))
+    ));
+    assert!(matches!(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            ResolveCertificateV2 {
+                certificate_der: Some(vec![0x30, 0x82, 0xff]),
+                fingerprint_sha256: None,
+                issuer_fingerprint_sha256: None,
+                serial_number: None,
+                expected_tenant_id: None,
+            },
+        )
+        .await,
+        Err(AppError::BadRequest(_))
+    ));
+    assert!(matches!(
+        service::resolve_certificate_identity_v2(
+            &pool,
+            ResolveCertificateV2 {
+                certificate_der: Some(vec![0; service::RUNTIME_CERTIFICATE_DER_MAX_BYTES + 1]),
+                fingerprint_sha256: None,
+                issuer_fingerprint_sha256: None,
+                serial_number: None,
+                expected_tenant_id: None,
+            },
+        )
+        .await,
+        Err(AppError::PayloadTooLarge(_))
+    ));
+
+    // The deprecated resolver can see exactly the legacy namespace, even when
+    // two managed issuers share that serial. It can never select either managed
+    // row accidentally.
+    let legacy_identity = service::resolve_certificate_identity(
+        &pool,
+        &leaf_a.serial_number,
+        Some(&legacy.fingerprint_sha256),
+    )
+    .await
+    .unwrap();
+    assert_eq!(legacy_identity.credential_id, legacy.credential_id);
+    assert!(legacy_identity.issuer_id.is_none());
+    let legacy_v2 = resolve(
+        &pool,
+        ResolveCertificateV2 {
+            certificate_der: Some(legacy.der.clone()),
+            fingerprint_sha256: Some(legacy.fingerprint_sha256.clone()),
+            issuer_fingerprint_sha256: None,
+            serial_number: None,
+            expected_tenant_id: Some(tenant_a),
+        },
+    )
+    .await;
+    assert_eq!(legacy_v2.credential_id, legacy.credential_id);
+    assert!(legacy_v2.issuer_id.is_none());
+
+    // Retiring and retained issuers remain valid for verification. Pending or
+    // revoked credentials, expired leaves, disabled/expired issuers, inactive
+    // entities, and frozen/deleted tenants all fail closed immediately.
+    set_issuer_status(&pool, issuer_a.id, "retiring", false).await;
+    resolve(
+        &pool,
+        fingerprint_input(&leaf_a.fingerprint_sha256, Some(tenant_a)),
+    )
+    .await;
+    set_issuer_status(&pool, issuer_a.id, "retired", false).await;
+    resolve(
+        &pool,
+        fingerprint_input(&leaf_a.fingerprint_sha256, Some(tenant_a)),
+    )
+    .await;
+    set_issuer_status(&pool, issuer_a.id, "active", true).await;
+
+    sqlx::query("UPDATE credentials SET status = 'revocation_pending' WHERE id = $1")
+        .bind(leaf_a.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    sqlx::query("UPDATE credentials SET status = 'active' WHERE id = $1")
+        .bind(leaf_a.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let original_expiry = leaf_a.expires_at.as_ref().unwrap();
+    sqlx::query("UPDATE credentials SET expires_at = now() - interval '1 second' WHERE id = $1")
+        .bind(leaf_a.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    sqlx::query("UPDATE credentials SET expires_at = $2 WHERE id = $1")
+        .bind(leaf_a.credential_id)
+        .bind(original_expiry)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    set_issuer_status(&pool, issuer_a.id, "failed", false).await;
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    set_issuer_status(&pool, issuer_a.id, "expired", false).await;
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    set_issuer_status(&pool, issuer_a.id, "active", false).await;
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    set_issuer_status(&pool, issuer_a.id, "active", true).await;
+
+    sqlx::query("UPDATE entities SET status = 'inactive' WHERE id = $1")
+        .bind(entity_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    sqlx::query("UPDATE entities SET status = 'active' WHERE id = $1")
+        .bind(entity_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE entities SET status = 'inactive', deleted_at = now() WHERE id = $1",
+    )
+    .bind(entity_a)
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    sqlx::query("UPDATE entities SET status = 'active', deleted_at = NULL WHERE id = $1")
+        .bind(entity_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE tenants SET status = 'frozen' WHERE id = $1")
+        .bind(tenant_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    sqlx::query("UPDATE tenants SET status = 'active' WHERE id = $1")
+        .bind(tenant_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE tenants SET status = 'deleted', deleted_at = now() WHERE id = $1")
+        .bind(tenant_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
+    sqlx::query("UPDATE tenants SET status = 'active', deleted_at = NULL WHERE id = $1")
+        .bind(tenant_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Existing certificate lifecycle events are the stable cache-invalidation
+    // contract. Revoke through the public GraphQL transaction and prove the
+    // event names the exact credential and issuer before resolver denial.
+    let schema = build_schema(common::pki::graphql_state(pool.clone(), config.clone()));
+    let revoked = schema
+        .execute(
+            GraphqlRequest::new(
+                r#"mutation Revoke($input: RevokeCertificateV2Input!) {
+                  revokeCertificateV2(input: $input) { certificate { credentialId status } }
+                }"#,
+            )
+            .variables(Variables::from_json(json!({
+                "input": {"credentialId": leaf_b.credential_id, "reason": "cessation_of_operation"}
+            })))
+            .data(admin_auth()),
+        )
+        .await;
+    assert!(revoked.errors.is_empty(), "{:?}", revoked.errors);
+    let lifecycle_event: Value = sqlx::query_scalar(
+        "SELECT payload FROM event_outbox
+         WHERE event = 'certificate.revoke' AND (payload->>'target_id')::uuid = $1",
+    )
+    .bind(leaf_b.credential_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        lifecycle_event["details"]["credential_id"],
+        leaf_b.credential_id.to_string()
+    );
+    assert_eq!(
+        lifecycle_event["details"]["issuer_id"],
+        issuer_b.id.to_string()
+    );
+    assert_fingerprint_denied(&pool, &leaf_b.fingerprint_sha256).await;
+
+    // A global entity keeps an empty tenant while still returning its exact
+    // platform issuer.
+    let global_entity = common::pki::create_global_entity(&pool, "pki-resolver-global").await;
+    let global_issuer = common::pki::provision_platform_leaf_issuer(&pool, &config, &root).await;
+    let global_leaf =
+        issue_managed_optional_tenant(&pool, &config, None, global_entity, "resolver-global").await;
+    let global = resolve(
+        &pool,
+        fingerprint_input(&global_leaf.fingerprint_sha256, None),
+    )
+    .await;
+    assert_identity(&global, &global_leaf, global_issuer.id, None);
+
+    // Ninety-six simultaneous exact lookups complete inside a bounded window
+    // and never cross-resolve the duplicate serial.
+    timeout(Duration::from_secs(10), async {
+        let mut tasks = JoinSet::new();
+        for index in 0..96 {
+            let pool = pool.clone();
+            let fingerprint_a = leaf_a.fingerprint_sha256.clone();
+            let issuer_b_fingerprint = issuer_b_fingerprint.to_string();
+            let shared_serial = leaf_a.serial_number.clone();
+            let expected_a = leaf_a.credential_id;
+            let expected_b = leaf_b.credential_id;
+            tasks.spawn(async move {
+                if index % 2 == 0 {
+                    let resolved = service::resolve_certificate_identity_v2(
+                        &pool,
+                        fingerprint_input(&fingerprint_a, Some(tenant_a)),
+                    )
+                    .await
+                    .unwrap();
+                    (resolved.credential_id, expected_a)
+                } else {
+                    let resolved = service::resolve_certificate_identity_v2(
+                        &pool,
+                        issuer_serial_input(&issuer_b_fingerprint, &shared_serial, Some(tenant_b)),
+                    )
+                    .await
+                    .expect_err("revoked duplicate must remain denied");
+                    assert!(matches!(resolved, AppError::Unauthorized(_)));
+                    (expected_b, expected_b)
+                }
+            });
+        }
+        while let Some(result) = tasks.join_next().await {
+            let (actual, expected) = result.unwrap();
+            assert_eq!(actual, expected);
+        }
+    })
+    .await
+    .expect("resolver concurrency check exceeded ten seconds");
+
+    // Exercise the actual versioned gRPC contract and its deprecated sibling.
+    let active_keys = active_keys(&pool, &config).await;
+    let admin_token = token_for(&pool, &config, &active_keys, common::admin_id()).await;
+    let state = AppState::new(pool.clone(), config.clone(), active_keys, None);
+    let listener = grpc::bind_listener("127.0.0.1:0".parse().unwrap())
+        .await
+        .unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let _ = grpc::serve(listener, state, None).await;
+    });
+    let mut client = certificate_client(address).await;
+
+    let missing_auth = client
+        .resolve_certificate_v2(ResolveCertificateV2Request {
+            fingerprint_sha256: leaf_a.fingerprint_sha256.clone(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("resolver requires authenticated service metadata");
+    assert_eq!(missing_auth.code(), Code::Unauthenticated);
+
+    let response = client
+        .resolve_certificate_v2(authed_request(
+            &admin_token,
+            ResolveCertificateV2Request {
+                certificate_der: leaf_a_der,
+                fingerprint_sha256: leaf_a.fingerprint_sha256.clone(),
+                issuer_fingerprint_sha256: issuer_a_fingerprint.to_string(),
+                serial_number: leaf_a.serial_number.clone(),
+                expected_tenant_id: tenant_a.to_string(),
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.entity_id, entity_a.to_string());
+    assert_eq!(response.tenant_id, tenant_a.to_string());
+    assert_eq!(response.credential_id, leaf_a.credential_id.to_string());
+    assert_eq!(response.issuer_id, issuer_a.id.to_string());
+    assert_eq!(response.status, "active");
+
+    let tenant_mismatch = client
+        .resolve_certificate_v2(authed_request(
+            &admin_token,
+            ResolveCertificateV2Request {
+                fingerprint_sha256: leaf_a.fingerprint_sha256.clone(),
+                expected_tenant_id: tenant_b.to_string(),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect_err("expected tenant mismatch must fail before authorization");
+    assert_eq!(tenant_mismatch.code(), Code::PermissionDenied);
+
+    let global_response = client
+        .resolve_certificate_v2(authed_request(
+            &admin_token,
+            ResolveCertificateV2Request {
+                fingerprint_sha256: global_leaf.fingerprint_sha256,
+                ..Default::default()
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(global_response.entity_id, global_entity.to_string());
+    assert!(global_response.tenant_id.is_empty());
+    assert_eq!(global_response.issuer_id, global_issuer.id.to_string());
+
+    let legacy_response = client
+        .resolve_certificate(authed_request(
+            &admin_token,
+            ResolveCertificateRequest {
+                serial_number: leaf_a.serial_number.clone(),
+                fingerprint_sha256: legacy.fingerprint_sha256,
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        legacy_response.credential_id,
+        legacy.credential_id.to_string()
+    );
+    server.abort();
+}
+
+async fn resolve(pool: &PgPool, input: ResolveCertificateV2) -> service::CertificateIdentity {
+    service::resolve_certificate_identity_v2(pool, input)
+        .await
+        .unwrap()
+}
+
+fn fingerprint_input(fingerprint: &str, tenant_id: Option<Uuid>) -> ResolveCertificateV2 {
+    ResolveCertificateV2 {
+        certificate_der: None,
+        fingerprint_sha256: Some(fingerprint.to_string()),
+        issuer_fingerprint_sha256: None,
+        serial_number: None,
+        expected_tenant_id: tenant_id,
+    }
+}
+
+fn issuer_serial_input(
+    issuer_fingerprint: &str,
+    serial_number: &str,
+    tenant_id: Option<Uuid>,
+) -> ResolveCertificateV2 {
+    ResolveCertificateV2 {
+        certificate_der: None,
+        fingerprint_sha256: None,
+        issuer_fingerprint_sha256: Some(issuer_fingerprint.to_string()),
+        serial_number: Some(serial_number.to_string()),
+        expected_tenant_id: tenant_id,
+    }
+}
+
+fn assert_identity(
+    actual: &service::CertificateIdentity,
+    certificate: &CertificateRecord,
+    issuer_id: Uuid,
+    tenant_id: Option<Uuid>,
+) {
+    assert_eq!(actual.entity_id, certificate.entity_id);
+    assert_eq!(actual.tenant_id, tenant_id);
+    assert_eq!(actual.credential_id, certificate.credential_id);
+    assert_eq!(actual.issuer_id, Some(issuer_id));
+    assert_eq!(&actual.expires_at, certificate.expires_at.as_ref().unwrap());
+    assert_eq!(actual.status, "active");
+}
+
+fn assert_unauthorized(result: Result<service::CertificateIdentity, AppError>) {
+    assert!(
+        matches!(&result, Err(AppError::Unauthorized(_))),
+        "expected unauthorized resolver result, got {result:?}"
+    );
+}
+
+async fn assert_fingerprint_denied(pool: &PgPool, fingerprint: &str) {
+    assert_unauthorized(
+        service::resolve_certificate_identity_v2(pool, fingerprint_input(fingerprint, None)).await,
+    );
+}
+
+async fn issue_managed(
+    pool: &PgPool,
+    config: &atom::config::Config,
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    label: &str,
+) -> CertificateRecord {
+    issue_managed_optional_tenant(pool, config, Some(tenant_id), entity_id, label).await
+}
+
+async fn issue_managed_optional_tenant(
+    pool: &PgPool,
+    config: &atom::config::Config,
+    tenant_id: Option<Uuid>,
+    entity_id: Uuid,
+    label: &str,
+) -> CertificateRecord {
+    service::issue_certificate_from_csr_v2(
+        pool,
+        config,
+        tenant_id,
+        service::IssueCertificateFromCsrV2 {
+            entity_id,
+            ttl_secs: Some(3600),
+            csr_pem: csr(label),
+            idempotency_key: format!("pr011-{label}-{}", Uuid::new_v4()),
+        },
+    )
+    .await
+    .unwrap()
+    .certificate
+}
+
+fn csr(label: &str) -> String {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params.distinguished_name.push(DnType::CommonName, label);
+    params.not_before = OffsetDateTime::now_utc() - TimeDuration::minutes(1);
+    params.not_after = OffsetDateTime::now_utc() + TimeDuration::hours(2);
+    params.serialize_request(&key).unwrap().pem().unwrap()
+}
+
+struct LegacyCertificate {
+    credential_id: Uuid,
+    fingerprint_sha256: String,
+    der: Vec<u8>,
+}
+
+async fn insert_legacy_certificate(pool: &PgPool, entity_id: Uuid) -> LegacyCertificate {
+    let key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "PR-011 legacy leaf");
+    params.not_before = OffsetDateTime::now_utc() - TimeDuration::minutes(1);
+    params.not_after = OffsetDateTime::now_utc() + TimeDuration::hours(2);
+    let certificate = params.self_signed(&key).unwrap();
+    let certificate_pem = certificate.pem();
+    let der = certificate_der(&certificate_pem);
+    let fingerprint_sha256 = sha256(&der);
+    let issuer_fingerprint_sha256 = sha256(b"PR-011 legacy file issuer");
+    let credential_id = Uuid::new_v4();
+    let now = Utc::now();
+    let expires_at = now + ChronoDuration::hours(1);
+    let metadata = json!({
+        "certificate_pem": certificate_pem,
+        "chain_pem": null,
+        "subject": {"common_name": "PR-011 legacy leaf"},
+        "dns_names": [],
+        "ip_addresses": [],
+        "issuer_kind": "legacy_file",
+        "issuer_subject": "PR-011 legacy file issuer",
+        "issuer_serial_number": "01",
+        "issuer_fingerprint_sha256": issuer_fingerprint_sha256,
+        "fingerprint_sha256": fingerprint_sha256,
+        "profile_id": null,
+        "profile_name": null,
+        "identity_uri": null,
+        "renewed_from_credential_id": null,
+        "renewal_threshold_seconds": null,
+        "renewal_due_at": null,
+        "not_before": now - ChronoDuration::minutes(1),
+        "not_after": expires_at,
+        "issued_from_csr": false,
+        "revoked_at": null,
+        "revocation_reason": null
+    });
+    let serial = Uuid::new_v4().simple().to_string();
+    sqlx::query(
+        "INSERT INTO credentials
+             (id, entity_id, kind, identifier, metadata, expires_at)
+         VALUES ($1, $2, 'certificate', $3, $4, $5)",
+    )
+    .bind(credential_id)
+    .bind(entity_id)
+    .bind(serial)
+    .bind(metadata)
+    .bind(expires_at)
+    .execute(pool)
+    .await
+    .unwrap();
+    LegacyCertificate {
+        credential_id,
+        fingerprint_sha256,
+        der,
+    }
+}
+
+async fn set_issuer_status(pool: &PgPool, issuer_id: Uuid, status: &str, enabled: bool) {
+    sqlx::query(
+        "UPDATE pki_authorities
+         SET status = $2, issuance_enabled = $3,
+             retiring_at = CASE WHEN $2 = 'retiring' THEN now() ELSE NULL END,
+             retired_at = CASE WHEN $2 = 'retired' THEN now() ELSE NULL END
+         WHERE id = $1",
+    )
+    .bind(issuer_id)
+    .bind(status)
+    .bind(enabled)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn certificate_der(certificate_pem: &str) -> Vec<u8> {
+    let (remaining, pem) = parse_x509_pem(certificate_pem.as_bytes()).unwrap();
+    assert!(remaining.iter().all(u8::is_ascii_whitespace));
+    pem.contents
+}
+
+fn sha256(value: &[u8]) -> String {
+    hex::encode(digest::digest(&digest::SHA256, value).as_ref())
+}
+
+fn random_fingerprint() -> String {
+    sha256(Uuid::new_v4().as_bytes())
+}
+
+fn colon_fingerprint(fingerprint: &str) -> String {
+    fingerprint
+        .as_bytes()
+        .chunks(2)
+        .map(|chunk| std::str::from_utf8(chunk).unwrap())
+        .collect::<Vec<_>>()
+        .join(":")
+        .to_uppercase()
+}
+
+fn database_code(error: &sqlx::Error) -> Option<String> {
+    match error {
+        sqlx::Error::Database(error) => error.code().map(|code| code.into_owned()),
+        _ => None,
+    }
+}
+
+fn admin_auth() -> AuthContext {
+    AuthContext {
+        entity_id: common::admin_id(),
+        tenant_id: None,
+        session_id: None,
+        ..Default::default()
+    }
+}
+
+async fn active_keys(pool: &PgPool, config: &atom::config::Config) -> ActiveKeys {
+    keys::rotate(pool, &config.signing_keys)
+        .await
+        .expect("rotate signing key")
+}
+
+async fn token_for(
+    pool: &PgPool,
+    config: &atom::config::Config,
+    keys: &ActiveKeys,
+    entity_id: Uuid,
+) -> String {
+    let session = identity_repo::create_session(pool, entity_id, 3600)
+        .await
+        .expect("create session");
+    encode_jwt(
+        entity_id,
+        session.id,
+        None,
+        &keys.primary,
+        3600,
+        &config.jwt_issuer,
+        &config.jwt_audience,
+    )
+    .expect("encode jwt")
+}
+
+fn authed_request<T>(token: &str, message: T) -> GrpcRequest<T> {
+    let mut request = GrpcRequest::new(message);
+    let value = format!("Bearer {token}")
+        .parse::<MetadataValue<_>>()
+        .expect("metadata value");
+    request.metadata_mut().insert("authorization", value);
+    request
+}
+
+async fn certificate_client(address: std::net::SocketAddr) -> CertificateServiceClient<Channel> {
+    let endpoint = format!("http://{address}");
+    for _ in 0..20 {
+        if let Ok(channel) = Channel::from_shared(endpoint.clone())
+            .unwrap()
+            .connect()
+            .await
+        {
+            return CertificateServiceClient::new(channel);
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+    CertificateServiceClient::connect(endpoint).await.unwrap()
+}

--- a/tests/m38_pki_runtime_resolver_v2.rs
+++ b/tests/m38_pki_runtime_resolver_v2.rs
@@ -359,13 +359,11 @@ async fn runtime_resolver_v2_enforces_the_pr011_cutover_contract() {
         .execute(&pool)
         .await
         .unwrap();
-    sqlx::query(
-        "UPDATE entities SET status = 'inactive', deleted_at = now() WHERE id = $1",
-    )
-    .bind(entity_a)
-    .execute(&pool)
-    .await
-    .unwrap();
+    sqlx::query("UPDATE entities SET status = 'inactive', deleted_at = now() WHERE id = $1")
+        .bind(entity_a)
+        .execute(&pool)
+        .await
+        .unwrap();
     assert_fingerprint_denied(&pool, &leaf_a.fingerprint_sha256).await;
     sqlx::query("UPDATE entities SET status = 'active', deleted_at = NULL WHERE id = $1")
         .bind(entity_a)


### PR DESCRIPTION
## Objective

Implement PR-011's unambiguous runtime certificate identity contract and safely enable duplicate serials across managed issuers.

## Dependencies

- PR-007 — merged as #52 into `certificates`.
- PR-008 — merged as #53 into `certificates`.
- PR-009 — merged as #54 into `certificates`.
- PR-010 — merged as #55 into `certificates`.
- Branch starts from `certificates` commit `6bd561dbc958d4a82322806a50816a11cf5cae1a`.

## Changes

- Adds `CertificateService.ResolveCertificateV2` with leaf DER, leaf SHA-256 fingerprint, and managed issuer-fingerprint-plus-serial selectors.
- Corroborates every supplied selector and rejects mismatches rather than choosing one.
- Returns entity, tenant, credential, issuer, expiry, and status; global entities retain an empty tenant.
- Validates credential, expiry, entity, tenant, and issuer lifecycle, including `revocation_pending`.
- Restricts the deprecated serial resolver and every legacy GraphQL/renewal/revocation/OCSP reader to `issuer_id IS NULL`.
- Replaces global certificate-serial uniqueness with managed `(issuer_id, identifier)` uniqueness plus a separately unique legacy namespace, building replacement indexes before dropping the old index.
- Formalizes existing certificate and subject lifecycle outbox events as the resolver cache-invalidation contract.
- Updates protobuf/generated reference, operator/API docs, roadmap state, and regression tests, including the older authority and revocation expectations superseded by the v2 cutover.

## Acceptance criteria validation

| Criterion | Implementation | Verification | Result |
|---|---|---|---|
| Fingerprint resolves exactly one credential | Globally unique fingerprint index plus `runtime_certificate_by_fingerprint` | PR-011 fingerprint and gRPC contract assertions | Passed — Rust CI run #306 |
| Issuer plus serial resolves exactly one credential | Authority fingerprint resolves an authoritative issuer ID, then the issuer-scoped unique key | Two issuer-specific resolutions using the same serial | Passed — Rust CI run #306 |
| Same serial under two issuers | Migration creates partial issuer-scoped uniqueness | Migration simulation updates two issuers to one serial and rejects reuse within one issuer | Passed — Rust CI run #306 |
| Expected tenant mismatch denied | Resolver compares stored tenant before authorization | Direct service and gRPC `PERMISSION_DENIED` assertions | Passed — Rust CI run #306 |
| Lifecycle failures denied | One resolver projection checks credential, expiry, entity, tenant, issuer status/validity and active-issuer enablement | Unknown, pending, revoked, expired, disabled/expired issuer, inactive/deleted entity, frozen/deleted tenant cases | Passed — Rust CI run #306 |
| No ambiguous live reader | Managed paths use credential/fingerprint/issuer selectors; named legacy readers add `issuer_id IS NULL` | Duplicate serial plus deprecated resolver proves only the legacy credential is returned; source inventory included | Passed — Rust CI run #306 |
| Uniqueness changes after reader cutover | Migration builds both replacement unique indexes before dropping global uniqueness | Existing-row migration simulation and index-conflict assertions | Passed — Rust CI run #306 |

## Mandatory tests

Implemented in `tests/m38_pki_runtime_resolver_v2.rs`:

- [x] Duplicate serials across issuers and the isolated legacy namespace
- [x] DER/provided fingerprint mismatch
- [x] Fingerprint/issuer mismatch
- [x] DER-derived fingerprint
- [x] Expected tenant match and mismatch
- [x] Unknown, revocation-pending, revoked, expired, disabled/expired issuer, inactive/deleted entity, frozen/deleted tenant
- [x] Deprecated legacy resolver compatibility
- [x] Migration with existing legacy and managed data
- [x] 96-way bounded concurrent/load check
- [x] Global entity returns no tenant
- [x] Versioned gRPC authentication and response contract
- [x] Lifecycle outbox event contains exact credential and issuer identifiers
- [x] Invalid/malformed/oversized selector handling

CI commands (all passed in [Rust run #306](https://github.com/absmach/atom/actions/runs/31107365793) and [API Docs run #247](https://github.com/absmach/atom/actions/runs/31107365733)):

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --no-run --locked`
- Repository fresh-database loop, including `cargo test --test m38_pki_runtime_resolver_v2 -- --include-ignored --test-threads=1`
- `buf lint`, generated gRPC reference drift check, and OpenAPI validation

## Additional validation

Passed locally:

- Direct rustfmt 1.88 over every changed Rust source and test
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm run build` from `docs/`
- `CI=true COREPACK_HOME=/tmp/atom-corepack corepack pnpm audit --prod --audit-level high` from `docs/` (one moderate finding; no high/critical finding)

Rust compilation and PostgreSQL execution were performed by the repository's GitHub Actions runner. The generated gRPC reference intentionally matches `buf generate` byte-for-byte and its drift check passed.

## Non-goals

No relying-party adapter or consuming-platform wiring is included; that remains PR-012. No CRL/OCSP encoding change, new authentication tier, or consumer-specific cache implementation is added.

## Compatibility and risks

- The old gRPC resolver remains present and is marked deprecated in protobuf/docs; it can resolve only legacy `issuer_id IS NULL` credentials.
- Legacy GraphQL renewal/revocation/query and global OCSP behavior remain available within that same unique namespace.
- Migration 012 is forward-only, preserves existing rows, adds `revocation_pending` only for certificate credentials, and atomically swaps uniqueness indexes.
- Deploy the migrated application readers with the schema cutover before permitting issuer-duplicate serial inserts during a rolling deployment.
- Managed issuer+serial input uses the authority certificate fingerprint, never a caller-selected tenant or issuer ID.
- No certificate, private key, CSR, token, or secret is logged or placed in lifecycle events.
