### PR TITLE
Add objectId reverse lookup to directPolicies query

### DIFF
--- a/src/authz/repo.rs
+++ b/src/authz/repo.rs
@@ -4239,18 +4239,14 @@ pub async fn create_direct_policy(
     create_direct_policy_with_audit(pool, false, None, req).await
 }
 
-/// Resolves the target object's own object groups and every ancestor of those
-/// groups, carrying the object's real `(object_kind, object_type)` in the shape
-/// a permission block records it, so a block's declared scope can be compared
-/// exactly the way the PDP compares it (`grant_scope_matches`, migration 001).
+/// Resolves the object's own object groups and every ancestor of those
+/// groups, carrying `(object_kind, object_type)` in the shape a permission
+/// block records it, so a block's declared scope can be compared the way the
+/// PDP compares it (`grant_scope_matches`, migration 001).
 ///
-/// The walk is anchored at the object and goes *upward*, so its cost is bounded
-/// by the group tree's depth — not by how many blocks exist in the tenant.
-/// Cycles cannot occur: `set_group_parent` rejects them before insert.
-///
-/// The membership joins are ordinary set-returning joins over every matching
-/// row. An object may sit in more than one object group, and each membership
-/// must produce its own match; nothing here may collapse to a single row.
+/// Anchored at the object and walks *upward*, so cost is bounded by tree
+/// depth, not block count. The membership joins return every matching row —
+/// an object in several groups must produce a match for each.
 const DIRECT_POLICY_OBJECT_CTE: &str = r#"WITH RECURSIVE object_parent_groups(group_id, object_kind, object_type) AS (
              SELECT oge.group_id, 'entity'::text, 'entity:' || e.kind
              FROM object_group_entities oge
