### PR TITLE
[PKI PR-004 follow-up] Enforce profile and chain constraints

### DIFF
--- a/migrations/015_pki_profile_usage_invariants.sql
+++ b/migrations/015_pki_profile_usage_invariants.sql
@@ -1,0 +1,10 @@
+-- An empty KeyUsage or ExtendedKeyUsage extension is not a restriction. When
+-- rcgen receives an empty list it omits the extension, and relying parties can
+-- interpret the certificate as valid for unrestricted purposes. Every stored
+-- leaf profile must therefore name at least one usage in both categories.
+
+ALTER TABLE certificate_profiles
+    ADD CONSTRAINT chk_certificate_profiles_nonempty_key_usages
+        CHECK (cardinality(key_usages) > 0),
+    ADD CONSTRAINT chk_certificate_profiles_nonempty_extended_key_usages
+        CHECK (cardinality(extended_key_usages) > 0);

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -1033,13 +1033,40 @@ fn validate_chain(issuer_der: &[u8], chain_pem: &str) -> Result<(), AppError> {
             "issuer chain must begin with the issuing certificate",
         ));
     }
-    for pair in chain.windows(2) {
-        let (_, child) = x509_parser::parse_x509_certificate(&pair[0])
-            .map_err(|_| AppError::bad_request("invalid issuer chain certificate"))?;
-        let (_, parent) = x509_parser::parse_x509_certificate(&pair[1])
-            .map_err(|_| AppError::bad_request("invalid issuer chain certificate"))?;
-        validate_issuer_certificate(&child)?;
-        validate_issuer_certificate(&parent)?;
+    let parsed_chain = chain
+        .iter()
+        .map(|certificate| {
+            x509_parser::parse_x509_certificate(certificate)
+                .map(|(_, certificate)| certificate)
+                .map_err(|_| AppError::bad_request("invalid issuer chain certificate"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for (index, certificate) in parsed_chain.iter().enumerate() {
+        validate_issuer_certificate(certificate)?;
+        let constraints = certificate
+            .tbs_certificate
+            .basic_constraints()
+            .map_err(|_| AppError::bad_request("invalid issuer basic constraints"))?
+            .ok_or_else(|| AppError::bad_request("issuer is missing basic constraints"))?;
+        let subordinate_ca_count = parsed_chain[..index]
+            .iter()
+            .filter(|subordinate| subordinate.issuer() != subordinate.subject())
+            .count();
+        if constraints
+            .value
+            .path_len_constraint
+            .is_some_and(|limit| subordinate_ca_count > limit as usize)
+        {
+            return Err(AppError::bad_request(
+                "issuer chain exceeds a parent path-length constraint",
+            ));
+        }
+    }
+
+    for pair in parsed_chain.windows(2) {
+        let child = &pair[0];
+        let parent = &pair[1];
         if child.issuer() != parent.subject() {
             return Err(AppError::bad_request("issuer chain names do not link"));
         }
@@ -1054,18 +1081,15 @@ fn validate_chain(issuer_der: &[u8], chain_pem: &str) -> Result<(), AppError> {
             ));
         }
     }
-    let (_, root) = x509_parser::parse_x509_certificate(
-        chain
-            .last()
-            .ok_or_else(|| AppError::bad_request("issuer chain is empty"))?,
-    )
-    .map_err(|_| AppError::bad_request("invalid issuer root certificate"))?;
+    let root = parsed_chain
+        .last()
+        .ok_or_else(|| AppError::bad_request("issuer chain is empty"))?;
     if root.issuer() != root.subject() {
         return Err(AppError::bad_request(
             "issuer chain is not anchored by a root",
         ));
     }
-    validate_issuer_certificate(&root)?;
+    validate_issuer_certificate(root)?;
     root.verify_signature(None)
         .map_err(|_| AppError::bad_request("issuer chain root is not self-signed"))?;
     Ok(())
@@ -1235,6 +1259,42 @@ mod tests {
         let mut requested = CertificateParams::default();
         requested.key_usages = vec![KeyUsagePurpose::KeyCertSign];
         assert!(validate_requested_extensions(&profile, &requested).is_err());
+    }
+
+    #[test]
+    fn issuer_chain_rejects_parent_path_len_violation() {
+        let root_key = KeyPair::generate().unwrap();
+        let mut root_params = CertificateParams::default();
+        root_params
+            .distinguished_name
+            .push(DnType::CommonName, "Constrained Test Root");
+        root_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Constrained(0));
+        root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        let root = root_params.self_signed(&root_key).unwrap();
+
+        let issuer_key = KeyPair::generate().unwrap();
+        let mut issuer_params = CertificateParams::default();
+        issuer_params
+            .distinguished_name
+            .push(DnType::CommonName, "Subordinate Test Issuer");
+        issuer_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Constrained(0));
+        issuer_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        let issuer = issuer_params
+            .signed_by(&issuer_key, &Issuer::from_params(&root_params, &root_key))
+            .unwrap();
+        let issuer_pem = issuer.pem();
+        let chain_pem = format!("{issuer_pem}{}", root.pem());
+
+        let error = PkiIssuer::from_pem(
+            &issuer_pem,
+            &issuer_key.serialize_pem(),
+            &chain_pem,
+            "https://pki.example.test/ocsp",
+            "https://pki.example.test/ca.der",
+            "https://pki.example.test/crl.der",
+        )
+        .expect_err("a pathLen=0 root cannot have a subordinate CA");
+        assert!(error.to_string().contains("path-length constraint"));
     }
 
     #[test]

--- a/src/certs/profile.rs
+++ b/src/certs/profile.rs
@@ -313,6 +313,9 @@ impl TryFrom<ProfileRow> for CertificateProfile {
             .iter()
             .map(|usage| KeyUsage::parse(usage))
             .collect::<Result<Vec<_>, _>>()?;
+        if key_usages.is_empty() {
+            return Err(invalid_profile("key usages cannot be empty"));
+        }
         require_unique(&key_usages, "duplicate key usage")?;
 
         let extended_key_usages = row
@@ -320,6 +323,9 @@ impl TryFrom<ProfileRow> for CertificateProfile {
             .iter()
             .map(|usage| ExtendedKeyUsage::parse(usage))
             .collect::<Result<Vec<_>, _>>()?;
+        if extended_key_usages.is_empty() {
+            return Err(invalid_profile("extended key usages cannot be empty"));
+        }
         require_unique(&extended_key_usages, "duplicate extended key usage")?;
 
         let san_policy: SanPolicy = serde_json::from_value(row.san_policy)
@@ -513,6 +519,31 @@ fn invalid_profile(message: impl Into<String>) -> AppError {
 mod tests {
     use super::*;
 
+    fn valid_profile_row() -> ProfileRow {
+        ProfileRow {
+            id: Uuid::new_v4(),
+            tenant_id: None,
+            base_profile_id: None,
+            name: "test".to_string(),
+            permitted_key_algorithms: serde_json::json!([
+                {"algorithm": "ecdsa", "sizes": [256]}
+            ]),
+            default_ttl_seconds: 3_600,
+            maximum_ttl_seconds: 7_200,
+            renewal_threshold_seconds: 600,
+            key_usages: vec!["digital_signature".to_string()],
+            extended_key_usages: vec!["client_auth".to_string()],
+            san_policy: serde_json::json!({
+                "dns": {"mode": "deny", "values": []},
+                "ip": {"mode": "deny", "values": []},
+                "email": {"mode": "deny", "values": []},
+                "uri": {"mode": "identity", "values": []}
+            }),
+            identity_uri_template: "urn:atom:{scope}entity:{entity_id}".to_string(),
+            basic_constraints: serde_json::json!({"ca": false, "path_len": null}),
+        }
+    }
+
     fn rule(mode: SanRuleMode, values: &[&str]) -> SanRule {
         SanRule {
             mode,
@@ -550,5 +581,28 @@ mod tests {
             &[SanRuleMode::EntityTemplate]
         )
         .is_err());
+    }
+
+    #[test]
+    fn empty_usage_sets_fail_closed_in_typed_profile_loading() {
+        let mut row = valid_profile_row();
+        row.key_usages.clear();
+        let AppError::Internal(error) =
+            CertificateProfile::try_from(row).expect_err("empty key usages")
+        else {
+            panic!("empty stored key usages must be an internal integrity error");
+        };
+        assert!(error.to_string().contains("key usages cannot be empty"));
+
+        let mut row = valid_profile_row();
+        row.extended_key_usages.clear();
+        let AppError::Internal(error) =
+            CertificateProfile::try_from(row).expect_err("empty extended key usages")
+        else {
+            panic!("empty stored extended key usages must be an internal integrity error");
+        };
+        assert!(error
+            .to_string()
+            .contains("extended key usages cannot be empty"));
     }
 }

--- a/tests/m31_pki_certificate_profiles.rs
+++ b/tests/m31_pki_certificate_profiles.rs
@@ -53,6 +53,22 @@ async fn stored_profiles_and_pki_core_enforce_the_pr004_contract() {
     assert_eq!(client.extended_key_usages().len(), 1);
     assert_eq!(server.extended_key_usages().len(), 1);
 
+    let empty_key_usages =
+        sqlx::query("UPDATE certificate_profiles SET key_usages = '{}'::text[] WHERE id = $1")
+            .bind(client.id())
+            .execute(&pool)
+            .await
+            .map(|_| ());
+    assert_check_violation(empty_key_usages);
+    let empty_extended_key_usages = sqlx::query(
+        "UPDATE certificate_profiles SET extended_key_usages = '{}'::text[] WHERE id = $1",
+    )
+    .bind(client.id())
+    .execute(&pool)
+    .await
+    .map(|_| ());
+    assert_check_violation(empty_extended_key_usages);
+
     let combined_id = insert_platform_profile(
         &pool,
         "combined",


### PR DESCRIPTION
## Objective

Close the two post-merge review findings on PR-004.

## Changes

- Reject empty KeyUsage and ExtendedKeyUsage sets both at the PostgreSQL boundary and when loading a typed certificate profile.
- Enforce every CA certificate's BasicConstraints `pathLenConstraint` while validating an issuer chain, counting non-self-issued subordinate CAs per RFC 5280.
- Add focused unit and fresh-database coverage for both invariants.

## Review findings addressed

- absmach/atom#49: empty usage arrays can omit restricting extensions.
- absmach/atom#49: issuer chain validation did not enforce parent path-length constraints.

## Validation

`git diff --check` passes locally. Rust formatting, locked Clippy, compilation, and the full fresh-PostgreSQL suite run in the hosted workflows.

## Scope

This PR targets `certificates` and contains PR-004 corrective work only.