### PR TITLE
[PKI PR-003 follow-up] Close CA provisioning review gaps

### DIFF
--- a/src/certs/authority/graphql.rs
+++ b/src/certs/authority/graphql.rs
@@ -4,9 +4,9 @@ use uuid::Uuid;
 use crate::{
     audit,
     auth::{require_capability, Scope},
-    error::db_err,
+    error::{db_err, AppError},
     graphql::{
-        auth::{deny_scoped_token, gql_error, require_auth},
+        auth::{gql_error, require_auth},
         types::parse_id,
     },
     models::enums::AuditOutcome,
@@ -58,26 +58,36 @@ impl AuthorityMutation {
     ) -> Result<Authority> {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
-        require_mutation_access(state, &auth, Scope::Platform).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let authority = provisioning::import_root_in_tx(&mut tx, &certificate_pem)
-            .await
-            .map_err(gql_error)?;
-        commit_authority_event(
+        let result = async {
+            require_mutation_access(state, &auth, Scope::Platform).await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let outcome =
+                provisioning::import_root_mutation_in_tx(&mut tx, &certificate_pem).await?;
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.value,
+                outcome.changed,
+                "pki.authority.root_imported",
+                "pki.authority.root_import_replayed",
+                AuditOutcome::Allow,
+                serde_json::json!({"version": outcome.value.version}),
+            )
+            .await?;
+            Ok(outcome.value.into())
+        }
+        .await;
+        observe_authority_result(
             state,
-            tx,
             &auth,
-            &authority,
+            None,
+            None,
             "pki.authority.root_imported",
-            AuditOutcome::Allow,
-            serde_json::json!({"version": authority.version}),
+            serde_json::json!({"transport": "graphql"}),
+            result,
         )
-        .await?;
-        Ok(authority.into())
+        .await
     }
 
     async fn begin_tenant_authority_provisioning(
@@ -88,30 +98,40 @@ impl AuthorityMutation {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
         let tenant_id = parse_id(tenant_id, "tenantId")?;
-        require_mutation_access(state, &auth, Scope::Tenant(tenant_id)).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let authority = provisioning::begin_tenant_authority_in_tx(
-            &mut tx,
-            &state.config.pki_ca_keys,
-            tenant_id,
+        let result = async {
+            require_mutation_access(state, &auth, Scope::Tenant(tenant_id)).await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let outcome = provisioning::begin_tenant_authority_mutation_in_tx(
+                &mut tx,
+                &state.config.pki_ca_keys,
+                tenant_id,
+            )
+            .await?;
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.value,
+                outcome.changed,
+                "pki.authority.provisioning_started",
+                "pki.authority.provisioning_replayed",
+                AuditOutcome::Allow,
+                lifecycle_details(&outcome.value),
+            )
+            .await?;
+            Ok(outcome.value.into())
+        }
+        .await;
+        observe_authority_result(
+            state,
+            &auth,
+            Some(tenant_id),
+            None,
+            "pki.authority.provisioning_started",
+            serde_json::json!({"transport": "graphql", "kind": "tenant_intermediate"}),
+            result,
         )
         .await
-        .map_err(gql_error)?;
-        commit_authority_event(
-            state,
-            tx,
-            &auth,
-            &authority,
-            "pki.authority.provisioning_started",
-            AuditOutcome::Allow,
-            lifecycle_details(&authority),
-        )
-        .await?;
-        Ok(authority.into())
     }
 
     async fn begin_platform_leaf_issuer_provisioning(
@@ -120,27 +140,39 @@ impl AuthorityMutation {
     ) -> Result<Authority> {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
-        require_mutation_access(state, &auth, Scope::Platform).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let authority =
-            provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &state.config.pki_ca_keys)
-                .await
-                .map_err(gql_error)?;
-        commit_authority_event(
+        let result = async {
+            require_mutation_access(state, &auth, Scope::Platform).await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let outcome = provisioning::begin_platform_leaf_issuer_mutation_in_tx(
+                &mut tx,
+                &state.config.pki_ca_keys,
+            )
+            .await?;
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.value,
+                outcome.changed,
+                "pki.authority.provisioning_started",
+                "pki.authority.provisioning_replayed",
+                AuditOutcome::Allow,
+                lifecycle_details(&outcome.value),
+            )
+            .await?;
+            Ok(outcome.value.into())
+        }
+        .await;
+        observe_authority_result(
             state,
-            tx,
             &auth,
-            &authority,
+            None,
+            None,
             "pki.authority.provisioning_started",
-            AuditOutcome::Allow,
-            lifecycle_details(&authority),
+            serde_json::json!({"transport": "graphql", "kind": "platform_leaf_issuer"}),
+            result,
         )
-        .await?;
-        Ok(authority.into())
+        .await
     }
 
     async fn begin_platform_intermediate_provisioning(
@@ -149,27 +181,39 @@ impl AuthorityMutation {
     ) -> Result<Authority> {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
-        require_mutation_access(state, &auth, Scope::Platform).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let authority =
-            provisioning::begin_platform_intermediate_in_tx(&mut tx, &state.config.pki_ca_keys)
-                .await
-                .map_err(gql_error)?;
-        commit_authority_event(
+        let result = async {
+            require_mutation_access(state, &auth, Scope::Platform).await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let outcome = provisioning::begin_platform_intermediate_mutation_in_tx(
+                &mut tx,
+                &state.config.pki_ca_keys,
+            )
+            .await?;
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.value,
+                outcome.changed,
+                "pki.authority.provisioning_started",
+                "pki.authority.provisioning_replayed",
+                AuditOutcome::Allow,
+                lifecycle_details(&outcome.value),
+            )
+            .await?;
+            Ok(outcome.value.into())
+        }
+        .await;
+        observe_authority_result(
             state,
-            tx,
             &auth,
-            &authority,
+            None,
+            None,
             "pki.authority.provisioning_started",
-            AuditOutcome::Allow,
-            lifecycle_details(&authority),
+            serde_json::json!({"transport": "graphql", "kind": "platform_intermediate"}),
+            result,
         )
-        .await?;
-        Ok(authority.into())
+        .await
     }
 
     async fn import_signed_authority(
@@ -181,46 +225,57 @@ impl AuthorityMutation {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
         let authority_id = parse_id(authority_id, "authorityId")?;
-        let existing = repo::authority_by_id(&state.pool, authority_id)
-            .await
-            .map_err(gql_error)?;
-        require_mutation_access(state, &auth, authority_scope(&existing)).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let outcome = provisioning::import_signed_authority_in_tx(
-            &mut tx,
-            &state.config.pki_ca_keys,
-            authority_id,
-            &certificate_pem,
+        let mut observed_tenant_id = auth.tenant_id;
+        let result = async {
+            let existing = repo::authority_by_id(&state.pool, authority_id).await?;
+            observed_tenant_id = existing.tenant_id;
+            require_mutation_access(state, &auth, authority_scope(&existing)).await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let mutation = provisioning::import_signed_authority_mutation_in_tx(
+                &mut tx,
+                &state.config.pki_ca_keys,
+                authority_id,
+                &certificate_pem,
+            )
+            .await?;
+            let outcome = mutation.value;
+            let audit_outcome = if outcome.succeeded() {
+                AuditOutcome::Allow
+            } else {
+                AuditOutcome::Error
+            };
+            let details = serde_json::json!({
+                "kind": authority_kind(&outcome.authority),
+                "version": outcome.authority.version,
+                "status": authority_status(&outcome.authority),
+                "replaced_authorities": outcome.replaced_authorities,
+                "validation_succeeded": outcome.succeeded()
+            });
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.authority,
+                mutation.changed,
+                "pki.authority.signed_certificate_imported",
+                "pki.authority.signed_certificate_import_replayed",
+                audit_outcome,
+                details,
+            )
+            .await?;
+            Ok(outcome.into())
+        }
+        .await;
+        observe_authority_result(
+            state,
+            &auth,
+            observed_tenant_id,
+            Some(authority_id),
+            "pki.authority.signed_certificate_imported",
+            serde_json::json!({"transport": "graphql"}),
+            result,
         )
         .await
-        .map_err(gql_error)?;
-        let audit_outcome = if outcome.succeeded() {
-            AuditOutcome::Allow
-        } else {
-            AuditOutcome::Error
-        };
-        let details = serde_json::json!({
-            "kind": authority_kind(&outcome.authority),
-            "version": outcome.authority.version,
-            "status": authority_status(&outcome.authority),
-            "replaced_authorities": outcome.replaced_authorities,
-            "validation_succeeded": outcome.succeeded()
-        });
-        commit_authority_event(
-            state,
-            tx,
-            &auth,
-            &outcome.authority,
-            "pki.authority.signed_certificate_imported",
-            audit_outcome,
-            details,
-        )
-        .await?;
-        Ok(outcome.into())
     }
 
     async fn provision_tenant_authority_automatically(
@@ -231,43 +286,59 @@ impl AuthorityMutation {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
         let tenant_id = parse_id(tenant_id, "tenantId")?;
-        deny_scoped_token(&auth)?;
-        require_pki_capability(state, &auth, Scope::Tenant(tenant_id)).await?;
-        require_capability(
-            &state.pool,
-            &auth,
-            "pki.provision_automated",
-            Scope::Platform,
-        )
-        .await
-        .map_err(gql_error)?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let outcome = provisioning::provision_tenant_automatically_in_tx(
-            &mut tx,
-            &state.config.pki_ca_keys,
-            tenant_id,
-        )
-        .await
-        .map_err(gql_error)?;
-        commit_authority_event(
+        let result = async {
+            auth.reject_scoped_credential_management()?;
+            require_capability(
+                &state.pool,
+                &auth,
+                "pki.provision",
+                Scope::Tenant(tenant_id),
+            )
+            .await?;
+            require_capability(
+                &state.pool,
+                &auth,
+                "pki.provision_automated",
+                Scope::Platform,
+            )
+            .await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let mutation = provisioning::provision_tenant_automatically_mutation_in_tx(
+                &mut tx,
+                &state.config.pki_ca_keys,
+                tenant_id,
+            )
+            .await?;
+            let outcome = mutation.value;
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.authority,
+                mutation.changed,
+                "pki.authority.provisioned_automatically",
+                "pki.authority.automated_provisioning_replayed",
+                AuditOutcome::Allow,
+                serde_json::json!({
+                    "kind": authority_kind(&outcome.authority),
+                    "version": outcome.authority.version,
+                    "replaced_authorities": outcome.replaced_authorities
+                }),
+            )
+            .await?;
+            Ok(outcome.into())
+        }
+        .await;
+        observe_authority_result(
             state,
-            tx,
             &auth,
-            &outcome.authority,
+            Some(tenant_id),
+            None,
             "pki.authority.provisioned_automatically",
-            AuditOutcome::Allow,
-            serde_json::json!({
-                "kind": authority_kind(&outcome.authority),
-                "version": outcome.authority.version,
-                "replaced_authorities": outcome.replaced_authorities
-            }),
+            serde_json::json!({"transport": "graphql"}),
+            result,
         )
-        .await?;
-        Ok(outcome.into())
+        .await
     }
 
     async fn begin_authority_retirement(
@@ -297,38 +368,57 @@ impl AuthorityMutation {
         let auth = require_auth(ctx)?;
         let state = ctx.data::<AppState>()?;
         let authority_id = parse_id(authority_id, "authorityId")?;
-        let existing = repo::authority_by_id(&state.pool, authority_id)
-            .await
-            .map_err(gql_error)?;
-        require_mutation_access(state, &auth, authority_scope(&existing)).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let authority = if complete {
-            provisioning::complete_retirement_in_tx(&mut tx, authority_id).await
-        } else {
-            provisioning::begin_retirement_in_tx(&mut tx, &state.config.pki_ca_keys, authority_id)
-                .await
-        }
-        .map_err(gql_error)?;
         let event = if complete {
             "pki.authority.retired"
         } else {
             "pki.authority.retiring"
         };
-        commit_authority_event(
+        let replay_event = if complete {
+            "pki.authority.retirement_completion_replayed"
+        } else {
+            "pki.authority.retirement_start_replayed"
+        };
+        let mut observed_tenant_id = auth.tenant_id;
+        let result = async {
+            let existing = repo::authority_by_id(&state.pool, authority_id).await?;
+            observed_tenant_id = existing.tenant_id;
+            require_mutation_access(state, &auth, authority_scope(&existing)).await?;
+            let mut tx = state.pool.begin().await.map_err(db_err)?;
+            let outcome = if complete {
+                provisioning::complete_retirement_mutation_in_tx(&mut tx, authority_id).await?
+            } else {
+                provisioning::begin_retirement_mutation_in_tx(
+                    &mut tx,
+                    &state.config.pki_ca_keys,
+                    authority_id,
+                )
+                .await?
+            };
+            commit_authority_mutation(
+                state,
+                tx,
+                &auth,
+                &outcome.value,
+                outcome.changed,
+                event,
+                replay_event,
+                AuditOutcome::Allow,
+                lifecycle_details(&outcome.value),
+            )
+            .await?;
+            Ok(outcome.value.into())
+        }
+        .await;
+        observe_authority_result(
             state,
-            tx,
             &auth,
-            &authority,
+            observed_tenant_id,
+            Some(authority_id),
             event,
-            AuditOutcome::Allow,
-            lifecycle_details(&authority),
+            serde_json::json!({"transport": "graphql"}),
+            result,
         )
-        .await?;
-        Ok(authority.into())
+        .await
     }
 }
 
@@ -490,9 +580,9 @@ async fn require_mutation_access(
     state: &AppState,
     auth: &crate::auth::AuthContext,
     scope: Scope,
-) -> Result<()> {
-    deny_scoped_token(auth)?;
-    require_pki_capability(state, auth, scope).await
+) -> std::result::Result<(), AppError> {
+    auth.reject_scoped_credential_management()?;
+    require_capability(&state.pool, auth, "pki.provision", scope).await
 }
 
 async fn require_pki_capability(
@@ -521,7 +611,7 @@ async fn commit_authority_event(
     event: &'static str,
     outcome: AuditOutcome,
     details: serde_json::Value,
-) -> Result<()> {
+) -> std::result::Result<(), AppError> {
     audit::commit_with_audit(
         &state.pool,
         tx,
@@ -537,7 +627,72 @@ async fn commit_authority_event(
         },
     )
     .await
-    .map_err(gql_error)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn commit_authority_mutation(
+    state: &AppState,
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    auth: &crate::auth::AuthContext,
+    authority: &AuthorityRecord,
+    changed: bool,
+    event: &'static str,
+    replay_event: &'static str,
+    outcome: AuditOutcome,
+    details: serde_json::Value,
+) -> std::result::Result<(), AppError> {
+    if changed {
+        return commit_authority_event(state, tx, auth, authority, event, outcome, details).await;
+    }
+
+    tx.commit().await.map_err(db_err)?;
+    let mut replay_details = details;
+    if let serde_json::Value::Object(ref mut object) = replay_details {
+        object.insert("replay".to_string(), serde_json::Value::Bool(true));
+    }
+    audit::write(
+        &state.pool,
+        false,
+        audit::AuditEvent {
+            actor_entity_id: Some(auth.entity_id),
+            tenant_id: authority.tenant_id,
+            target_kind: Some("pki_authority"),
+            target_id: Some(authority.id),
+            event: replay_event,
+            outcome,
+            details: replay_details,
+        },
+    )
+    .await;
+    Ok(())
+}
+
+async fn observe_authority_result<T>(
+    state: &AppState,
+    auth: &crate::auth::AuthContext,
+    tenant_id: Option<Uuid>,
+    target_id: Option<Uuid>,
+    event: &'static str,
+    details: serde_json::Value,
+    result: std::result::Result<T, AppError>,
+) -> Result<T> {
+    if let Err(ref error) = result {
+        audit::observe_error(
+            &state.pool,
+            state.config.events.enabled(),
+            &audit::AuditMeta {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id,
+                target_kind: "pki_authority",
+                target_id,
+                event,
+            },
+            &details,
+            error,
+        )
+        .await;
+    }
+    result.map_err(gql_error)
 }
 
 fn lifecycle_details(authority: &AuthorityRecord) -> serde_json::Value {

--- a/src/certs/authority/provisioning.rs
+++ b/src/certs/authority/provisioning.rs
@@ -118,9 +118,7 @@ pub async fn import_root_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     certificate_pem: &str,
 ) -> Result<AuthorityRecord, AppError> {
-    Ok(import_root_mutation_in_tx(tx, certificate_pem)
-        .await?
-        .value)
+    Ok(import_root_mutation_in_tx(tx, certificate_pem).await?.value)
 }
 
 pub async fn import_root_mutation_in_tx(
@@ -145,8 +143,7 @@ pub async fn import_root_mutation_in_tx(
 
     let version = repo::next_authority_version(tx, AuthorityKind::Root, None).await?;
     let completed = completed_authority(&parsed, &parsed.pem);
-    let authority =
-        repo::insert_root_authority(tx, Uuid::new_v4(), version, &completed).await?;
+    let authority = repo::insert_root_authority(tx, Uuid::new_v4(), version, &completed).await?;
     Ok(AuthorityMutationOutcome {
         value: authority,
         changed: true,
@@ -158,9 +155,11 @@ pub async fn begin_tenant_authority_in_tx(
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
 ) -> Result<AuthorityRecord, AppError> {
-    Ok(begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id)
-        .await?
-        .value)
+    Ok(
+        begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id)
+            .await?
+            .value,
+    )
 }
 
 pub async fn begin_tenant_authority_mutation_in_tx(
@@ -181,48 +180,34 @@ pub async fn begin_platform_leaf_issuer_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
 ) -> Result<AuthorityRecord, AppError> {
-    Ok(
-        begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys)
-            .await?
-            .value,
-    )
+    Ok(begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys)
+        .await?
+        .value)
 }
 
 pub async fn begin_platform_leaf_issuer_mutation_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
 ) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
-    begin_offline_authority_mutation_in_tx(
-        tx,
-        ca_keys,
-        AuthorityKind::PlatformLeafIssuer,
-        None,
-    )
-    .await
+    begin_offline_authority_mutation_in_tx(tx, ca_keys, AuthorityKind::PlatformLeafIssuer, None)
+        .await
 }
 
 pub async fn begin_platform_intermediate_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
 ) -> Result<AuthorityRecord, AppError> {
-    Ok(
-        begin_platform_intermediate_mutation_in_tx(tx, ca_keys)
-            .await?
-            .value,
-    )
+    Ok(begin_platform_intermediate_mutation_in_tx(tx, ca_keys)
+        .await?
+        .value)
 }
 
 pub async fn begin_platform_intermediate_mutation_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
 ) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
-    begin_offline_authority_mutation_in_tx(
-        tx,
-        ca_keys,
-        AuthorityKind::PlatformIntermediate,
-        None,
-    )
-    .await
+    begin_offline_authority_mutation_in_tx(tx, ca_keys, AuthorityKind::PlatformIntermediate, None)
+        .await
 }
 
 async fn begin_offline_authority_mutation_in_tx(
@@ -454,11 +439,9 @@ pub async fn begin_retirement_in_tx(
     ca_keys: &PkiCaKeyConfig,
     authority_id: Uuid,
 ) -> Result<AuthorityRecord, AppError> {
-    Ok(
-        begin_retirement_mutation_in_tx(tx, ca_keys, authority_id)
-            .await?
-            .value,
-    )
+    Ok(begin_retirement_mutation_in_tx(tx, ca_keys, authority_id)
+        .await?
+        .value)
 }
 
 pub async fn begin_retirement_mutation_in_tx(

--- a/src/certs/authority/provisioning.rs
+++ b/src/certs/authority/provisioning.rs
@@ -40,6 +40,12 @@ impl AuthorityImportOutcome {
     }
 }
 
+#[derive(Debug)]
+pub struct AuthorityMutationOutcome<T> {
+    pub value: T,
+    pub changed: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrustBundle {
     pub pem: String,
@@ -112,13 +118,25 @@ pub async fn import_root_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     certificate_pem: &str,
 ) -> Result<AuthorityRecord, AppError> {
+    Ok(import_root_mutation_in_tx(tx, certificate_pem)
+        .await?
+        .value)
+}
+
+pub async fn import_root_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    certificate_pem: &str,
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
     repo::lock_provisioning(tx).await?;
     let parsed = parse_authority_certificate(certificate_pem)?;
     validate_root_certificate(&parsed)?;
 
     if let Some(existing) = repo::authority_by_fingerprint(tx, &parsed.fingerprint_sha256).await? {
         if existing.kind == AuthorityKind::Root {
-            return Ok(existing);
+            return Ok(AuthorityMutationOutcome {
+                value: existing,
+                changed: false,
+            });
         }
         return Err(AppError::conflict(
             "certificate fingerprint already belongs to another authority",
@@ -127,7 +145,12 @@ pub async fn import_root_in_tx(
 
     let version = repo::next_authority_version(tx, AuthorityKind::Root, None).await?;
     let completed = completed_authority(&parsed, &parsed.pem);
-    repo::insert_root_authority(tx, Uuid::new_v4(), version, &completed).await
+    let authority =
+        repo::insert_root_authority(tx, Uuid::new_v4(), version, &completed).await?;
+    Ok(AuthorityMutationOutcome {
+        value: authority,
+        changed: true,
+    })
 }
 
 pub async fn begin_tenant_authority_in_tx(
@@ -135,7 +158,17 @@ pub async fn begin_tenant_authority_in_tx(
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
 ) -> Result<AuthorityRecord, AppError> {
-    begin_offline_authority_in_tx(
+    Ok(begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id)
+        .await?
+        .value)
+}
+
+pub async fn begin_tenant_authority_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    ca_keys: &PkiCaKeyConfig,
+    tenant_id: Uuid,
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_offline_authority_mutation_in_tx(
         tx,
         ca_keys,
         AuthorityKind::TenantIntermediate,
@@ -148,29 +181,66 @@ pub async fn begin_platform_leaf_issuer_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
 ) -> Result<AuthorityRecord, AppError> {
-    begin_offline_authority_in_tx(tx, ca_keys, AuthorityKind::PlatformLeafIssuer, None).await
+    Ok(
+        begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys)
+            .await?
+            .value,
+    )
+}
+
+pub async fn begin_platform_leaf_issuer_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    ca_keys: &PkiCaKeyConfig,
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_offline_authority_mutation_in_tx(
+        tx,
+        ca_keys,
+        AuthorityKind::PlatformLeafIssuer,
+        None,
+    )
+    .await
 }
 
 pub async fn begin_platform_intermediate_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
 ) -> Result<AuthorityRecord, AppError> {
-    begin_offline_authority_in_tx(tx, ca_keys, AuthorityKind::PlatformIntermediate, None).await
+    Ok(
+        begin_platform_intermediate_mutation_in_tx(tx, ca_keys)
+            .await?
+            .value,
+    )
 }
 
-async fn begin_offline_authority_in_tx(
+pub async fn begin_platform_intermediate_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    ca_keys: &PkiCaKeyConfig,
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_offline_authority_mutation_in_tx(
+        tx,
+        ca_keys,
+        AuthorityKind::PlatformIntermediate,
+        None,
+    )
+    .await
+}
+
+async fn begin_offline_authority_mutation_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
     kind: AuthorityKind,
     tenant_id: Option<Uuid>,
-) -> Result<AuthorityRecord, AppError> {
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
     repo::lock_provisioning(tx).await?;
     if let Some(tenant_id) = tenant_id {
         repo::lock_active_tenant(tx, tenant_id).await?;
     }
     if let Some(existing) = repo::pending_authority_for_scope(tx, kind, tenant_id).await? {
         if existing.provisioning_mode == "offline" {
-            return Ok(existing);
+            return Ok(AuthorityMutationOutcome {
+                value: existing,
+                changed: false,
+            });
         }
         return Err(AppError::conflict(
             "authority provisioning already exists for this scope",
@@ -179,7 +249,12 @@ async fn begin_offline_authority_in_tx(
 
     let parent = repo::active_root(tx).await?;
     ensure_parent_available(&parent)?;
-    create_pending_authority(tx, ca_keys, kind, tenant_id, &parent, "offline").await
+    let authority =
+        create_pending_authority(tx, ca_keys, kind, tenant_id, &parent, "offline").await?;
+    Ok(AuthorityMutationOutcome {
+        value: authority,
+        changed: true,
+    })
 }
 
 pub async fn provision_tenant_automatically_in_tx(
@@ -187,6 +262,18 @@ pub async fn provision_tenant_automatically_in_tx(
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
 ) -> Result<AuthorityImportOutcome, AppError> {
+    Ok(
+        provision_tenant_automatically_mutation_in_tx(tx, ca_keys, tenant_id)
+            .await?
+            .value,
+    )
+}
+
+pub async fn provision_tenant_automatically_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    ca_keys: &PkiCaKeyConfig,
+    tenant_id: Uuid,
+) -> Result<AuthorityMutationOutcome<AuthorityImportOutcome>, AppError> {
     repo::lock_provisioning(tx).await?;
     repo::lock_active_tenant(tx, tenant_id).await?;
 
@@ -194,10 +281,13 @@ pub async fn provision_tenant_automatically_in_tx(
         repo::active_authority_for_scope(tx, AuthorityKind::TenantIntermediate, Some(tenant_id))
             .await?
     {
-        return Ok(AuthorityImportOutcome {
-            authority: active,
-            validation_error: None,
-            replaced_authorities: Vec::new(),
+        return Ok(AuthorityMutationOutcome {
+            value: AuthorityImportOutcome {
+                authority: active,
+                validation_error: None,
+                replaced_authorities: Vec::new(),
+            },
+            changed: false,
         });
     }
     if let Some(existing) =
@@ -222,7 +312,11 @@ pub async fn provision_tenant_automatically_in_tx(
     )
     .await?;
     let certificate_pem = sign_pending_authority(ca_keys, &pending, &parent)?;
-    import_signed_authority_locked(tx, ca_keys, pending, &certificate_pem).await
+    let outcome = import_signed_authority_locked(tx, ca_keys, pending, &certificate_pem).await?;
+    Ok(AuthorityMutationOutcome {
+        value: outcome,
+        changed: true,
+    })
 }
 
 pub async fn import_signed_authority_in_tx(
@@ -231,9 +325,27 @@ pub async fn import_signed_authority_in_tx(
     authority_id: Uuid,
     certificate_pem: &str,
 ) -> Result<AuthorityImportOutcome, AppError> {
+    Ok(
+        import_signed_authority_mutation_in_tx(tx, ca_keys, authority_id, certificate_pem)
+            .await?
+            .value,
+    )
+}
+
+pub async fn import_signed_authority_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    ca_keys: &PkiCaKeyConfig,
+    authority_id: Uuid,
+    certificate_pem: &str,
+) -> Result<AuthorityMutationOutcome<AuthorityImportOutcome>, AppError> {
     repo::lock_provisioning(tx).await?;
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
-    import_signed_authority_locked(tx, ca_keys, authority, certificate_pem).await
+    let was_active = authority.status == AuthorityStatus::Active;
+    let outcome = import_signed_authority_locked(tx, ca_keys, authority, certificate_pem).await?;
+    Ok(AuthorityMutationOutcome {
+        value: outcome,
+        changed: !was_active,
+    })
 }
 
 async fn import_signed_authority_locked(
@@ -342,6 +454,18 @@ pub async fn begin_retirement_in_tx(
     ca_keys: &PkiCaKeyConfig,
     authority_id: Uuid,
 ) -> Result<AuthorityRecord, AppError> {
+    Ok(
+        begin_retirement_mutation_in_tx(tx, ca_keys, authority_id)
+            .await?
+            .value,
+    )
+}
+
+pub async fn begin_retirement_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    ca_keys: &PkiCaKeyConfig,
+    authority_id: Uuid,
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
     repo::lock_provisioning(tx).await?;
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
     if authority.kind == AuthorityKind::Root {
@@ -350,7 +474,10 @@ pub async fn begin_retirement_in_tx(
         ));
     }
     if authority.status == AuthorityStatus::Retiring {
-        return Ok(authority);
+        return Ok(AuthorityMutationOutcome {
+            value: authority,
+            changed: false,
+        });
     }
     if authority.status != AuthorityStatus::Active {
         return Err(AppError::conflict("only an active authority can retire"));
@@ -363,31 +490,51 @@ pub async fn begin_retirement_in_tx(
             .retire(authority_key_context(&authority), &key)
             .map_err(key_provider_error)?;
     }
-    repo::transition_authority(
+    let authority = repo::transition_authority(
         tx,
         authority_id,
         AuthorityStatus::Active,
         AuthorityStatus::Retiring,
     )
-    .await
+    .await?;
+    Ok(AuthorityMutationOutcome {
+        value: authority,
+        changed: true,
+    })
 }
 
 pub async fn complete_retirement_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     authority_id: Uuid,
 ) -> Result<AuthorityRecord, AppError> {
+    Ok(complete_retirement_mutation_in_tx(tx, authority_id)
+        .await?
+        .value)
+}
+
+pub async fn complete_retirement_mutation_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    authority_id: Uuid,
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
     repo::lock_provisioning(tx).await?;
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
     if authority.status == AuthorityStatus::Retired {
-        return Ok(authority);
+        return Ok(AuthorityMutationOutcome {
+            value: authority,
+            changed: false,
+        });
     }
-    repo::transition_authority(
+    let authority = repo::transition_authority(
         tx,
         authority_id,
         AuthorityStatus::Retiring,
         AuthorityStatus::Retired,
     )
-    .await
+    .await?;
+    Ok(AuthorityMutationOutcome {
+        value: authority,
+        changed: true,
+    })
 }
 
 pub async fn trust_bundle(pool: &PgPool) -> Result<TrustBundle, AppError> {
@@ -645,6 +792,15 @@ fn validate_ca_shape(
         {
             Err(AppError::bad_request(
                 "platform intermediate must permit one subordinate CA level",
+            ))
+        }
+        AuthorityKind::Root
+            if certificate
+                .path_len_constraint
+                .is_some_and(|path_len| path_len < 2) =>
+        {
+            Err(AppError::bad_request(
+                "root authority must permit the platform and tenant intermediate levels",
             ))
         }
         AuthorityKind::Root
@@ -932,6 +1088,19 @@ mod tests {
         let error =
             validate_ca_shape(AuthorityKind::PlatformLeafIssuer, &parsed).expect_err("path length");
         assert!(error.to_string().contains("pathLenConstraint=0"));
+    }
+
+    #[test]
+    fn root_requires_the_full_configured_ca_depth() {
+        let key = KeyPair::generate().expect("key");
+        let certificate = test_ca_params("Shallow Root", 1)
+            .self_signed(&key)
+            .expect("certificate");
+        let parsed = parse_authority_certificate(&certificate.pem()).expect("parse");
+        let error = validate_root_certificate(&parsed).expect_err("insufficient path length");
+        assert!(error
+            .to_string()
+            .contains("platform and tenant intermediate levels"));
     }
 
     #[test]

--- a/tests/m30_pki_ca_provisioning.rs
+++ b/tests/m30_pki_ca_provisioning.rs
@@ -90,6 +90,91 @@ async fn graphql_provisioning_writes_redacted_audit_and_outbox_events() {
     assert_eq!(outbox_payload["target_kind"], "pki_authority");
     assert_eq!(outbox_payload["tenant_id"], tenant_id.to_string());
     assert_eq!(outbox_payload["details"]["status"], "pending_signature");
+
+    let replay = schema
+        .execute(
+            GraphqlRequest::new(format!(
+                r#"
+                mutation {{
+                  beginTenantAuthorityProvisioning(tenantId: "{tenant_id}") {{
+                    id
+                    status
+                  }}
+                }}
+                "#
+            ))
+            .data(AuthContext {
+                entity_id: common::admin_id(),
+                tenant_id: None,
+                session_id: None,
+                ..Default::default()
+            }),
+        )
+        .await;
+    assert!(replay.errors.is_empty(), "{:?}", replay.errors);
+    assert_eq!(
+        replay.data.into_json().expect("replay JSON")
+            ["beginTenantAuthorityProvisioning"]["id"],
+        authority_id.to_string()
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM event_outbox WHERE event = 'pki.authority.provisioning_started' AND (payload->>'target_id')::uuid = $1",
+        )
+        .bind(authority_id)
+        .fetch_one(&pool)
+        .await
+        .expect("one transition event"),
+        1,
+        "an idempotent replay must not publish another lifecycle transition"
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM audit_logs WHERE event = 'pki.authority.provisioning_replayed' AND target_id = $1",
+        )
+        .bind(authority_id)
+        .fetch_one(&pool)
+        .await
+        .expect("replay audit"),
+        1
+    );
+
+    let invalid_root = schema
+        .execute(
+            GraphqlRequest::new(
+                r#"
+                mutation {
+                  importRootAuthority(certificatePem: "not a certificate") {
+                    id
+                  }
+                }
+                "#,
+            )
+            .data(AuthContext {
+                entity_id: common::admin_id(),
+                tenant_id: None,
+                session_id: None,
+                ..Default::default()
+            }),
+        )
+        .await;
+    assert!(!invalid_root.errors.is_empty());
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT count(*)
+            FROM event_outbox
+            WHERE event = 'pki.authority.root_imported'
+              AND payload->'details'->>'transport' = 'graphql'
+              AND payload->>'outcome' = 'error'
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("failure observation"),
+        1,
+        "failed authority mutations must publish one error observation"
+    );
 }
 
 #[tokio::test]

--- a/tests/m30_pki_ca_provisioning.rs
+++ b/tests/m30_pki_ca_provisioning.rs
@@ -113,8 +113,7 @@ async fn graphql_provisioning_writes_redacted_audit_and_outbox_events() {
         .await;
     assert!(replay.errors.is_empty(), "{:?}", replay.errors);
     assert_eq!(
-        replay.data.into_json().expect("replay JSON")
-            ["beginTenantAuthorityProvisioning"]["id"],
+        replay.data.into_json().expect("replay JSON")["beginTenantAuthorityProvisioning"]["id"],
         authority_id.to_string()
     );
     assert_eq!(


### PR DESCRIPTION
## Objective

Close the three post-merge review findings on PR-003 without changing its public hierarchy-selection contract.

## Changes

- Observe every failed or denied authority mutation through the standard structured failure path and outbox event.
- Distinguish lifecycle transitions from idempotent replays. Replays commit no state transition, publish no duplicate lifecycle event, and write a replay-specific audit record.
- Reject a constrained root with `pathLenConstraint < 2`, because it cannot support the configured root → platform intermediate → tenant intermediate hierarchy.
- Preserve the existing provisioning APIs for internal/test callers while exposing mutation outcomes to the GraphQL transport.

## Review findings addressed

- absmach/atom#48: observe errors from authority mutations.
- absmach/atom#48: suppress lifecycle events for idempotent no-ops.
- absmach/atom#48: reject roots that cannot support the configured CA depth.

## Validation

Added focused coverage for:

- one and only one lifecycle outbox event across an idempotent provisioning replay;
- replay-specific audit evidence;
- failure observation for an invalid root import;
- rejection of a root constrained below the required CA depth.

`git diff --check` passes locally. Rust formatting, locked Clippy, compilation, and the full fresh-PostgreSQL suite are delegated to the repository's hosted workflows because Rust tooling is not installed in this runtime.

## Scope

This PR targets `certificates` and contains PR-003 corrective work only.