@@ -4365,23 +4361,15 @@ fn validate_direct_policy_object_filter(
 
 /// Lists direct policies, filtered by subject, by object, or by both.
 ///
-/// **The object filter is a policy lookup, not an effective-access
-/// computation.** With `object_id` set, the result is every direct policy whose
-/// permission block *names* that object:
-///
-/// - `object` — the block targets the object id directly;
-/// - `group` — the block targets an object group id directly;
-/// - `group_direct_objects` — the object is a direct member of the block's
-///   object group;
-/// - `group_descendant_objects` — the object is a member of a descendant of the
-///   block's object group;
-/// - `group_child_groups` / `group_descendant_groups` — the object is an object
-///   group covered by the block's group hierarchy scope.
-///
-/// Blocks that reach the object without naming it — `platform`, `tenant`,
-/// `object_kind`, `object_type` — are **not** returned. A caller that reads this
-/// as "everyone who can access X" will under-report; that question is a
-/// different query with different semantics.
+/// **The object filter is a policy lookup, not effective access.** With
+/// `object_id` set, the result is every direct policy whose permission block
+/// *names* that object: `object` (direct), `group` (the object is the named
+/// group), `group_direct_objects`/`group_descendant_objects` (member/
+/// descendant-member of the block's group), or `group_child_groups`/
+/// `group_descendant_groups` (a group covered by the block's hierarchy
+/// scope). Blocks that reach the object without naming it (`platform`,
+/// `tenant`, `object_kind`, `object_type`) are **not** returned — reading
+/// this as "everyone who can access X" will under-report.
 pub async fn list_direct_policies(
     pool: &PgPool,
     params: ListDirectPolicies,

--- a/src/authz/repo.rs
+++ b/src/authz/repo.rs
@@ -4239,14 +4239,128 @@ pub async fn create_direct_policy(
     create_direct_policy_with_audit(pool, false, None, req).await
 }
 
+/// Resolves the target object's own object groups and every ancestor of those
+/// groups, carrying the object's real `(object_kind, object_type)` in the shape
+/// a permission block records it, so a block's declared scope can be compared
+/// exactly the way the PDP compares it (`grant_scope_matches`, migration 001).
+///
+/// The walk is anchored at the object and goes *upward*, so its cost is bounded
+/// by the group tree's depth — not by how many blocks exist in the tenant.
+/// Cycles cannot occur: `set_group_parent` rejects them before insert.
+///
+/// The membership joins are ordinary set-returning joins over every matching
+/// row. An object may sit in more than one object group, and each membership
+/// must produce its own match; nothing here may collapse to a single row.
+const DIRECT_POLICY_OBJECT_CTE: &str = r#"WITH RECURSIVE object_parent_groups(group_id, object_kind, object_type) AS (
+             SELECT oge.group_id, 'entity'::text, 'entity:' || e.kind
+             FROM object_group_entities oge
+             JOIN entities e ON e.id = oge.entity_id
+             WHERE oge.entity_id = $5::uuid AND e.deleted_at IS NULL
+             UNION ALL
+             SELECT ogr.group_id, 'resource'::text, 'resource:' || r.kind
+             FROM object_group_resources ogr
+             JOIN resources r ON r.id = ogr.resource_id
+             WHERE ogr.resource_id = $5::uuid AND r.deleted_at IS NULL
+           ),
+           object_ancestor_groups(group_id, object_kind, object_type) AS (
+             SELECT ogh.parent_id, opg.object_kind, opg.object_type
+             FROM object_parent_groups opg
+             JOIN object_group_hierarchy ogh ON ogh.child_id = opg.group_id
+             UNION ALL
+             SELECT ogh.parent_id, oag.object_kind, oag.object_type
+             FROM object_ancestor_groups oag
+             JOIN object_group_hierarchy ogh ON ogh.child_id = oag.group_id
+           )"#;
+
+/// The reverse-lookup predicate: does this policy's permission block name the
+/// object in `$5`, narrowed by the optional `$6` / `$7` co-filters?
+///
+/// Only the three scope modes that name a specific object are considered. A
+/// `group_descendant_objects` block matches through *strict* ancestors of the
+/// object's own group, mirroring the PDP: an object directly in the block's
+/// group is the `group_direct_objects` case, not the descendant case.
+const DIRECT_POLICY_OBJECT_PREDICATE: &str = r#"($5::uuid IS NULL OR EXISTS (
+               SELECT 1 FROM permission_blocks pb
+               WHERE pb.id = direct_policies.permission_block_id
+                 AND ($6::text IS NULL OR pb.object_kind IS NULL OR pb.object_kind = $6)
+                 AND ($7::text IS NULL OR pb.object_type IS NULL OR pb.object_type = $7)
+                 AND (
+                   (pb.scope_mode = 'object' AND pb.object_id = $5)
+                   OR (pb.scope_mode = 'group_direct_objects' AND EXISTS (
+                         SELECT 1 FROM object_parent_groups opg
+                         WHERE opg.group_id = pb.group_id
+                           AND opg.object_kind = pb.object_kind
+                           AND opg.object_type = pb.object_type))
+                   OR (pb.scope_mode = 'group_descendant_objects' AND EXISTS (
+                         SELECT 1 FROM object_ancestor_groups oag
+                         WHERE oag.group_id = pb.group_id
+                           AND oag.object_kind = pb.object_kind
+                           AND oag.object_type = pb.object_type))
+                 )
+             ))"#;
+
+/// `object_kind` / `object_type` only make sense alongside `object_id`: the
+/// reverse-lookup predicate is inert without it, so accepting them on their own
+/// would silently return the *unfiltered* listing. Reject instead.
+fn validate_direct_policy_object_filter(
+    object_id: Option<Uuid>,
+    object_kind: Option<ObjectKind>,
+    object_type: Option<&str>,
+) -> Result<(), AppError> {
+    if object_id.is_none() && (object_kind.is_some() || object_type.is_some()) {
+        return Err(AppError::bad_request(
+            "objectKind and objectType are co-filters for objectId and require it",
+        ));
+    }
+    if let Some(object_type) = object_type {
+        let (prefix, suffix) = object_type.split_once(':').ok_or_else(|| {
+            AppError::bad_request("objectType must be namespaced as object_kind:type")
+        })?;
+        if prefix.is_empty() || suffix.is_empty() {
+            return Err(AppError::bad_request(
+                "objectType must be namespaced as object_kind:type",
+            ));
+        }
+        if object_kind.is_some_and(|kind| kind.as_str() != prefix) {
+            return Err(AppError::bad_request(
+                "objectType namespace must match objectKind",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Lists direct policies, filtered by subject, by object, or by both.
+///
+/// **The object filter is a policy lookup, not an effective-access
+/// computation.** With `object_id` set, the result is every direct policy whose
+/// permission block *names* that object:
+///
+/// - `object` — the block targets the object id directly;
+/// - `group_direct_objects` — the object is a direct member of the block's
+///   object group;
+/// - `group_descendant_objects` — the object is a member of a descendant of the
+///   block's object group.
+///
+/// Blocks that reach the object without naming it — `platform`, `tenant`,
+/// `object_kind`, `object_type` — are **not** returned. A caller that reads this
+/// as "everyone who can access X" will under-report; that question is a
+/// different query with different semantics.
 pub async fn list_direct_policies(
     pool: &PgPool,
     params: ListDirectPolicies,
 ) -> Result<DirectPolicyList, AppError> {
     let limit = params.limit.clamp(1, 100);
     let offset = params.offset.max(0);
-    let items = sqlx::query_as::<_, DirectPolicy>(
-        r#"SELECT id, tenant_id, subject_kind, subject_id, permission_block_id, created_at
+    let object_type = normalize_optional_text(params.object_type);
+    validate_direct_policy_object_filter(
+        params.object_id,
+        params.object_kind,
+        object_type.as_deref(),
+    )?;
+    let items_sql = format!(
+        r#"{DIRECT_POLICY_OBJECT_CTE}
+           SELECT id, tenant_id, subject_kind, subject_id, permission_block_id, created_at
            FROM direct_policies
            WHERE ($1::uuid IS NULL OR tenant_id = $1)
              AND ($2::text IS NULL OR subject_kind = $2)
@@ -4256,21 +4370,27 @@ pub async fn list_direct_policies(
                (subject_kind = 'entity' AND EXISTS (SELECT 1 FROM entities se WHERE se.id = direct_policies.subject_id AND se.deleted_at IS NULL))
                OR (subject_kind = 'group' AND EXISTS (SELECT 1 FROM principal_groups sg WHERE sg.id = direct_policies.subject_id AND sg.deleted_at IS NULL))
              )
+             AND {DIRECT_POLICY_OBJECT_PREDICATE}
            ORDER BY created_at DESC
-           LIMIT $5 OFFSET $6"#,
-    )
-    .bind(params.tenant_id)
-    .bind(params.subject_kind.clone())
-    .bind(params.subject_id)
-    .bind(params.permission_block_id)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await
-    .map_err(db_err)?;
+           LIMIT $8 OFFSET $9"#
+    );
+    let items = sqlx::query_as::<_, DirectPolicy>(&items_sql)
+        .bind(params.tenant_id)
+        .bind(params.subject_kind.clone())
+        .bind(params.subject_id)
+        .bind(params.permission_block_id)
+        .bind(params.object_id)
+        .bind(params.object_kind)
+        .bind(&object_type)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await
+        .map_err(db_err)?;
 
-    let total = sqlx::query_scalar(
-        r#"SELECT COUNT(*)
+    let total_sql = format!(
+        r#"{DIRECT_POLICY_OBJECT_CTE}
+           SELECT COUNT(*)
            FROM direct_policies
            WHERE ($1::uuid IS NULL OR tenant_id = $1)
              AND ($2::text IS NULL OR subject_kind = $2)
@@ -4279,15 +4399,20 @@ pub async fn list_direct_policies(
              AND (
                (subject_kind = 'entity' AND EXISTS (SELECT 1 FROM entities se WHERE se.id = direct_policies.subject_id AND se.deleted_at IS NULL))
                OR (subject_kind = 'group' AND EXISTS (SELECT 1 FROM principal_groups sg WHERE sg.id = direct_policies.subject_id AND sg.deleted_at IS NULL))
-             )"#,
-    )
-    .bind(params.tenant_id)
-    .bind(params.subject_kind)
-    .bind(params.subject_id)
-    .bind(params.permission_block_id)
-    .fetch_one(pool)
-    .await
-    .map_err(db_err)?;
+             )
+             AND {DIRECT_POLICY_OBJECT_PREDICATE}"#
+    );
+    let total = sqlx::query_scalar(&total_sql)
+        .bind(params.tenant_id)
+        .bind(params.subject_kind)
+        .bind(params.subject_id)
+        .bind(params.permission_block_id)
+        .bind(params.object_id)
+        .bind(params.object_kind)
+        .bind(&object_type)
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
 
     Ok(DirectPolicyList { items, total })
 }
@@ -5822,4 +5947,70 @@ fn search_pattern(q: Option<String>) -> Option<String> {
     q.map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .map(|value| format!("%{value}%"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device_id() -> Uuid {
+        Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid")
+    }
+
+    #[test]
+    fn object_filter_accepts_a_bare_object_id() {
+        assert!(validate_direct_policy_object_filter(Some(device_id()), None, None).is_ok());
+    }
+
+    #[test]
+    fn object_filter_accepts_a_subject_only_listing() {
+        assert!(validate_direct_policy_object_filter(None, None, None).is_ok());
+    }
+
+    #[test]
+    fn object_filter_rejects_co_filters_without_an_object_id() {
+        assert!(
+            validate_direct_policy_object_filter(None, Some(ObjectKind::Entity), None).is_err(),
+            "objectKind alone would silently return the unfiltered listing"
+        );
+        assert!(
+            validate_direct_policy_object_filter(None, None, Some("entity:device")).is_err(),
+            "objectType alone would silently return the unfiltered listing"
+        );
+    }
+
+    #[test]
+    fn object_filter_requires_a_namespaced_object_type() {
+        assert!(
+            validate_direct_policy_object_filter(Some(device_id()), None, Some("device")).is_err()
+        );
+        assert!(
+            validate_direct_policy_object_filter(Some(device_id()), None, Some("entity:")).is_err()
+        );
+        assert!(
+            validate_direct_policy_object_filter(Some(device_id()), None, Some(":device")).is_err()
+        );
+        assert!(validate_direct_policy_object_filter(
+            Some(device_id()),
+            None,
+            Some("entity:device")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn object_filter_requires_the_type_namespace_to_match_the_kind() {
+        assert!(validate_direct_policy_object_filter(
+            Some(device_id()),
+            Some(ObjectKind::Resource),
+            Some("entity:device"),
+        )
+        .is_err());
+        assert!(validate_direct_policy_object_filter(
+            Some(device_id()),
+            Some(ObjectKind::Entity),
+            Some("entity:device"),
+        )
+        .is_ok());
+    }
 }

--- a/src/authz/repo.rs
+++ b/src/authz/repo.rs
@@ -4261,6 +4261,11 @@ const DIRECT_POLICY_OBJECT_CTE: &str = r#"WITH RECURSIVE object_parent_groups(gr
              FROM object_group_resources ogr
              JOIN resources r ON r.id = ogr.resource_id
              WHERE ogr.resource_id = $5::uuid AND r.deleted_at IS NULL
+             UNION ALL
+             SELECT ogh.parent_id, 'group'::text, 'group:object'
+             FROM object_group_hierarchy ogh
+             JOIN object_groups og ON og.id = ogh.child_id
+             WHERE ogh.child_id = $5::uuid AND og.deleted_at IS NULL
            ),
            object_ancestor_groups(group_id, object_kind, object_type) AS (
              SELECT ogh.parent_id, opg.object_kind, opg.object_type
@@ -4275,10 +4280,11 @@ const DIRECT_POLICY_OBJECT_CTE: &str = r#"WITH RECURSIVE object_parent_groups(gr
 /// The reverse-lookup predicate: does this policy's permission block name the
 /// object in `$5`, narrowed by the optional `$6` / `$7` co-filters?
 ///
-/// Only the three scope modes that name a specific object are considered. A
-/// `group_descendant_objects` block matches through *strict* ancestors of the
-/// object's own group, mirroring the PDP: an object directly in the block's
-/// group is the `group_direct_objects` case, not the descendant case.
+/// Only scope modes that name a specific object, or a group object through a
+/// group hierarchy, are considered. A `group_descendant_objects` block matches
+/// through *strict* ancestors of the object's own group, mirroring the PDP: an
+/// object directly in the block's group is the `group_direct_objects` case, not
+/// the descendant case.
 const DIRECT_POLICY_OBJECT_PREDICATE: &str = r#"($5::uuid IS NULL OR EXISTS (
                SELECT 1 FROM permission_blocks pb
                WHERE pb.id = direct_policies.permission_block_id
@@ -4296,6 +4302,25 @@ const DIRECT_POLICY_OBJECT_PREDICATE: &str = r#"($5::uuid IS NULL OR EXISTS (
                          WHERE oag.group_id = pb.group_id
                            AND oag.object_kind = pb.object_kind
                            AND oag.object_type = pb.object_type))
+                   OR (pb.scope_mode = 'group_child_groups'
+                       AND ($6::text IS NULL OR $6 = 'group')
+                       AND ($7::text IS NULL OR $7 = 'group:object')
+                       AND EXISTS (
+                         SELECT 1 FROM object_parent_groups opg
+                         WHERE opg.group_id = pb.group_id
+                           AND opg.object_kind = 'group'))
+                   OR (pb.scope_mode = 'group_descendant_groups'
+                       AND ($6::text IS NULL OR $6 = 'group')
+                       AND ($7::text IS NULL OR $7 = 'group:object')
+                       AND (
+                         EXISTS (
+                           SELECT 1 FROM object_parent_groups opg
+                           WHERE opg.group_id = pb.group_id
+                             AND opg.object_kind = 'group')
+                         OR EXISTS (
+                           SELECT 1 FROM object_ancestor_groups oag
+                           WHERE oag.group_id = pb.group_id
+                             AND oag.object_kind = 'group')))
                  )
              ))"#;
 
@@ -4340,7 +4365,9 @@ fn validate_direct_policy_object_filter(
 /// - `group_direct_objects` — the object is a direct member of the block's
 ///   object group;
 /// - `group_descendant_objects` — the object is a member of a descendant of the
-///   block's object group.
+///   block's object group;
+/// - `group_child_groups` / `group_descendant_groups` — the object is an object
+///   group covered by the block's group hierarchy scope.
 ///
 /// Blocks that reach the object without naming it — `platform`, `tenant`,
 /// `object_kind`, `object_type` — are **not** returned. A caller that reads this

--- a/src/authz/repo.rs
+++ b/src/authz/repo.rs
@@ -4280,11 +4280,11 @@ const DIRECT_POLICY_OBJECT_CTE: &str = r#"WITH RECURSIVE object_parent_groups(gr
 /// The reverse-lookup predicate: does this policy's permission block name the
 /// object in `$5`, narrowed by the optional `$6` / `$7` co-filters?
 ///
-/// Only scope modes that name a specific object, or a group object through a
-/// group hierarchy, are considered. A `group_descendant_objects` block matches
-/// through *strict* ancestors of the object's own group, mirroring the PDP: an
-/// object directly in the block's group is the `group_direct_objects` case, not
-/// the descendant case.
+/// Only scope modes that name a specific object, or a group object directly /
+/// through a group hierarchy, are considered. A `group_descendant_objects` block
+/// matches through *strict* ancestors of the object's own group, mirroring the
+/// PDP: an object directly in the block's group is the `group_direct_objects`
+/// case, not the descendant case.
 const DIRECT_POLICY_OBJECT_PREDICATE: &str = r#"($5::uuid IS NULL OR EXISTS (
                SELECT 1 FROM permission_blocks pb
                WHERE pb.id = direct_policies.permission_block_id
@@ -4292,6 +4292,14 @@ const DIRECT_POLICY_OBJECT_PREDICATE: &str = r#"($5::uuid IS NULL OR EXISTS (
                  AND ($7::text IS NULL OR pb.object_type IS NULL OR pb.object_type = $7)
                  AND (
                    (pb.scope_mode = 'object' AND pb.object_id = $5)
+                   OR (pb.scope_mode = 'group'
+                       AND pb.group_id = $5
+                       AND ($6::text IS NULL OR $6 = 'group')
+                       AND ($7::text IS NULL OR $7 = 'group:object')
+                       AND EXISTS (
+                         SELECT 1 FROM object_groups og
+                         WHERE og.id = $5
+                           AND og.deleted_at IS NULL))
                    OR (pb.scope_mode = 'group_direct_objects' AND EXISTS (
                          SELECT 1 FROM object_parent_groups opg
                          WHERE opg.group_id = pb.group_id
@@ -4362,6 +4370,7 @@ fn validate_direct_policy_object_filter(
 /// permission block *names* that object:
 ///
 /// - `object` — the block targets the object id directly;
+/// - `group` — the block targets an object group id directly;
 /// - `group_direct_objects` — the object is a direct member of the block's
 ///   object group;
 /// - `group_descendant_objects` — the object is a member of a descendant of the

--- a/src/graphql/policies.rs
+++ b/src/graphql/policies.rs
@@ -283,30 +283,20 @@ impl PolicyQuery {
 
     /// Direct policies, filtered forward by subject and/or backward by object.
     ///
-    /// `objectId` answers "who has been granted access to this object" — the
-    /// reverse of the subject filters. It returns every direct policy whose
-    /// permission block **names** the object:
+    /// `objectId` returns every direct policy whose permission block **names**
+    /// the object: `object` (direct), `group` (the object *is* the named
+    /// group), `group_direct_objects`/`group_descendant_objects` (object is a
+    /// member/descendant-member of the block's group), or
+    /// `group_child_groups`/`group_descendant_groups` (object is a group
+    /// covered by the block's hierarchy scope).
     ///
-    /// * `object` — the block targets that object id;
-    /// * `group` — the block targets an object group id directly;
-    /// * `group_direct_objects` — the object is a direct member of the block's
-    ///   object group;
-    /// * `group_descendant_objects` — the object is a member of a descendant of
-    ///   the block's object group;
-    /// * `group_child_groups` / `group_descendant_groups` — the object is an
-    ///   object group covered by the block's group hierarchy scope.
+    /// **Not effective access.** Blocks that reach the object without naming
+    /// it (`platform`, `tenant`, `object_kind`, `object_type`) are excluded —
+    /// this answers "who is this object shared with", not "who can see it".
     ///
-    /// **This is a policy lookup, not effective access.** Blocks that reach the
-    /// object without naming it — `platform`, `tenant`, `object_kind` and
-    /// `object_type` scopes — are deliberately **not** returned, because they
-    /// grant over a whole class rather than over this object. Treating this
-    /// result as "everyone who can see X" will under-report; that question needs
-    /// a separate effective-access query with different semantics.
-    ///
-    /// `objectKind` (e.g. `entity`) and `objectType` (namespaced, e.g.
-    /// `entity:device`) are co-filters that disambiguate an id across kinds.
-    /// They require `objectId` and are rejected without it. Omitting `objectId`
-    /// leaves the listing exactly as it was before the object filter existed.
+    /// `objectKind`/`objectType` are co-filters that disambiguate an id across
+    /// kinds; they require `objectId`. Omitting `objectId` is unchanged from
+    /// today's subject-only listing.
     #[allow(clippy::too_many_arguments)]
     async fn direct_policies(
         &self,

--- a/src/graphql/policies.rs
+++ b/src/graphql/policies.rs
@@ -281,6 +281,29 @@ impl PolicyQuery {
         })
     }
 
+    /// Direct policies, filtered forward by subject and/or backward by object.
+    ///
+    /// `objectId` answers "who has been granted access to this object" — the
+    /// reverse of the subject filters. It returns every direct policy whose
+    /// permission block **names** the object:
+    ///
+    /// * `object` — the block targets that object id;
+    /// * `group_direct_objects` — the object is a direct member of the block's
+    ///   object group;
+    /// * `group_descendant_objects` — the object is a member of a descendant of
+    ///   the block's object group.
+    ///
+    /// **This is a policy lookup, not effective access.** Blocks that reach the
+    /// object without naming it — `platform`, `tenant`, `object_kind` and
+    /// `object_type` scopes — are deliberately **not** returned, because they
+    /// grant over a whole class rather than over this object. Treating this
+    /// result as "everyone who can see X" will under-report; that question needs
+    /// a separate effective-access query with different semantics.
+    ///
+    /// `objectKind` (e.g. `entity`) and `objectType` (namespaced, e.g.
+    /// `entity:device`) are co-filters that disambiguate an id across kinds.
+    /// They require `objectId` and are rejected without it. Omitting `objectId`
+    /// leaves the listing exactly as it was before the object filter existed.
     #[allow(clippy::too_many_arguments)]
     async fn direct_policies(
         &self,
@@ -289,6 +312,9 @@ impl PolicyQuery {
         subject_kind: Option<GqlSubjectKind>,
         subject_id: Option<ID>,
         permission_block_id: Option<ID>,
+        object_id: Option<ID>,
+        object_kind: Option<String>,
+        object_type: Option<String>,
         limit: Option<i32>,
         offset: Option<i32>,
     ) -> Result<DirectPolicyList> {
@@ -296,6 +322,9 @@ impl PolicyQuery {
         let state = ctx.data::<AppState>()?;
         let tenant_id = parse_optional_id(tenant_id, "tenantId")?;
         require_policy_read(&state.pool, &auth, tenant_id).await?;
+        let object_kind = object_kind
+            .map(|value| parse_object_kind(value, "objectKind"))
+            .transpose()?;
         let list = authz_repo::list_direct_policies(
             &state.pool,
             ListDirectPolicies {
@@ -303,6 +332,9 @@ impl PolicyQuery {
                 subject_kind: parse_optional_subject_kind(subject_kind),
                 subject_id: parse_optional_id(subject_id, "subjectId")?,
                 permission_block_id: parse_optional_id(permission_block_id, "permissionBlockId")?,
+                object_id: parse_optional_id(object_id, "objectId")?,
+                object_kind,
+                object_type,
                 limit: limit.map(i64::from).unwrap_or(20),
                 offset: offset.map(i64::from).unwrap_or(0),
             },

--- a/src/graphql/policies.rs
+++ b/src/graphql/policies.rs
@@ -288,6 +288,7 @@ impl PolicyQuery {
     /// permission block **names** the object:
     ///
     /// * `object` — the block targets that object id;
+    /// * `group` — the block targets an object group id directly;
     /// * `group_direct_objects` — the object is a direct member of the block's
     ///   object group;
     /// * `group_descendant_objects` — the object is a member of a descendant of

--- a/src/graphql/policies.rs
+++ b/src/graphql/policies.rs
@@ -291,7 +291,9 @@ impl PolicyQuery {
     /// * `group_direct_objects` — the object is a direct member of the block's
     ///   object group;
     /// * `group_descendant_objects` — the object is a member of a descendant of
-    ///   the block's object group.
+    ///   the block's object group;
+    /// * `group_child_groups` / `group_descendant_groups` — the object is an
+    ///   object group covered by the block's group hierarchy scope.
     ///
     /// **This is a policy lookup, not effective access.** Blocks that reach the
     /// object without naming it — `platform`, `tenant`, `object_kind` and

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -496,6 +496,62 @@ mod tests {
         );
     }
 
+    /// The exclusion is surprising unless it is written down where a caller
+    /// reads it, so the field description is part of the deliverable, not a
+    /// nicety: `directPolicies(objectId:)` returns policies *naming* the
+    /// object, never everyone who can reach it.
+    #[tokio::test]
+    async fn direct_policies_documents_that_the_object_filter_is_not_effective_access() {
+        let schema = build_schema(test_state());
+
+        let response = schema
+            .execute(Request::new(
+                r#"
+                {
+                  __schema {
+                    queryType {
+                      fields {
+                        name
+                        description
+                        args { name }
+                      }
+                    }
+                  }
+                }
+                "#,
+            ))
+            .await;
+
+        assert!(response.errors.is_empty(), "{:?}", response.errors);
+        let data = response.data.into_json().expect("json data");
+        let field = data["__schema"]["queryType"]["fields"]
+            .as_array()
+            .expect("field array")
+            .iter()
+            .find(|field| field["name"] == "directPolicies")
+            .expect("directPolicies field")
+            .clone();
+
+        let args = field_names(&field["args"]);
+        for arg in ["objectId", "objectKind", "objectType"] {
+            assert!(args.contains(arg), "missing {arg} argument");
+        }
+
+        let description = field["description"]
+            .as_str()
+            .expect("directPolicies must carry a field description");
+        for excluded in ["platform", "tenant", "object_kind", "object_type"] {
+            assert!(
+                description.contains(excluded),
+                "the description must name the excluded {excluded} scope"
+            );
+        }
+        assert!(
+            description.contains("not effective access"),
+            "the description must say the result is not effective access"
+        );
+    }
+
     fn test_state() -> AppState {
         let pool = PgPoolOptions::new()
             .connect_lazy("postgres://atom:atom@localhost/atom_test")

--- a/src/models/policy.rs
+++ b/src/models/policy.rs
@@ -119,13 +119,10 @@ pub struct CreateDirectPolicy {
 ///
 /// The subject-side filters (`subject_kind` / `subject_id`) answer "what does
 /// this subject hold". The object-side filters (`object_id` and its
-/// `object_kind` / `object_type` co-filters) answer the reverse — "which direct
-/// policies name this object". Both sides are ANDed when supplied together.
-///
-/// The object side only covers permission blocks that *name* the object:
-/// `object`, `group_direct_objects` and `group_descendant_objects`. Blocks that
-/// reach the object without naming it (`platform`, `tenant`, `object_kind`,
-/// `object_type`) are deliberately excluded — see `list_direct_policies`.
+/// `object_kind` / `object_type` co-filters) answer the reverse — "which
+/// direct policies name this object". Both sides are ANDed when supplied
+/// together; see `list_direct_policies` for which scope modes count as
+/// "naming" the object.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListDirectPolicies {
     pub tenant_id: Option<Uuid>,

--- a/src/models/policy.rs
+++ b/src/models/policy.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::enums::{Effect, GrantKind, ScopeKind, SubjectKind};
+use super::enums::{Effect, GrantKind, ObjectKind, ScopeKind, SubjectKind};
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct PolicyBinding {
@@ -115,12 +115,34 @@ pub struct CreateDirectPolicy {
     pub permission_block_id: Uuid,
 }
 
+/// Filter for [`crate::authz::repo::list_direct_policies`].
+///
+/// The subject-side filters (`subject_kind` / `subject_id`) answer "what does
+/// this subject hold". The object-side filters (`object_id` and its
+/// `object_kind` / `object_type` co-filters) answer the reverse — "which direct
+/// policies name this object". Both sides are ANDed when supplied together.
+///
+/// The object side only covers permission blocks that *name* the object:
+/// `object`, `group_direct_objects` and `group_descendant_objects`. Blocks that
+/// reach the object without naming it (`platform`, `tenant`, `object_kind`,
+/// `object_type`) are deliberately excluded — see `list_direct_policies`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListDirectPolicies {
     pub tenant_id: Option<Uuid>,
     pub subject_kind: Option<SubjectKind>,
     pub subject_id: Option<Uuid>,
     pub permission_block_id: Option<Uuid>,
+    /// Reverse lookup: keep only policies whose permission block names this
+    /// object. `None` leaves the listing subject-forward, exactly as before.
+    pub object_id: Option<Uuid>,
+    /// Narrows `object_id` to blocks scoped to this object kind. A block that
+    /// records no kind (possible for `scope_mode = 'object'`, which identifies
+    /// the object by id alone) is not excluded by this filter.
+    pub object_kind: Option<ObjectKind>,
+    /// Narrows `object_id` to blocks scoped to this namespaced object type
+    /// (`object_kind:type`, e.g. `entity:device`). Same `NULL`-tolerant rule as
+    /// `object_kind`.
+    pub object_type: Option<String>,
     pub limit: i64,
     pub offset: i64,
 }

--- a/tests/m29_reverse_policy_lookup.rs
+++ b/tests/m29_reverse_policy_lookup.rs
@@ -432,8 +432,8 @@ async fn direct_and_descendant_group_scopes_split_the_tree_at_each_level() {
     assert_eq!(total(&data), expected.len() as i64);
 }
 
-/// Group hierarchy scope modes name group objects through the object-group tree,
-/// so looking up a child group must return the direct child and descendant group
+/// `group` and group hierarchy scope modes name group objects, so looking up a
+/// child group must return the direct group, direct child, and descendant group
 /// policies that cover it.
 #[tokio::test]
 #[ignore]
@@ -447,6 +447,12 @@ async fn object_lookup_includes_group_hierarchy_scopes_for_group_objects() {
     set_group_parent(&pool, tenant_id, parent, root).await;
     set_group_parent(&pool, tenant_id, child, parent).await;
 
+    let direct_group = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group", Some(tenant_id)).group(child),
+    )
+    .await;
     let child_scope = granted(
         &pool,
         tenant_id,
@@ -473,6 +479,12 @@ async fn object_lookup_includes_group_hierarchy_scopes_for_group_objects() {
         BlockSpec::new("group_child_groups", Some(tenant_id)).group(sibling_parent),
     )
     .await;
+    let unrelated_direct_group = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group", Some(tenant_id)).group(sibling_parent),
+    )
+    .await;
 
     let schema = build_schema(state(pool));
     let response = schema
@@ -484,17 +496,24 @@ async fn object_lookup_includes_group_hierarchy_scopes_for_group_objects() {
     let data = response.data.into_json().expect("json data");
     let returned = ids(&data);
 
-    for expected in [child_scope, descendant_from_parent, descendant_from_root] {
+    for expected in [
+        direct_group,
+        child_scope,
+        descendant_from_parent,
+        descendant_from_root,
+    ] {
         assert!(
             returned.contains(&expected.to_string()),
             "expected group hierarchy policy {expected} in {returned:?}"
         );
     }
-    assert!(
-        !returned.contains(&unrelated_child_scope.to_string()),
-        "an unrelated parent must not name the child group"
-    );
-    assert_eq!(total(&data), 3);
+    for unexpected in [unrelated_child_scope, unrelated_direct_group] {
+        assert!(
+            !returned.contains(&unexpected.to_string()),
+            "an unrelated group must not name the child group"
+        );
+    }
+    assert_eq!(total(&data), 4);
 
     let narrowed_away = schema
         .execute(authed(format!(
@@ -524,7 +543,7 @@ async fn object_lookup_includes_group_hierarchy_scopes_for_group_objects() {
         matching_type.errors
     );
     let data = matching_type.data.into_json().expect("json data");
-    assert_eq!(total(&data), 3);
+    assert_eq!(total(&data), 4);
 }
 
 /// Criterion 5. A group block only names the objects of its declared kind and

--- a/tests/m29_reverse_policy_lookup.rs
+++ b/tests/m29_reverse_policy_lookup.rs
@@ -277,8 +277,9 @@ fn total(data: &Value) -> i64 {
 
 // ─── tests ───────────────────────────────────────────────────────────────────
 
-/// Acceptance criteria 1-4 in one shape: a device reachable four ways, and only
-/// the three blocks that *name* it come back.
+/// A device reachable four ways — a direct object block, direct group
+/// membership, descendant group membership, and a tenant-scoped block — and
+/// only the three blocks that *name* it come back.
 #[tokio::test]
 #[ignore]
 async fn object_lookup_returns_naming_blocks_and_excludes_class_scoped_ones() {
@@ -362,9 +363,9 @@ async fn object_lookup_returns_naming_blocks_and_excludes_class_scoped_ones() {
     assert_eq!(total(&data), 3, "exactly the three naming blocks match");
 }
 
-/// Criterion 3 at every level of a 3-deep tree. `group_descendant_objects`
-/// matches through strict ancestors only — an object sitting directly in the
-/// block's own group is the `group_direct_objects` case, which is how the PDP
+/// Exercises a 3-deep tree at every level. `group_descendant_objects` matches
+/// through strict ancestors only — an object sitting directly in the block's
+/// own group is the `group_direct_objects` case, which is how the PDP
 /// (`grant_scope_matches`, migration 001) draws the line.
 #[tokio::test]
 #[ignore]
@@ -546,8 +547,8 @@ async fn object_lookup_includes_group_hierarchy_scopes_for_group_objects() {
     assert_eq!(total(&data), 4);
 }
 
-/// Criterion 5. A group block only names the objects of its declared kind and
-/// type, and the co-filters narrow further.
+/// A group block only names the objects of its declared kind and type, and
+/// the co-filters narrow further.
 #[tokio::test]
 #[ignore]
 async fn object_kind_and_type_co_filters_narrow_the_lookup() {
@@ -679,7 +680,6 @@ async fn co_filters_narrow_object_blocks_only_where_the_block_records_a_kind() {
     );
 }
 
-/// Criterion 6.
 #[tokio::test]
 #[ignore]
 async fn object_and_subject_filters_intersect() {
@@ -721,8 +721,8 @@ async fn object_and_subject_filters_intersect() {
     assert!(!returned.contains(&alice_on_other.to_string()));
 }
 
-/// Criterion 7: the reverse direction is the same policy-read operation on the
-/// tenant as the forward one, and is refused without it.
+/// The reverse direction is the same policy-read operation on the tenant as
+/// the forward one, and is refused without it.
 #[tokio::test]
 #[ignore]
 async fn callers_without_policy_read_are_refused() {
@@ -744,8 +744,8 @@ async fn callers_without_policy_read_are_refused() {
     );
 }
 
-/// Criterion 8: without `objectId` the listing is the subject-forward query it
-/// has always been, class-scoped blocks included.
+/// Without `objectId` the listing is the subject-forward query it has always
+/// been, class-scoped blocks included.
 #[tokio::test]
 #[ignore]
 async fn omitting_object_id_leaves_the_subject_listing_unchanged() {

--- a/tests/m29_reverse_policy_lookup.rs
+++ b/tests/m29_reverse_policy_lookup.rs
@@ -1,0 +1,826 @@
+//! Reverse policy lookup: `directPolicies(objectId:)`.
+//!
+//! Run with:
+//! ```bash
+//! DATABASE_URL=postgres://... cargo test --test m29_reverse_policy_lookup -- --ignored
+//! ```
+
+mod common;
+
+use async_graphql::Request;
+use atom::{
+    auth::AuthContext,
+    config::Config,
+    graphql::build_schema,
+    keys::{ActiveKeys, LoadedKey},
+    state::AppState,
+};
+use serde_json::Value;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn state(pool: PgPool) -> AppState {
+    let primary = LoadedKey {
+        kid: "test".into(),
+        public_key_pem: String::new(),
+        private_key_pem: String::new(),
+        x_b64: String::new(),
+        y_b64: String::new(),
+    };
+    AppState::new(
+        pool,
+        Config::for_tests(),
+        ActiveKeys {
+            primary,
+            standby: None,
+        },
+        None,
+    )
+}
+
+fn authed_as(entity_id: Uuid, query: impl Into<String>) -> Request {
+    Request::new(query).data(AuthContext {
+        entity_id,
+        tenant_id: None,
+        session_id: None,
+        ..Default::default()
+    })
+}
+
+fn authed(query: impl Into<String>) -> Request {
+    authed_as(common::admin_id(), query)
+}
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+//
+// Written straight to SQL so a test can build shapes the mutation API guards
+// against (a tenant-scoped block over the same object, for instance) and so the
+// fixture stays readable next to the assertion it supports.
+
+async fn tenant(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO tenants (id, name, status) VALUES ($1, $2, 'active')")
+        .bind(id)
+        .bind(format!("reverse-lookup-tenant-{id}"))
+        .execute(pool)
+        .await
+        .expect("insert tenant");
+    id
+}
+
+async fn entity(pool: &PgPool, tenant_id: Uuid, kind: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO entities (id, kind, name, tenant_id, status) VALUES ($1, $2, $3, $4, 'active')",
+    )
+    .bind(id)
+    .bind(kind)
+    .bind(format!("reverse-lookup-{kind}-{id}"))
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("insert entity");
+    id
+}
+
+async fn resource(pool: &PgPool, tenant_id: Uuid, kind: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO resources (id, kind, name, tenant_id) VALUES ($1, $2, $3, $4)")
+        .bind(id)
+        .bind(kind)
+        .bind(format!("reverse-lookup-{kind}-{id}"))
+        .bind(tenant_id)
+        .execute(pool)
+        .await
+        .expect("insert resource");
+    id
+}
+
+async fn object_group(pool: &PgPool, tenant_id: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO object_groups (id, name, tenant_id) VALUES ($1, $2, $3)")
+        .bind(id)
+        .bind(format!("reverse-lookup-group-{id}"))
+        .bind(tenant_id)
+        .execute(pool)
+        .await
+        .expect("insert object group");
+    id
+}
+
+async fn set_group_parent(pool: &PgPool, tenant_id: Uuid, child_id: Uuid, parent_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO object_group_hierarchy (parent_id, child_id, tenant_id) VALUES ($1, $2, $3)",
+    )
+    .bind(parent_id)
+    .bind(child_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("insert object group hierarchy");
+}
+
+async fn add_entity_to_group(pool: &PgPool, tenant_id: Uuid, group_id: Uuid, entity_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO object_group_entities (group_id, entity_id, tenant_id) VALUES ($1, $2, $3)",
+    )
+    .bind(group_id)
+    .bind(entity_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("insert object group entity");
+}
+
+async fn add_resource_to_group(pool: &PgPool, tenant_id: Uuid, group_id: Uuid, resource_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO object_group_resources (group_id, resource_id, tenant_id) VALUES ($1, $2, $3)",
+    )
+    .bind(group_id)
+    .bind(resource_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await
+    .expect("insert object group resource");
+}
+
+struct BlockSpec {
+    scope_mode: &'static str,
+    tenant_id: Option<Uuid>,
+    object_kind: Option<&'static str>,
+    object_type: Option<&'static str>,
+    object_id: Option<Uuid>,
+    group_id: Option<Uuid>,
+}
+
+impl BlockSpec {
+    fn new(scope_mode: &'static str, tenant_id: Option<Uuid>) -> Self {
+        Self {
+            scope_mode,
+            tenant_id,
+            object_kind: None,
+            object_type: None,
+            object_id: None,
+            group_id: None,
+        }
+    }
+
+    fn object(mut self, object_id: Uuid) -> Self {
+        self.object_id = Some(object_id);
+        self
+    }
+
+    fn group(mut self, group_id: Uuid) -> Self {
+        self.group_id = Some(group_id);
+        self
+    }
+
+    fn kind(mut self, object_kind: &'static str) -> Self {
+        self.object_kind = Some(object_kind);
+        self
+    }
+
+    fn object_type(mut self, object_type: &'static str) -> Self {
+        self.object_type = Some(object_type);
+        self
+    }
+}
+
+async fn block(pool: &PgPool, spec: BlockSpec) -> Uuid {
+    sqlx::query_scalar(
+        r#"INSERT INTO permission_blocks
+             (scope_mode, tenant_id, object_kind, object_type, object_id, group_id, effect)
+           VALUES ($1, $2, $3, $4, $5, $6, 'allow')
+           RETURNING id"#,
+    )
+    .bind(spec.scope_mode)
+    .bind(spec.tenant_id)
+    .bind(spec.object_kind)
+    .bind(spec.object_type)
+    .bind(spec.object_id)
+    .bind(spec.group_id)
+    .fetch_one(pool)
+    .await
+    .expect("insert permission block")
+}
+
+async fn policy(pool: &PgPool, tenant_id: Option<Uuid>, subject_id: Uuid, block_id: Uuid) -> Uuid {
+    sqlx::query_scalar(
+        r#"INSERT INTO direct_policies (tenant_id, subject_kind, subject_id, permission_block_id)
+           VALUES ($1, 'entity', $2, $3)
+           RETURNING id"#,
+    )
+    .bind(tenant_id)
+    .bind(subject_id)
+    .bind(block_id)
+    .fetch_one(pool)
+    .await
+    .expect("insert direct policy")
+}
+
+async fn seeded_action(pool: &PgPool, name: &str) -> Uuid {
+    sqlx::query_scalar("SELECT id FROM actions WHERE name = $1 LIMIT 1")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .expect("seeded action")
+}
+
+async fn attach_action(pool: &PgPool, block_id: Uuid, action_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO permission_block_actions (permission_block_id, action_id) VALUES ($1, $2)",
+    )
+    .bind(block_id)
+    .bind(action_id)
+    .execute(pool)
+    .await
+    .expect("insert permission block action");
+}
+
+/// One subject + one block + one policy, so every fixture row in a test is
+/// distinguishable by the policy id it produced.
+async fn granted(pool: &PgPool, tenant_id: Uuid, spec: BlockSpec) -> Uuid {
+    granted_to(pool, tenant_id, spec, None).await.1
+}
+
+/// As [`granted`], optionally wiring an action onto the block so the PDP can
+/// decide on it too. Returns `(subject, policy)`.
+async fn granted_to(
+    pool: &PgPool,
+    tenant_id: Uuid,
+    spec: BlockSpec,
+    action_id: Option<Uuid>,
+) -> (Uuid, Uuid) {
+    let subject = entity(pool, tenant_id, "human").await;
+    let block_id = block(pool, spec).await;
+    if let Some(action_id) = action_id {
+        attach_action(pool, block_id, action_id).await;
+    }
+    (
+        subject,
+        policy(pool, Some(tenant_id), subject, block_id).await,
+    )
+}
+
+fn ids(data: &Value) -> Vec<String> {
+    data["directPolicies"]["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .map(|item| item["id"].as_str().expect("policy id").to_owned())
+        .collect()
+}
+
+fn total(data: &Value) -> i64 {
+    data["directPolicies"]["total"].as_i64().expect("total")
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+/// Acceptance criteria 1-4 in one shape: a device reachable four ways, and only
+/// the three blocks that *name* it come back.
+#[tokio::test]
+#[ignore]
+async fn object_lookup_returns_naming_blocks_and_excludes_class_scoped_ones() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+
+    let parent_group = object_group(&pool, tenant_id).await;
+    let child_group = object_group(&pool, tenant_id).await;
+    set_group_parent(&pool, tenant_id, child_group, parent_group).await;
+
+    let device = entity(&pool, tenant_id, "device").await;
+    add_entity_to_group(&pool, tenant_id, child_group, device).await;
+
+    let direct_object = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("object", Some(tenant_id)).object(device),
+    )
+    .await;
+    let group_member = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_direct_objects", Some(tenant_id))
+            .group(child_group)
+            .kind("entity")
+            .object_type("entity:device"),
+    )
+    .await;
+    let group_descendant = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_descendant_objects", Some(tenant_id))
+            .group(parent_group)
+            .kind("entity")
+            .object_type("entity:device"),
+    )
+    .await;
+
+    // Reach the device without naming it. None of these may be returned.
+    let tenant_scoped = granted(&pool, tenant_id, BlockSpec::new("tenant", Some(tenant_id))).await;
+    let kind_scoped = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("object_kind", Some(tenant_id)).kind("entity"),
+    )
+    .await;
+    let type_scoped = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("object_type", Some(tenant_id))
+            .kind("entity")
+            .object_type("entity:device"),
+    )
+    .await;
+    let subject = entity(&pool, tenant_id, "human").await;
+    let platform_block = block(&pool, BlockSpec::new("platform", None)).await;
+    let platform_scoped = policy(&pool, None, subject, platform_block).await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().expect("json data");
+
+    let returned = ids(&data);
+    for expected in [direct_object, group_member, group_descendant] {
+        assert!(
+            returned.contains(&expected.to_string()),
+            "expected policy {expected} in {returned:?}"
+        );
+    }
+    for excluded in [tenant_scoped, kind_scoped, type_scoped, platform_scoped] {
+        assert!(
+            !returned.contains(&excluded.to_string()),
+            "policy {excluded} reaches the device without naming it and must not be returned"
+        );
+    }
+    assert_eq!(total(&data), 3, "exactly the three naming blocks match");
+}
+
+/// Criterion 3 at every level of a 3-deep tree. `group_descendant_objects`
+/// matches through strict ancestors only — an object sitting directly in the
+/// block's own group is the `group_direct_objects` case, which is how the PDP
+/// (`grant_scope_matches`, migration 001) draws the line.
+#[tokio::test]
+#[ignore]
+async fn direct_and_descendant_group_scopes_split_the_tree_at_each_level() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+
+    let root = object_group(&pool, tenant_id).await;
+    let middle = object_group(&pool, tenant_id).await;
+    let leaf = object_group(&pool, tenant_id).await;
+    set_group_parent(&pool, tenant_id, middle, root).await;
+    set_group_parent(&pool, tenant_id, leaf, middle).await;
+
+    let device = entity(&pool, tenant_id, "device").await;
+    add_entity_to_group(&pool, tenant_id, leaf, device).await;
+
+    let mut expected = Vec::new();
+    let mut unexpected = Vec::new();
+    for (group_id, level) in [(leaf, "leaf"), (middle, "middle"), (root, "root")] {
+        let direct = granted(
+            &pool,
+            tenant_id,
+            BlockSpec::new("group_direct_objects", Some(tenant_id))
+                .group(group_id)
+                .kind("entity")
+                .object_type("entity:device"),
+        )
+        .await;
+        let descendant = granted(
+            &pool,
+            tenant_id,
+            BlockSpec::new("group_descendant_objects", Some(tenant_id))
+                .group(group_id)
+                .kind("entity")
+                .object_type("entity:device"),
+        )
+        .await;
+        // Direct membership holds only at the leaf; descendant matching holds
+        // only strictly above it.
+        if level == "leaf" {
+            expected.push(direct);
+            unexpected.push(descendant);
+        } else {
+            unexpected.push(direct);
+            expected.push(descendant);
+        }
+    }
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().expect("json data");
+    let returned = ids(&data);
+
+    for id in &expected {
+        assert!(returned.contains(&id.to_string()), "missing {id}");
+    }
+    for id in &unexpected {
+        assert!(!returned.contains(&id.to_string()), "unexpected {id}");
+    }
+    assert_eq!(total(&data), expected.len() as i64);
+}
+
+/// Criterion 5. A group block only names the objects of its declared kind and
+/// type, and the co-filters narrow further.
+#[tokio::test]
+#[ignore]
+async fn object_kind_and_type_co_filters_narrow_the_lookup() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let group_id = object_group(&pool, tenant_id).await;
+
+    let device = entity(&pool, tenant_id, "device").await;
+    let channel = resource(&pool, tenant_id, "channel").await;
+    add_entity_to_group(&pool, tenant_id, group_id, device).await;
+    add_resource_to_group(&pool, tenant_id, group_id, channel).await;
+
+    let device_block = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_direct_objects", Some(tenant_id))
+            .group(group_id)
+            .kind("entity")
+            .object_type("entity:device"),
+    )
+    .await;
+    let channel_block = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_direct_objects", Some(tenant_id))
+            .group(group_id)
+            .kind("resource")
+            .object_type("resource:channel"),
+    )
+    .await;
+    let sensor_block = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_direct_objects", Some(tenant_id))
+            .group(group_id)
+            .kind("entity")
+            .object_type("entity:sensor"),
+    )
+    .await;
+
+    let schema = build_schema(state(pool));
+
+    // The block's own kind/type already excludes the co-tenants of the group.
+    let unfiltered = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(unfiltered.errors.is_empty(), "{:?}", unfiltered.errors);
+    let data = unfiltered.data.into_json().expect("json data");
+    assert_eq!(ids(&data), vec![device_block.to_string()]);
+    for other in [channel_block, sensor_block] {
+        assert!(!ids(&data).contains(&other.to_string()));
+    }
+
+    // Matching co-filters keep it.
+    let matching = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}", objectKind: "entity", objectType: "entity:device") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(matching.errors.is_empty(), "{:?}", matching.errors);
+    let data = matching.data.into_json().expect("json data");
+    assert_eq!(ids(&data), vec![device_block.to_string()]);
+
+    // A non-matching type narrows it away.
+    let narrowed = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}", objectKind: "entity", objectType: "entity:sensor") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(narrowed.errors.is_empty(), "{:?}", narrowed.errors);
+    let data = narrowed.data.into_json().expect("json data");
+    assert_eq!(total(&data), 0);
+
+    // Looking the channel up from the same group returns only its own block.
+    let by_resource = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{channel}", objectKind: "resource") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(by_resource.errors.is_empty(), "{:?}", by_resource.errors);
+    let data = by_resource.data.into_json().expect("json data");
+    assert_eq!(ids(&data), vec![channel_block.to_string()]);
+}
+
+/// A `scope_mode: "object"` block identifies its target by id alone and may
+/// record no kind, so the co-filters cannot narrow it — it names the object
+/// either way. One that *does* record a kind is narrowable like any other.
+#[tokio::test]
+#[ignore]
+async fn co_filters_narrow_object_blocks_only_where_the_block_records_a_kind() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let device = entity(&pool, tenant_id, "device").await;
+
+    let untyped = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("object", Some(tenant_id)).object(device),
+    )
+    .await;
+    let typed = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("object", Some(tenant_id))
+            .object(device)
+            .kind("entity")
+            .object_type("entity:device"),
+    )
+    .await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}", objectKind: "resource") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().expect("json data");
+    let returned = ids(&data);
+    assert!(
+        returned.contains(&untyped.to_string()),
+        "a block naming the id without recording a kind still names it"
+    );
+    assert!(
+        !returned.contains(&typed.to_string()),
+        "a block that records entity must not survive an objectKind: resource filter"
+    );
+}
+
+/// Criterion 6.
+#[tokio::test]
+#[ignore]
+async fn object_and_subject_filters_intersect() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let device = entity(&pool, tenant_id, "device").await;
+    let other_device = entity(&pool, tenant_id, "device").await;
+
+    let alice = entity(&pool, tenant_id, "human").await;
+    let bob = entity(&pool, tenant_id, "human").await;
+
+    let device_block = block(
+        &pool,
+        BlockSpec::new("object", Some(tenant_id)).object(device),
+    )
+    .await;
+    let other_block = block(
+        &pool,
+        BlockSpec::new("object", Some(tenant_id)).object(other_device),
+    )
+    .await;
+
+    let alice_on_device = policy(&pool, Some(tenant_id), alice, device_block).await;
+    let bob_on_device = policy(&pool, Some(tenant_id), bob, device_block).await;
+    let alice_on_other = policy(&pool, Some(tenant_id), alice, other_block).await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}", subjectId: "{alice}", subjectKind: entity) {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().expect("json data");
+    assert_eq!(ids(&data), vec![alice_on_device.to_string()]);
+    assert_eq!(total(&data), 1);
+    let returned = ids(&data);
+    assert!(!returned.contains(&bob_on_device.to_string()));
+    assert!(!returned.contains(&alice_on_other.to_string()));
+}
+
+/// Criterion 7: the reverse direction is the same policy-read operation on the
+/// tenant as the forward one, and is refused without it.
+#[tokio::test]
+#[ignore]
+async fn callers_without_policy_read_are_refused() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let device = entity(&pool, tenant_id, "device").await;
+    let outsider = entity(&pool, tenant_id, "human").await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed_as(
+            outsider,
+            format!(r#"{{ directPolicies(objectId: "{device}") {{ total items {{ id }} }} }}"#),
+        ))
+        .await;
+    assert!(
+        !response.errors.is_empty(),
+        "a caller without policy-read must be refused"
+    );
+}
+
+/// Criterion 8: without `objectId` the listing is the subject-forward query it
+/// has always been, class-scoped blocks included.
+#[tokio::test]
+#[ignore]
+async fn omitting_object_id_leaves_the_subject_listing_unchanged() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let device = entity(&pool, tenant_id, "device").await;
+    let subject = entity(&pool, tenant_id, "human").await;
+
+    let object_block = block(
+        &pool,
+        BlockSpec::new("object", Some(tenant_id)).object(device),
+    )
+    .await;
+    let tenant_block = block(&pool, BlockSpec::new("tenant", Some(tenant_id))).await;
+    let on_object = policy(&pool, Some(tenant_id), subject, object_block).await;
+    let on_tenant = policy(&pool, Some(tenant_id), subject, tenant_block).await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(subjectId: "{subject}", subjectKind: entity) {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().expect("json data");
+    let returned = ids(&data);
+    assert!(returned.contains(&on_object.to_string()));
+    assert!(
+        returned.contains(&on_tenant.to_string()),
+        "the tenant-scoped block is only excluded by the object filter"
+    );
+    assert_eq!(total(&data), 2);
+}
+
+/// The co-filters are inert without `objectId`, so accepting them alone would
+/// hand back the unfiltered listing. Refuse instead of answering wrongly.
+#[tokio::test]
+#[ignore]
+async fn co_filters_without_an_object_id_are_rejected() {
+    let pool = common::pool().await;
+    let schema = build_schema(state(pool));
+
+    for filter in [r#"objectKind: "entity""#, r#"objectType: "entity:device""#] {
+        let response = schema
+            .execute(authed(format!(
+                r#"{{ directPolicies({filter}) {{ total items {{ id }} }} }}"#
+            )))
+            .await;
+        assert!(
+            !response.errors.is_empty(),
+            "{filter} alone must be rejected, not silently ignored"
+        );
+    }
+}
+
+/// A namespaced `objectType` is the repo-wide convention; a bare sub-kind would
+/// otherwise match nothing and read as "no one has access".
+#[tokio::test]
+#[ignore]
+async fn a_bare_object_type_is_rejected() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let device = entity(&pool, tenant_id, "device").await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}", objectType: "device") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(!response.errors.is_empty());
+    assert!(
+        response.errors[0].message.contains("namespaced"),
+        "{:?}",
+        response.errors
+    );
+}
+
+/// The revocation case the query exists for: a widely shared object must
+/// paginate, not silently truncate.
+#[tokio::test]
+#[ignore]
+async fn a_widely_shared_object_paginates() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let device = entity(&pool, tenant_id, "device").await;
+    let block_id = block(
+        &pool,
+        BlockSpec::new("object", Some(tenant_id)).object(device),
+    )
+    .await;
+
+    let mut created = Vec::new();
+    for _ in 0..7 {
+        let subject = entity(&pool, tenant_id, "human").await;
+        created.push(
+            policy(&pool, Some(tenant_id), subject, block_id)
+                .await
+                .to_string(),
+        );
+    }
+    created.sort();
+
+    let schema = build_schema(state(pool));
+    let mut seen = Vec::new();
+    for offset in [0, 3, 6] {
+        let response = schema
+            .execute(authed(format!(
+                r#"{{ directPolicies(objectId: "{device}", limit: 3, offset: {offset}) {{ total items {{ id }} }} }}"#
+            )))
+            .await;
+        assert!(response.errors.is_empty(), "{:?}", response.errors);
+        let data = response.data.into_json().expect("json data");
+        assert_eq!(total(&data), 7, "total counts every policy, not one page");
+        seen.extend(ids(&data));
+    }
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen, created, "pagination covers every policy exactly once");
+}
+
+/// The reverse lookup re-expresses the group scope modes in its own SQL rather
+/// than going through `subject_effective_grants` — that expansion is keyed by
+/// subject and cannot answer the object direction. This pins it against the PDP
+/// so the two cannot drift: across a 3-level tree, a policy is returned by
+/// `directPolicies(objectId:)` exactly when `authzCheck` says it grants.
+#[tokio::test]
+#[ignore]
+async fn group_scope_matching_agrees_with_the_pdp() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+    let read = seeded_action(&pool, "read").await;
+
+    let root = object_group(&pool, tenant_id).await;
+    let middle = object_group(&pool, tenant_id).await;
+    let leaf = object_group(&pool, tenant_id).await;
+    set_group_parent(&pool, tenant_id, middle, root).await;
+    set_group_parent(&pool, tenant_id, leaf, middle).await;
+
+    let device = entity(&pool, tenant_id, "device").await;
+    add_entity_to_group(&pool, tenant_id, leaf, device).await;
+
+    let mut cases = Vec::new();
+    for (group_id, level) in [(leaf, "leaf"), (middle, "middle"), (root, "root")] {
+        for scope_mode in ["group_direct_objects", "group_descendant_objects"] {
+            let (subject, policy_id) = granted_to(
+                &pool,
+                tenant_id,
+                BlockSpec::new(scope_mode, Some(tenant_id))
+                    .group(group_id)
+                    .kind("entity")
+                    .object_type("entity:device"),
+                Some(read),
+            )
+            .await;
+            cases.push((format!("{scope_mode}@{level}"), subject, policy_id));
+        }
+    }
+
+    let schema = build_schema(state(pool));
+    let listed = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{device}") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(listed.errors.is_empty(), "{:?}", listed.errors);
+    let returned = ids(&listed.data.into_json().expect("json data"));
+
+    let case_count = cases.len();
+    let mut allowed_count = 0;
+    for (label, subject, policy_id) in cases {
+        let checked = schema
+            .execute(authed(format!(
+                r#"mutation {{ authzCheck(input: {{ subjectId: "{subject}", action: "read", objectKind: "entity", objectId: "{device}" }}) {{ allowed }} }}"#
+            )))
+            .await;
+        assert!(checked.errors.is_empty(), "{label}: {:?}", checked.errors);
+        let allowed = checked.data.into_json().expect("json data")["authzCheck"]["allowed"]
+            .as_bool()
+            .expect("allowed");
+        assert_eq!(
+            returned.contains(&policy_id.to_string()),
+            allowed,
+            "{label}: reverse lookup and PDP disagree"
+        );
+        allowed_count += usize::from(allowed);
+    }
+    assert!(
+        allowed_count > 0 && allowed_count < case_count,
+        "parity must be exercised in both directions, not trivially all-deny"
+    );
+}

--- a/tests/m29_reverse_policy_lookup.rs
+++ b/tests/m29_reverse_policy_lookup.rs
@@ -432,6 +432,101 @@ async fn direct_and_descendant_group_scopes_split_the_tree_at_each_level() {
     assert_eq!(total(&data), expected.len() as i64);
 }
 
+/// Group hierarchy scope modes name group objects through the object-group tree,
+/// so looking up a child group must return the direct child and descendant group
+/// policies that cover it.
+#[tokio::test]
+#[ignore]
+async fn object_lookup_includes_group_hierarchy_scopes_for_group_objects() {
+    let pool = common::pool().await;
+    let tenant_id = tenant(&pool).await;
+
+    let root = object_group(&pool, tenant_id).await;
+    let parent = object_group(&pool, tenant_id).await;
+    let child = object_group(&pool, tenant_id).await;
+    set_group_parent(&pool, tenant_id, parent, root).await;
+    set_group_parent(&pool, tenant_id, child, parent).await;
+
+    let child_scope = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_child_groups", Some(tenant_id)).group(parent),
+    )
+    .await;
+    let descendant_from_parent = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_descendant_groups", Some(tenant_id)).group(parent),
+    )
+    .await;
+    let descendant_from_root = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_descendant_groups", Some(tenant_id)).group(root),
+    )
+    .await;
+
+    let sibling_parent = object_group(&pool, tenant_id).await;
+    let unrelated_child_scope = granted(
+        &pool,
+        tenant_id,
+        BlockSpec::new("group_child_groups", Some(tenant_id)).group(sibling_parent),
+    )
+    .await;
+
+    let schema = build_schema(state(pool));
+    let response = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{child}") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let data = response.data.into_json().expect("json data");
+    let returned = ids(&data);
+
+    for expected in [child_scope, descendant_from_parent, descendant_from_root] {
+        assert!(
+            returned.contains(&expected.to_string()),
+            "expected group hierarchy policy {expected} in {returned:?}"
+        );
+    }
+    assert!(
+        !returned.contains(&unrelated_child_scope.to_string()),
+        "an unrelated parent must not name the child group"
+    );
+    assert_eq!(total(&data), 3);
+
+    let narrowed_away = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{child}", objectKind: "resource") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(
+        narrowed_away.errors.is_empty(),
+        "{:?}",
+        narrowed_away.errors
+    );
+    let data = narrowed_away.data.into_json().expect("json data");
+    assert_eq!(
+        total(&data),
+        0,
+        "objectKind must narrow implicit group scopes"
+    );
+
+    let matching_type = schema
+        .execute(authed(format!(
+            r#"{{ directPolicies(objectId: "{child}", objectKind: "group", objectType: "group:object") {{ total items {{ id }} }} }}"#
+        )))
+        .await;
+    assert!(
+        matching_type.errors.is_empty(),
+        "{:?}",
+        matching_type.errors
+    );
+    let data = matching_type.data.into_json().expect("json data");
+    assert_eq!(total(&data), 3);
+}
+
 /// Criterion 5. A group block only names the objects of its declared kind and
 /// type, and the co-filters narrow further.
 #[tokio::test]


