### PR TITLE
Add attributesContains filter to entities and groups queries

### DIFF
--- a/src/authz/repo.rs
+++ b/src/authz/repo.rs
@@ -4817,6 +4817,7 @@ async fn authorized_entity_ids(
     let limit = params.limit.clamp(1, 500);
     let offset = params.offset.max(0);
     let q = search_pattern(params.q);
+    let attributes_contains = params.attributes_contains.filter(|attrs| !attrs.is_null());
 
     let sql = r#"WITH RECURSIVE target_groups(id) AS (
                    SELECT $8::uuid WHERE $8::uuid IS NOT NULL
@@ -4849,6 +4850,7 @@ async fn authorized_entity_ids(
                      AND ($6::uuid IS NULL OR e.profile_id = $6)
                      AND ($7::text IS NULL OR e.status::text = $7)
                      AND ($8::uuid IS NULL OR gep.group_id IN (SELECT id FROM target_groups))
+                     AND ($13::jsonb IS NULL OR e.attributes @> $13::jsonb)
                ),
                candidate_ancestors(object_id, ancestor_id) AS (
                    SELECT c.id, gh.parent_id
@@ -4930,6 +4932,7 @@ async fn authorized_entity_ids(
         .bind(limit)
         .bind(offset)
         .bind(ceiling_credential_id)
+        .bind(attributes_contains)
         .fetch_all(pool)
         .await
         .map_err(db_err)?;
@@ -5153,6 +5156,7 @@ async fn authorized_group_ids(
     let limit = params.limit.clamp(1, 500);
     let offset = params.offset.max(0);
     let q = search_pattern(params.q);
+    let attributes_contains = params.attributes_contains.filter(|attrs| !attrs.is_null());
     let status = params.entity_status.map(|status| match status {
         crate::models::enums::EntityStatus::Active => "active".to_string(),
         crate::models::enums::EntityStatus::Inactive => "inactive".to_string(),
@@ -5194,6 +5198,7 @@ async fn authorized_group_ids(
                      AND ($5::text IS NULL OR g.name ILIKE $5 OR g.description ILIKE $5 OR g.attributes::text ILIKE $5)
                      AND ($8::text IS NULL OR g.status = $8)
                      AND ($6::uuid IS NULL OR gph.parent_id IN (SELECT id FROM target_groups))
+                     AND ($12::jsonb IS NULL OR g.attributes @> $12::jsonb)
                ),
                candidate_ancestors(object_id, ancestor_id) AS (
                    SELECT c.id, gh.parent_id
@@ -5270,6 +5275,7 @@ async fn authorized_group_ids(
         .bind(limit)
         .bind(offset)
         .bind(ceiling_credential_id)
+        .bind(attributes_contains)
         .fetch_all(pool)
         .await
         .map_err(db_err)?;

--- a/src/graphql/entities.rs
+++ b/src/graphql/entities.rs
@@ -1,4 +1,5 @@
 use async_graphql::{Context, Object, Result, ID};
+use serde_json::Value;
 
 use crate::{
     audit,
@@ -78,6 +79,7 @@ impl EntityQuery {
         kind: Option<GqlEntityKind>,
         profile_id: Option<ID>,
         tenant_id: Option<ID>,
+        attributes_contains: Option<Value>,
         parent_group_id: Option<ID>,
         include_descendants: Option<bool>,
         status: Option<GqlEntityStatus>,
@@ -105,6 +107,7 @@ impl EntityQuery {
                     kind: parsed_kind,
                     profile_id,
                     tenant_id,
+                    attributes_contains,
                     status: parsed_status,
                     deleted,
                     parent_group_id,
@@ -131,7 +134,7 @@ impl EntityQuery {
                 object_type: parsed_kind.as_ref().map(entity_object_type),
                 tenant_id,
                 q,
-                attributes_contains: None,
+                attributes_contains,
                 profile_id,
                 entity_status: parsed_status,
                 group_type: None,

--- a/src/graphql/groups.rs
+++ b/src/graphql/groups.rs
@@ -1,4 +1,5 @@
 use async_graphql::{Context, Object, Result, ID};
+use serde_json::Value;
 
 use crate::{
     audit,
@@ -37,6 +38,7 @@ impl GroupQuery {
         ctx: &Context<'_>,
         q: Option<String>,
         tenant_id: Option<ID>,
+        attributes_contains: Option<Value>,
         parent_id: Option<ID>,
         status: Option<GqlEntityStatus>,
         deleted: Option<GqlDeletedFilter>,
@@ -52,6 +54,7 @@ impl GroupQuery {
             None,
             q,
             tenant_id,
+            attributes_contains,
             parse_optional_id(parent_id, "parentId")?,
             parse_optional_entity_status(status),
             parse_deleted_filter(deleted),
@@ -141,6 +144,7 @@ impl GroupQuery {
             None,
             None,
             None,
+            None,
             Some(parent_id),
             None,
             DeletedFilter::Live,
@@ -171,6 +175,7 @@ impl GroupQuery {
             Some("object".to_string()),
             q,
             tenant_id,
+            None,
             parse_optional_id(parent_id, "parentId")?,
             parse_optional_entity_status(status),
             parse_deleted_filter(deleted),
@@ -201,6 +206,7 @@ impl GroupQuery {
             q,
             tenant_id,
             None,
+            None,
             parse_optional_entity_status(status),
             parse_deleted_filter(deleted),
             limit,
@@ -217,6 +223,7 @@ async fn authorized_group_list(
     group_type: Option<String>,
     q: Option<String>,
     tenant_id: Option<uuid::Uuid>,
+    attributes_contains: Option<Value>,
     parent_group_id: Option<uuid::Uuid>,
     status: Option<EntityStatus>,
     deleted: DeletedFilter,
@@ -234,6 +241,7 @@ async fn authorized_group_list(
             ListGroups {
                 q: q.clone(),
                 tenant_id,
+                attributes_contains,
                 group_type: group_type.clone(),
                 parent_id: parent_group_id,
                 status,
@@ -260,7 +268,7 @@ async fn authorized_group_list(
             object_type: None,
             tenant_id,
             q,
-            attributes_contains: None,
+            attributes_contains,
             profile_id: None,
             entity_status: status,
             group_type,

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -440,8 +440,8 @@ mod tests {
     }
 
     /// `entities`, `groups` and `resources` all carry a JSONB `attributes`
-    /// column, so all three expose the same containment filter under the same
-    /// name and type. Divergence here is the symmetry bug ATOM-01 fixed.
+    /// column, so all three should expose the same containment filter under
+    /// the same name and type.
     #[tokio::test]
     async fn entity_group_and_resource_queries_expose_attributes_contains_filter() {
         let schema = build_schema(test_state());

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -439,6 +439,58 @@ mod tests {
         assert!(arg_names.contains("derivedKind"));
     }
 
+    /// `entities`, `groups` and `resources` all carry a JSONB `attributes`
+    /// column, so all three expose the same containment filter under the same
+    /// name and type. Divergence here is the symmetry bug ATOM-01 fixed.
+    #[tokio::test]
+    async fn entity_group_and_resource_queries_expose_attributes_contains_filter() {
+        let schema = build_schema(test_state());
+
+        let response = schema
+            .execute(Request::new(
+                r#"
+                {
+                  __schema {
+                    queryType {
+                      fields {
+                        name
+                        args {
+                          name
+                          type { name }
+                        }
+                      }
+                    }
+                  }
+                }
+                "#,
+            ))
+            .await;
+
+        assert!(response.errors.is_empty(), "{:?}", response.errors);
+        let data = response.data.into_json().expect("json data");
+        let query_fields = data["__schema"]["queryType"]["fields"]
+            .as_array()
+            .expect("query fields");
+
+        for name in ["entities", "groups", "resources"] {
+            let field = query_fields
+                .iter()
+                .find(|field| field["name"].as_str() == Some(name))
+                .unwrap_or_else(|| panic!("missing query field {name}"));
+            let filter = field["args"]
+                .as_array()
+                .expect("args")
+                .iter()
+                .find(|arg| arg["name"].as_str() == Some("attributesContains"))
+                .unwrap_or_else(|| panic!("{name} is missing the attributesContains filter"));
+            assert_eq!(
+                filter["type"]["name"].as_str(),
+                Some("JSON"),
+                "{name}.attributesContains must be an optional JSON object"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn schema_enum_values_match_atom_storage_values() {
         let schema = build_schema(test_state());

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -192,6 +192,7 @@ pub async fn list_entities(pool: &PgPool, params: ListEntities) -> Result<Entity
     let include_descendants = params.include_descendants;
     let deleted = params.deleted.as_str();
     let q = search_pattern(params.q);
+    let attributes_contains = params.attributes_contains.filter(|attrs| !attrs.is_null());
 
     let items = sqlx::query_as::<_, Entity>(
         r#"WITH RECURSIVE target_groups(id) AS (
@@ -212,6 +213,7 @@ pub async fn list_entities(pool: &PgPool, params: ListEntities) -> Result<Entity
              AND ($4::text IS NULL OR e.status = $4)
              AND ($5::text IS NULL OR e.name ILIKE $5 OR e.alias ILIKE $5 OR e.attributes::text ILIKE $5)
              AND ($6::uuid IS NULL OR gep.group_id IN (SELECT id FROM target_groups))
+             AND ($11::jsonb IS NULL OR e.attributes @> $11::jsonb)
              AND ($10::text = 'all'
                   OR ($10::text = 'live' AND e.deleted_at IS NULL)
                   OR ($10::text = 'deleted' AND e.deleted_at IS NOT NULL))
@@ -228,6 +230,7 @@ pub async fn list_entities(pool: &PgPool, params: ListEntities) -> Result<Entity
     .bind(limit)
     .bind(offset)
     .bind(deleted)
+    .bind(attributes_contains.clone())
     .fetch_all(pool)
     .await
     .map_err(db_err)?;
@@ -250,6 +253,7 @@ pub async fn list_entities(pool: &PgPool, params: ListEntities) -> Result<Entity
              AND ($4::text IS NULL OR e.status = $4)
              AND ($5::text IS NULL OR e.name ILIKE $5 OR e.alias ILIKE $5 OR e.attributes::text ILIKE $5)
              AND ($6::uuid IS NULL OR gep.group_id IN (SELECT id FROM target_groups))
+             AND ($9::jsonb IS NULL OR e.attributes @> $9::jsonb)
              AND ($8::text = 'all'
                   OR ($8::text = 'live' AND e.deleted_at IS NULL)
                   OR ($8::text = 'deleted' AND e.deleted_at IS NOT NULL))"#,
@@ -262,6 +266,7 @@ pub async fn list_entities(pool: &PgPool, params: ListEntities) -> Result<Entity
     .bind(parent_group_id)
     .bind(include_descendants)
     .bind(deleted)
+    .bind(attributes_contains)
     .fetch_one(pool)
     .await
     .map_err(db_err)?;
@@ -1150,6 +1155,7 @@ pub async fn list_groups(pool: &PgPool, params: ListGroups) -> Result<GroupList,
     let q = search_pattern(params.q);
     let parent_id = params.parent_id;
     let deleted = params.deleted.as_str();
+    let attributes_contains = params.attributes_contains.filter(|attrs| !attrs.is_null());
 
     let items = sqlx::query_as::<_, Group>(
         r#"SELECT g.id, g.name, g.tenant_id, g.group_type, g.description, gh.parent_id,
@@ -1162,6 +1168,7 @@ pub async fn list_groups(pool: &PgPool, params: ListGroups) -> Result<GroupList,
              AND ($8::text IS NULL OR g.group_type = $8)
              AND (($4::uuid IS NULL AND $5::boolean = FALSE)
                   OR ($5::boolean = TRUE AND gh.parent_id = $4))
+             AND ($10::jsonb IS NULL OR g.attributes @> $10::jsonb)
              AND ($9::text = 'all'
                   OR ($9::text = 'live' AND g.deleted_at IS NULL)
                   OR ($9::text = 'deleted' AND g.deleted_at IS NOT NULL))
@@ -1177,6 +1184,7 @@ pub async fn list_groups(pool: &PgPool, params: ListGroups) -> Result<GroupList,
     .bind(offset)
     .bind(params.group_type.clone())
     .bind(deleted)
+    .bind(attributes_contains.clone())
     .fetch_all(pool)
     .await
     .map_err(db_err)?;
@@ -1191,6 +1199,7 @@ pub async fn list_groups(pool: &PgPool, params: ListGroups) -> Result<GroupList,
              AND ($6::text IS NULL OR g.group_type = $6)
              AND (($4::uuid IS NULL AND $5::boolean = FALSE)
                   OR ($5::boolean = TRUE AND gh.parent_id = $4))
+             AND ($8::jsonb IS NULL OR g.attributes @> $8::jsonb)
              AND ($7::text = 'all'
                   OR ($7::text = 'live' AND g.deleted_at IS NULL)
                   OR ($7::text = 'deleted' AND g.deleted_at IS NOT NULL))"#,
@@ -1202,6 +1211,7 @@ pub async fn list_groups(pool: &PgPool, params: ListGroups) -> Result<GroupList,
     .bind(parent_id.is_some())
     .bind(params.group_type)
     .bind(deleted)
+    .bind(attributes_contains)
     .fetch_one(pool)
     .await
     .map_err(db_err)?;
@@ -1451,6 +1461,7 @@ pub async fn list_child_groups(
         ListGroups {
             q: None,
             tenant_id: None,
+            attributes_contains: None,
             group_type: Some("object".to_string()),
             parent_id: Some(parent_id),
             status: None,

--- a/src/models/entity.rs
+++ b/src/models/entity.rs
@@ -57,6 +57,7 @@ pub struct ListEntities {
     pub kind: Option<EntityKind>,
     pub profile_id: Option<Uuid>,
     pub tenant_id: Option<Uuid>,
+    pub attributes_contains: Option<Value>,
     pub status: Option<EntityStatus>,
     #[serde(default)]
     pub deleted: DeletedFilter,

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -44,6 +44,7 @@ pub struct UpdateGroup {
 pub struct ListGroups {
     pub q: Option<String>,
     pub tenant_id: Option<Uuid>,
+    pub attributes_contains: Option<Value>,
     pub group_type: Option<String>,
     pub parent_id: Option<Uuid>,
     pub status: Option<EntityStatus>,

--- a/tests/m21_soft_delete.rs
+++ b/tests/m21_soft_delete.rs
@@ -606,6 +606,7 @@ async fn deleted_filter_lists_soft_deleted_objects() {
             kind: None,
             profile_id: None,
             tenant_id: None,
+            attributes_contains: None,
             status: None,
             deleted: DeletedFilter::Live,
             parent_group_id: None,
@@ -627,6 +628,7 @@ async fn deleted_filter_lists_soft_deleted_objects() {
             kind: None,
             profile_id: None,
             tenant_id: None,
+            attributes_contains: None,
             status: None,
             deleted: DeletedFilter::Deleted,
             parent_group_id: None,
@@ -658,6 +660,7 @@ async fn deleted_filter_lists_soft_deleted_objects() {
         ListGroups {
             q: Some(group_name.clone()),
             tenant_id: None,
+            attributes_contains: None,
             group_type: Some("object".to_string()),
             parent_id: None,
             status: None,
@@ -674,6 +677,7 @@ async fn deleted_filter_lists_soft_deleted_objects() {
         ListGroups {
             q: Some(group_name),
             tenant_id: None,
+            attributes_contains: None,
             group_type: Some("object".to_string()),
             parent_id: None,
             status: None,

--- a/tests/m29_entities_attributes_contains.rs
+++ b/tests/m29_entities_attributes_contains.rs
@@ -1,0 +1,691 @@
+//! `attributesContains` filtering on the `entities` and `groups` queries.
+//!
+//! Run with:
+//! ```bash
+//! DATABASE_URL=postgres://... cargo test --test m29_entities_attributes_contains -- --ignored
+//! ```
+
+mod common;
+
+use async_graphql::Request;
+use atom::{
+    auth::AuthContext, config::Config, graphql::build_schema, keys, models::enums::DeletedFilter,
+    state::AppState,
+};
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn state(pool: PgPool) -> AppState {
+    let config = Config::for_tests();
+    keys::bootstrap_if_needed(&pool, &config.signing_keys)
+        .await
+        .expect("bootstrap signing keys");
+    let active_keys = keys::load_active_keys(&pool, &config.signing_keys)
+        .await
+        .expect("load signing keys");
+    AppState::new(pool, config, active_keys, None)
+}
+
+fn authed(query: impl Into<String>) -> Request {
+    authed_as(common::admin_id(), query)
+}
+
+fn authed_as(entity_id: Uuid, query: impl Into<String>) -> Request {
+    Request::new(query).data(AuthContext {
+        entity_id,
+        tenant_id: None,
+        session_id: None,
+        ..Default::default()
+    })
+}
+
+async fn make_tenant(pool: &PgPool, name: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO tenants (id, name) VALUES ($1, $2)")
+        .bind(id)
+        .bind(format!("{name}-{id}"))
+        .execute(pool)
+        .await
+        .expect("insert tenant");
+    id
+}
+
+async fn make_entity(
+    pool: &PgPool,
+    tenant_id: Option<Uuid>,
+    kind: &str,
+    status: &str,
+    attributes: Value,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"INSERT INTO entities (id, kind, name, tenant_id, status, attributes)
+           VALUES ($1, $2, $3, $4, $5, $6)"#,
+    )
+    .bind(id)
+    .bind(kind)
+    .bind(format!("m29-entity-{id}"))
+    .bind(tenant_id)
+    .bind(status)
+    .bind(attributes)
+    .execute(pool)
+    .await
+    .expect("insert entity");
+    id
+}
+
+async fn make_object_group(
+    pool: &PgPool,
+    tenant_id: Uuid,
+    status: &str,
+    attributes: Value,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"INSERT INTO object_groups (id, name, tenant_id, status, attributes)
+           VALUES ($1, $2, $3, $4, $5)"#,
+    )
+    .bind(id)
+    .bind(format!("m29-group-{id}"))
+    .bind(tenant_id)
+    .bind(status)
+    .bind(attributes)
+    .execute(pool)
+    .await
+    .expect("insert object group");
+    id
+}
+
+/// Object-scoped `read` allow for `subject_id` on one object, mirroring how the
+/// GraphQL surface grants a subject visibility of a single entity or group.
+async fn grant_read(pool: &PgPool, tenant_id: Uuid, subject_id: Uuid, object_id: Uuid) {
+    let block_id: Uuid = sqlx::query_scalar(
+        r#"INSERT INTO permission_blocks (tenant_id, scope_mode, object_id, effect)
+           VALUES ($1, 'object', $2, 'allow') RETURNING id"#,
+    )
+    .bind(tenant_id)
+    .bind(object_id)
+    .fetch_one(pool)
+    .await
+    .expect("insert read block");
+    sqlx::query(
+        r#"INSERT INTO permission_block_actions (permission_block_id, action_id)
+           SELECT $1, id FROM actions WHERE name = 'read'"#,
+    )
+    .bind(block_id)
+    .execute(pool)
+    .await
+    .expect("insert read action");
+    sqlx::query(
+        r#"INSERT INTO direct_policies (tenant_id, subject_kind, subject_id, permission_block_id)
+           VALUES ($1, 'entity', $2, $3)"#,
+    )
+    .bind(tenant_id)
+    .bind(subject_id)
+    .bind(block_id)
+    .execute(pool)
+    .await
+    .expect("assign read policy");
+}
+
+fn listing(data: &Value, query: &str) -> (Vec<String>, i64) {
+    let ids = data[query]["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .map(|item| item["id"].as_str().expect("item id").to_owned())
+        .collect();
+    let total = data[query]["total"].as_i64().expect("total");
+    (ids, total)
+}
+
+/// Criteria 1, 2, 4 and 6: containment filters the listing, composes with the
+/// other filters, is reflected in `total`, and omitting it filters nothing.
+#[tokio::test]
+#[ignore]
+async fn entities_query_filters_by_attributes_contains() {
+    let pool = common::pool().await;
+    let tenant_a = make_tenant(&pool, "m29-entity-attrs-a").await;
+    let tenant_b = make_tenant(&pool, "m29-entity-attrs-b").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+    let schema = build_schema(state(pool.clone()).await);
+
+    let pending_device = make_entity(
+        &pool,
+        Some(tenant_a),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let provisioned_device = make_entity(
+        &pool,
+        Some(tenant_a),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "provisioned"}),
+    )
+    .await;
+    let pending_inactive_device = make_entity(
+        &pool,
+        Some(tenant_a),
+        "device",
+        "inactive",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let pending_human = make_entity(
+        &pool,
+        Some(tenant_a),
+        "human",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let pending_other_tenant = make_entity(
+        &pool,
+        Some(tenant_b),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+
+    let filtered = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              entities(attributesContains: {{ marker: "{marker}", provisioning_state: "pending" }}) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(filtered.errors.is_empty(), "{:?}", filtered.errors);
+    let (ids, total) = listing(&filtered.data.into_json().expect("json data"), "entities");
+    assert_eq!(total, 4, "total must reflect the filtered count");
+    assert_eq!(ids.len(), 4);
+    for expected in [
+        pending_device,
+        pending_inactive_device,
+        pending_human,
+        pending_other_tenant,
+    ] {
+        assert!(
+            ids.contains(&expected.to_string()),
+            "matching entity {expected} missing from {ids:?}"
+        );
+    }
+    assert!(!ids.contains(&provisioned_device.to_string()));
+
+    // Composes with kind, tenantId and status.
+    let composed = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              entities(
+                kind: device,
+                tenantId: "{tenant_a}",
+                status: active,
+                attributesContains: {{ marker: "{marker}", provisioning_state: "pending" }}
+              ) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(composed.errors.is_empty(), "{:?}", composed.errors);
+    let (ids, total) = listing(&composed.data.into_json().expect("json data"), "entities");
+    assert_eq!(total, 1);
+    assert_eq!(ids, vec![pending_device.to_string()]);
+
+    // Criterion 6: omitting the argument filters nothing.
+    let unfiltered = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              entities(kind: device, tenantId: "{tenant_a}") {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(unfiltered.errors.is_empty(), "{:?}", unfiltered.errors);
+    let (ids, total) = listing(&unfiltered.data.into_json().expect("json data"), "entities");
+    assert_eq!(total, 3);
+    for expected in [pending_device, provisioned_device, pending_inactive_device] {
+        assert!(
+            ids.contains(&expected.to_string()),
+            "unfiltered listing must contain {expected}, got {ids:?}"
+        );
+    }
+}
+
+/// Criterion 1a: array containment — the gateway view's "which devices are
+/// declared on this gateway" query.
+#[tokio::test]
+#[ignore]
+async fn entities_query_attributes_contains_matches_array_membership() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "m29-entity-gateways").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+    let schema = build_schema(state(pool.clone()).await);
+
+    let on_both = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "gateways": ["gw-a", "gw-b"]}),
+    )
+    .await;
+    let on_gw_a_only = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "gateways": ["gw-a"]}),
+    )
+    .await;
+    let on_gw_b_only = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "gateways": ["gw-b"]}),
+    )
+    .await;
+    let unattached = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "gateways": []}),
+    )
+    .await;
+
+    let response = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              entities(attributesContains: {{ marker: "{marker}", gateways: ["gw-a"] }}) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let (ids, total) = listing(&response.data.into_json().expect("json data"), "entities");
+
+    assert_eq!(total, 2);
+    assert!(ids.contains(&on_both.to_string()));
+    assert!(ids.contains(&on_gw_a_only.to_string()));
+    assert!(!ids.contains(&on_gw_b_only.to_string()));
+    assert!(!ids.contains(&unattached.to_string()));
+}
+
+/// Criterion 3: the filter composes with authorization on the **live** branch —
+/// the subject sees only entities it may read *and* that match, and `total` is
+/// the intersection, not either side alone.
+#[tokio::test]
+#[ignore]
+async fn entities_query_attributes_contains_composes_with_authorization() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "m29-entity-attrs-authz").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+    let schema = build_schema(state(pool.clone()).await);
+
+    let subject_id = make_entity(&pool, Some(tenant_id), "human", "active", json!({})).await;
+    let authorized_match = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let unauthorized_match = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let authorized_nonmatch = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "provisioned"}),
+    )
+    .await;
+    grant_read(&pool, tenant_id, subject_id, authorized_match).await;
+    grant_read(&pool, tenant_id, subject_id, authorized_nonmatch).await;
+
+    let filtered = schema
+        .execute(authed_as(
+            subject_id,
+            format!(
+                r#"
+            {{
+              entities(attributesContains: {{ marker: "{marker}", provisioning_state: "pending" }}) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+            ),
+        ))
+        .await;
+    assert!(filtered.errors.is_empty(), "{:?}", filtered.errors);
+    let (ids, total) = listing(&filtered.data.into_json().expect("json data"), "entities");
+    assert_eq!(total, 1, "total must count the authorized matches only");
+    assert_eq!(ids, vec![authorized_match.to_string()]);
+    assert!(
+        !ids.contains(&unauthorized_match.to_string()),
+        "a matching but unreadable entity must stay hidden"
+    );
+
+    // Without the filter the same subject still sees both entities it may read,
+    // so the filter — not the authorization — removed the non-matching one.
+    let unfiltered = schema
+        .execute(authed_as(
+            subject_id,
+            r#"
+            {
+              entities {
+                items { id }
+                total
+              }
+            }
+            "#,
+        ))
+        .await;
+    assert!(unfiltered.errors.is_empty(), "{:?}", unfiltered.errors);
+    let (ids, total) = listing(&unfiltered.data.into_json().expect("json data"), "entities");
+    assert_eq!(total, 2);
+    assert!(ids.contains(&authorized_match.to_string()));
+    assert!(ids.contains(&authorized_nonmatch.to_string()));
+}
+
+/// The deleted-filter branch (platform-manage only) applies the filter too.
+#[tokio::test]
+#[ignore]
+async fn entities_query_attributes_contains_applies_on_deleted_branch() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "m29-entity-attrs-deleted").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+    let schema = build_schema(state(pool.clone()).await);
+
+    let pending = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let provisioned = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "provisioned"}),
+    )
+    .await;
+    for entity_id in [pending, provisioned] {
+        atom::identity::repo::delete_entity(&pool, entity_id, None)
+            .await
+            .expect("soft delete entity");
+    }
+
+    let response = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              entities(
+                deleted: deleted,
+                attributesContains: {{ marker: "{marker}", provisioning_state: "pending" }}
+              ) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let (ids, total) = listing(&response.data.into_json().expect("json data"), "entities");
+
+    assert_eq!(total, 1);
+    assert_eq!(ids, vec![pending.to_string()]);
+}
+
+/// Criterion 5: `groups(attributesContains: …)` behaves equivalently, including
+/// composition with the other filters, `total`, and the omitted-argument case.
+#[tokio::test]
+#[ignore]
+async fn groups_query_filters_by_attributes_contains() {
+    let pool = common::pool().await;
+    let tenant_a = make_tenant(&pool, "m29-group-attrs-a").await;
+    let tenant_b = make_tenant(&pool, "m29-group-attrs-b").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+    let schema = build_schema(state(pool.clone()).await);
+
+    let site_north = make_object_group(
+        &pool,
+        tenant_a,
+        "active",
+        json!({"marker": marker, "site": "north"}),
+    )
+    .await;
+    let site_south = make_object_group(
+        &pool,
+        tenant_a,
+        "active",
+        json!({"marker": marker, "site": "south"}),
+    )
+    .await;
+    let site_north_inactive = make_object_group(
+        &pool,
+        tenant_a,
+        "inactive",
+        json!({"marker": marker, "site": "north"}),
+    )
+    .await;
+    let site_north_other_tenant = make_object_group(
+        &pool,
+        tenant_b,
+        "active",
+        json!({"marker": marker, "site": "north"}),
+    )
+    .await;
+
+    let filtered = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              groups(attributesContains: {{ marker: "{marker}", site: "north" }}) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(filtered.errors.is_empty(), "{:?}", filtered.errors);
+    let (ids, total) = listing(&filtered.data.into_json().expect("json data"), "groups");
+    assert_eq!(total, 3);
+    for expected in [site_north, site_north_inactive, site_north_other_tenant] {
+        assert!(
+            ids.contains(&expected.to_string()),
+            "matching group {expected} missing from {ids:?}"
+        );
+    }
+    assert!(!ids.contains(&site_south.to_string()));
+
+    // Composes with tenantId and status.
+    let composed = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              groups(
+                tenantId: "{tenant_a}",
+                status: active,
+                attributesContains: {{ marker: "{marker}", site: "north" }}
+              ) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(composed.errors.is_empty(), "{:?}", composed.errors);
+    let (ids, total) = listing(&composed.data.into_json().expect("json data"), "groups");
+    assert_eq!(total, 1);
+    assert_eq!(ids, vec![site_north.to_string()]);
+
+    // Criterion 6 for groups: omitting the argument filters nothing.
+    let unfiltered = schema
+        .execute(authed(format!(
+            r#"
+            {{
+              groups(tenantId: "{tenant_a}") {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+        )))
+        .await;
+    assert!(unfiltered.errors.is_empty(), "{:?}", unfiltered.errors);
+    let (ids, total) = listing(&unfiltered.data.into_json().expect("json data"), "groups");
+    assert_eq!(total, 3);
+    for expected in [site_north, site_south, site_north_inactive] {
+        assert!(
+            ids.contains(&expected.to_string()),
+            "unfiltered listing must contain {expected}, got {ids:?}"
+        );
+    }
+}
+
+/// Criterion 5 on the live branch: the group filter composes with authorization
+/// the same way the entity one does.
+#[tokio::test]
+#[ignore]
+async fn groups_query_attributes_contains_composes_with_authorization() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "m29-group-attrs-authz").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+    let schema = build_schema(state(pool.clone()).await);
+
+    let subject_id = make_entity(&pool, Some(tenant_id), "human", "active", json!({})).await;
+    let authorized_match = make_object_group(
+        &pool,
+        tenant_id,
+        "active",
+        json!({"marker": marker, "site": "north"}),
+    )
+    .await;
+    let unauthorized_match = make_object_group(
+        &pool,
+        tenant_id,
+        "active",
+        json!({"marker": marker, "site": "north"}),
+    )
+    .await;
+    let authorized_nonmatch = make_object_group(
+        &pool,
+        tenant_id,
+        "active",
+        json!({"marker": marker, "site": "south"}),
+    )
+    .await;
+    grant_read(&pool, tenant_id, subject_id, authorized_match).await;
+    grant_read(&pool, tenant_id, subject_id, authorized_nonmatch).await;
+
+    let response = schema
+        .execute(authed_as(
+            subject_id,
+            format!(
+                r#"
+            {{
+              groups(attributesContains: {{ marker: "{marker}", site: "north" }}) {{
+                items {{ id }}
+                total
+              }}
+            }}
+            "#
+            ),
+        ))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let (ids, total) = listing(&response.data.into_json().expect("json data"), "groups");
+
+    assert_eq!(total, 1);
+    assert_eq!(ids, vec![authorized_match.to_string()]);
+    assert!(!ids.contains(&unauthorized_match.to_string()));
+    assert!(!ids.contains(&authorized_nonmatch.to_string()));
+}
+
+/// The repository call the resolver makes on the deleted branch: a `None`
+/// filter must leave the listing untouched (regression guard for criterion 6).
+#[tokio::test]
+#[ignore]
+async fn list_entities_without_attributes_contains_is_unfiltered() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "m29-entity-attrs-none").await;
+    let marker = format!("m29-{}", Uuid::new_v4());
+
+    let pending = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "pending"}),
+    )
+    .await;
+    let provisioned = make_entity(
+        &pool,
+        Some(tenant_id),
+        "device",
+        "active",
+        json!({"marker": marker, "provisioning_state": "provisioned"}),
+    )
+    .await;
+
+    let list = atom::identity::repo::list_entities(
+        &pool,
+        atom::models::entity::ListEntities {
+            q: None,
+            kind: None,
+            profile_id: None,
+            tenant_id: Some(tenant_id),
+            attributes_contains: None,
+            status: None,
+            deleted: DeletedFilter::Live,
+            parent_group_id: None,
+            include_descendants: false,
+            limit: 50,
+            offset: 0,
+        },
+    )
+    .await
+    .expect("list entities");
+
+    assert_eq!(list.total, 2);
+    let ids: Vec<Uuid> = list.items.iter().map(|entity| entity.id).collect();
+    assert!(ids.contains(&pending));
+    assert!(ids.contains(&provisioned));
+}

--- a/tests/m29_entities_attributes_contains.rs
+++ b/tests/m29_entities_attributes_contains.rs
@@ -140,8 +140,8 @@ fn listing(data: &Value, query: &str) -> (Vec<String>, i64) {
     (ids, total)
 }
 
-/// Criteria 1, 2, 4 and 6: containment filters the listing, composes with the
-/// other filters, is reflected in `total`, and omitting it filters nothing.
+/// Containment filters the listing, composes with the other filters, is
+/// reflected in `total`, and omitting it filters nothing.
 #[tokio::test]
 #[ignore]
 async fn entities_query_filters_by_attributes_contains() {
@@ -244,7 +244,7 @@ async fn entities_query_filters_by_attributes_contains() {
     assert_eq!(total, 1);
     assert_eq!(ids, vec![pending_device.to_string()]);
 
-    // Criterion 6: omitting the argument filters nothing.
+    // Omitting the argument filters nothing.
     let unfiltered = schema
         .execute(authed(format!(
             r#"
@@ -268,8 +268,8 @@ async fn entities_query_filters_by_attributes_contains() {
     }
 }
 
-/// Criterion 1a: array containment — the gateway view's "which devices are
-/// declared on this gateway" query.
+/// Array containment — e.g. "which devices declare this gateway in their
+/// `gateways` list" — matches per-element, not by exact array equality.
 #[tokio::test]
 #[ignore]
 async fn entities_query_attributes_contains_matches_array_membership() {
@@ -333,7 +333,7 @@ async fn entities_query_attributes_contains_matches_array_membership() {
     assert!(!ids.contains(&unattached.to_string()));
 }
 
-/// Criterion 3: the filter composes with authorization on the **live** branch —
+/// The filter composes with authorization on the **live** (non-admin) branch —
 /// the subject sees only entities it may read *and* that match, and `total` is
 /// the intersection, not either side alone.
 #[tokio::test]
@@ -471,8 +471,9 @@ async fn entities_query_attributes_contains_applies_on_deleted_branch() {
     assert_eq!(ids, vec![pending.to_string()]);
 }
 
-/// Criterion 5: `groups(attributesContains: …)` behaves equivalently, including
-/// composition with the other filters, `total`, and the omitted-argument case.
+/// `groups(attributesContains: …)` behaves like the entity version: it
+/// composes with the other filters, is reflected in `total`, and the
+/// omitted-argument case is unfiltered.
 #[tokio::test]
 #[ignore]
 async fn groups_query_filters_by_attributes_contains() {
@@ -556,7 +557,7 @@ async fn groups_query_filters_by_attributes_contains() {
     assert_eq!(total, 1);
     assert_eq!(ids, vec![site_north.to_string()]);
 
-    // Criterion 6 for groups: omitting the argument filters nothing.
+    // Omitting the argument filters nothing.
     let unfiltered = schema
         .execute(authed(format!(
             r#"
@@ -580,8 +581,8 @@ async fn groups_query_filters_by_attributes_contains() {
     }
 }
 
-/// Criterion 5 on the live branch: the group filter composes with authorization
-/// the same way the entity one does.
+/// The group filter composes with authorization on the live branch the same
+/// way the entity one does.
 #[tokio::test]
 #[ignore]
 async fn groups_query_attributes_contains_composes_with_authorization() {
@@ -640,7 +641,7 @@ async fn groups_query_attributes_contains_composes_with_authorization() {
 }
 
 /// The repository call the resolver makes on the deleted branch: a `None`
-/// filter must leave the listing untouched (regression guard for criterion 6).
+/// filter must leave the listing untouched.
 #[tokio::test]
 #[ignore]
 async fn list_entities_without_attributes_contains_is_unfiltered() {


### PR DESCRIPTION
## Summary

Part of the [edge model work](https://github.com/absmach/magistrala/blob/edge/edge/prd/ATOM-01-entity-attribute-filter.md) (ATOM-01). `resources()` already supports filtering by JSONB attribute containment; `entities()` and `groups()` did not, purely because the parameter was hardcoded to `None` at the resolver. This is a symmetry fix.

- Adds `attributesContains: JSON` to the `entities()` and `groups()` GraphQL queries, mirroring `resources()`.
- Threads the filter through **both** branches of each query: the plain listing path and the live authorization-filtered path (`authorized_object_ids`), so the filter composes correctly with authorization and pagination (`total` reflects the filtered count).
- The PRD assumed the repository/SQL layer already supported this for entities/groups (true only for resources) — this PR adds the actual `attributes @> $n::jsonb` predicate to `list_entities`, `list_groups`, `authorized_entity_ids`, and `authorized_group_ids`, mirroring the existing resource implementation. No new indexes needed — `idx_entities_attrs`, `idx_object_groups_attrs`, and `idx_principal_groups_attrs` are all GIN and present since migration 001.
- Backs the gateway→devices reverse lookup used later in the edge model (`attributesContains: {gateways: [...]}`).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Unit tests: 135 passed
- [x] New integration suite `tests/m29_entities_attributes_contains.rs` (7 tests): filtering, array-containment matching, composition with authorization (verified with a negative control — reverting the live-branch wiring fails 5/7), the deleted-entities branch, and a `None`-passthrough regression guard for both `entities` and `groups`
- [x] Full DB-gated suite: 241 passed; 6 pre-existing failures unrelated to this change (broker-dependent AMQP tests requiring `TEST_AMQP_URL`, reproduced on a clean checkout)