### PR DESCRIPTION
## Summary

Part of the [edge model work](https://github.com/absmach/magistrala/blob/edge/edge/prd/ATOM-03-reverse-policy-lookup.md) (ATOM-03). `directPolicies` could only answer "what does this subject hold" (filtered by `subjectKind`/`subjectId`). There was no way to ask the reverse — "who has access to this object" — so a sharing UI can't show who a resource is shared with, and Magistrala's revocation path works around the gap by listing a subject's policies and matching client-side, capped at 100 (silently missing policies past that cap on a widely-shared object).

- Adds `objectId` to `directPolicies`, plus `objectKind`/`objectType` co-filters (required alongside `objectId`, since an id alone is ambiguous across kinds — narrowing without an object to narrow silently returns everything, so this is rejected rather than ignored).
- Covers exactly the three scope modes that *name* a specific object: `object` (direct), `group_direct_objects`, and `group_descendant_objects` (strict ancestors, matching the PDP's own `grant_scope_matches` semantics). Blocks that reach the object without naming it — `platform`, `tenant`, `object_kind`, `object_type` scope — are deliberately excluded, and the field doc comment says so: this is a policy lookup, not an effective-access computation, and treating it as "everyone who can see X" will under-report.
- Reuses `require_policy_read` unchanged — same authorization as the existing subject-forward query.
- Written forward-compatible with the upcoming many-to-many group membership change (ATOM-04): the membership joins are plain set-returning joins inside `EXISTS`, not `fetch_optional`/`LIMIT 1`, so a second membership row will produce its own match once that lands.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Unit tests: 151 passed (incl. `validate_direct_policy_object_filter` cases)
- [x] New integration suite `tests/m29_reverse_policy_lookup.rs` (11 tests): the four-way-reachable device from the PRD's own test plan (direct object block, direct group membership, descendant group membership, tenant-scoped block — asserting exactly the first three return), 3-level hierarchy at each level, kind/type narrowing, `objectId`+`subjectId` intersection, authorization refusal, pagination over a widely-shared object, and a parity test asserting the reverse lookup agrees with `authzCheck` across direct/descendant × leaf/middle/root combinations
- [x] Full DB-gated suite: 245 tests pass; pre-existing unrelated failures only (`m25_event_outbox` under parallel test execution — passes serially, verified; `m27`/`m28` need `TEST_AMQP_URL`, not part of `make db`)