### PR TITLE
[PKI PR-005–007 follow-up] Observe issuance and renewal failures

### DIFF
--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -179,8 +179,35 @@ impl CertificateMutation {
         let state = ctx.data::<AppState>()?;
         let entity_id = parse_id(input.entity_id, "entityId")?;
         let tenant_id = require_credential_management(state, &auth, entity_id).await?;
-        let mut tx = state.pool.begin().await.map_err(|e| gql_error(db_err(e)))?;
-        let issued = service::issue_generated_certificate_v2_in_tx(
+        let error_meta = audit::AuditMeta {
+            actor_entity_id: Some(auth.entity_id),
+            tenant_id,
+            target_kind: "entity",
+            target_id: Some(entity_id),
+            event: "certificate.issue",
+        };
+        let error_details = serde_json::json!({
+            "csr": false,
+            "generated_key": true,
+            "managed": true,
+            "transport": "graphql",
+        });
+        let mut tx = match state.pool.begin().await {
+            Ok(tx) => tx,
+            Err(error) => {
+                let error = db_err(error);
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
+        let issued = match service::issue_generated_certificate_v2_in_tx(
             &mut tx,
             &state.config,
             tenant_id,
@@ -190,8 +217,24 @@ impl CertificateMutation {
             },
         )
         .await
-        .map_err(gql_error)?;
-        audit::commit_with_audit(
+        {
+            Ok(issued) => issued,
+            Err(error) => {
+                if let Err(rollback_error) = tx.rollback().await {
+                    tracing::warn!("failed to roll back generated certificate issuance: {rollback_error}");
+                }
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
+        if let Err(error) = audit::commit_with_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -214,7 +257,17 @@ impl CertificateMutation {
             },
         )
         .await
-        .map_err(gql_error)?;
+        {
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
         Ok(issued.into())
     }
 
@@ -274,12 +327,34 @@ impl CertificateMutation {
         let state = ctx.data::<AppState>()?;
         let entity_id = parse_id(input.entity_id, "entityId")?;
         let tenant_id = require_credential_management(state, &auth, entity_id).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let issued = service::issue_certificate_from_csr_v2_in_tx(
+        let error_meta = audit::AuditMeta {
+            actor_entity_id: Some(auth.entity_id),
+            tenant_id,
+            target_kind: "entity",
+            target_id: Some(entity_id),
+            event: "certificate.issue",
+        };
+        let error_details = serde_json::json!({
+            "csr": true,
+            "managed": true,
+            "transport": "graphql",
+        });
+        let mut tx = match state.pool.begin().await {
+            Ok(tx) => tx,
+            Err(error) => {
+                let error = db_err(error);
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
+        let issued = match service::issue_certificate_from_csr_v2_in_tx(
             &mut tx,
             &state.config,
             tenant_id,
@@ -291,7 +366,23 @@ impl CertificateMutation {
             },
         )
         .await
-        .map_err(gql_error)?;
+        {
+            Ok(issued) => issued,
+            Err(error) => {
+                if let Err(rollback_error) = tx.rollback().await {
+                    tracing::warn!("failed to roll back CSR certificate issuance: {rollback_error}");
+                }
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
         let details = serde_json::json!({
             "credential_id": issued.certificate.credential_id,
             "serial_number": issued.certificate.serial_number,
@@ -302,9 +393,18 @@ impl CertificateMutation {
             "replay": issued.idempotent_replay,
         });
         if issued.idempotent_replay {
-            tx.commit()
-                .await
-                .map_err(|error| gql_error(db_err(error)))?;
+            if let Err(error) = tx.commit().await {
+                let error = db_err(error);
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
             audit::write(
                 &state.pool,
                 false,
@@ -320,7 +420,7 @@ impl CertificateMutation {
             )
             .await;
         } else {
-            audit::commit_with_audit(
+            if let Err(error) = audit::commit_with_audit(
                 &state.pool,
                 tx,
                 state.config.events.enabled(),
@@ -335,7 +435,17 @@ impl CertificateMutation {
                 },
             )
             .await
-            .map_err(gql_error)?;
+            {
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
         }
         Ok(issued.into())
     }
@@ -662,12 +772,35 @@ async fn renew_certificate_v2(
         .map_err(gql_error)?;
     require_certificate_rotate(state, &auth, &old).await?;
     let key_mode = key_source.mode();
-    let mut tx = state
-        .pool
-        .begin()
-        .await
-        .map_err(|error| gql_error(db_err(error)))?;
-    let issued = service::renew_certificate_v2_in_tx(
+    let error_meta = audit::AuditMeta {
+        actor_entity_id: Some(auth.entity_id),
+        tenant_id: old.tenant_id,
+        target_kind: "credential",
+        target_id: Some(old.credential_id),
+        event: "certificate.renew",
+    };
+    let error_details = serde_json::json!({
+        "key_mode": key_mode,
+        "revoke_old": revoke_old,
+        "managed": true,
+        "transport": "graphql",
+    });
+    let mut tx = match state.pool.begin().await {
+        Ok(tx) => tx,
+        Err(error) => {
+            let error = db_err(error);
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
+    };
+    let issued = match service::renew_certificate_v2_in_tx(
         &mut tx,
         &state.config,
         service::CertificateRenewalAuthorization::Operator {
@@ -684,7 +817,23 @@ async fn renew_certificate_v2(
         },
     )
     .await
-    .map_err(gql_error)?;
+    {
+        Ok(issued) => issued,
+        Err(error) => {
+            if let Err(rollback_error) = tx.rollback().await {
+                tracing::warn!("failed to roll back certificate renewal: {rollback_error}");
+            }
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
+    };
     let details = serde_json::json!({
         "old_credential_id": old.credential_id,
         "new_credential_id": issued.certificate.credential_id,
@@ -699,9 +848,18 @@ async fn renew_certificate_v2(
         "managed": true,
     });
     if issued.idempotent_replay {
-        tx.commit()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
+        if let Err(error) = tx.commit().await {
+            let error = db_err(error);
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
         audit::write(
             &state.pool,
             false,
@@ -717,7 +875,7 @@ async fn renew_certificate_v2(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        if let Err(error) = audit::commit_with_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -732,7 +890,17 @@ async fn renew_certificate_v2(
             },
         )
         .await
-        .map_err(gql_error)?;
+        {
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
     }
     Ok(issued.into())
 }

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -221,7 +221,9 @@ impl CertificateMutation {
             Ok(issued) => issued,
             Err(error) => {
                 if let Err(rollback_error) = tx.rollback().await {
-                    tracing::warn!("failed to roll back generated certificate issuance: {rollback_error}");
+                    tracing::warn!(
+                        "failed to roll back generated certificate issuance: {rollback_error}"
+                    );
                 }
                 audit::observe_error(
                     &state.pool,
@@ -370,7 +372,9 @@ impl CertificateMutation {
             Ok(issued) => issued,
             Err(error) => {
                 if let Err(rollback_error) = tx.rollback().await {
-                    tracing::warn!("failed to roll back CSR certificate issuance: {rollback_error}");
+                    tracing::warn!(
+                        "failed to roll back CSR certificate issuance: {rollback_error}"
+                    );
                 }
                 audit::observe_error(
                     &state.pool,

--- a/tests/m32_pki_csr_issuance.rs
+++ b/tests/m32_pki_csr_issuance.rs
@@ -180,6 +180,11 @@ async fn managed_csr_issuance_enforces_the_pr005_contract() {
         .await;
     assert!(errors_contain(&mismatched_retry.errors, "idempotency key"));
     assert_eq!(certificate_count(&pool, entity_a).await, 1);
+    assert_eq!(
+        error_event_count(&pool, "certificate.issue", entity_a).await,
+        1,
+        "failed managed CSR issuance must publish one error observation"
+    );
 
     let ledger: (String, String, Option<Uuid>) = sqlx::query_as(
         r#"SELECT request_key_hash, request_fingerprint_sha256, credential_id
@@ -640,7 +645,7 @@ async fn event_count(pool: &PgPool, table: &str, event: &str, target_id: Uuid) -
     let query = match table {
         "audit_logs" => "SELECT COUNT(*) FROM audit_logs WHERE event = $1 AND target_id = $2",
         "event_outbox" => {
-            "SELECT COUNT(*) FROM event_outbox WHERE event = $1 AND (payload->>'target_id')::uuid = $2"
+            "SELECT COUNT(*) FROM event_outbox WHERE event = $1 AND (payload->>'target_id')::uuid = $2 AND payload->>'outcome' = 'allow'"
         }
         _ => panic!("unsupported event table"),
     };
@@ -650,6 +655,21 @@ async fn event_count(pool: &PgPool, table: &str, event: &str, target_id: Uuid) -
         .fetch_one(pool)
         .await
         .unwrap()
+}
+
+async fn error_event_count(pool: &PgPool, event: &str, target_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM event_outbox
+           WHERE event = $1
+             AND (payload->>'target_id')::uuid = $2
+             AND payload->>'outcome' = 'error'
+             AND payload->'details'->>'transport' = 'graphql'"#,
+    )
+    .bind(event)
+    .bind(target_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }
 
 async fn install_serial_collision_trigger(pool: &PgPool, entity_id: Uuid) {

--- a/tests/m33_pki_generated_issuance.rs
+++ b/tests/m33_pki_generated_issuance.rs
@@ -132,6 +132,11 @@ async fn managed_generated_key_issuance_enforces_the_pr006_contract() {
         "no active issuing authority"
     ));
     assert_eq!(certificate_count(&pool, entity_without_issuer).await, 0);
+    assert_eq!(
+        error_event_count(&pool, "certificate.issue", entity_without_issuer).await,
+        1,
+        "failed generated issuance must publish one error observation"
+    );
 
     let issued = schema
         .execute(issue_request(
@@ -342,6 +347,21 @@ async fn certificate_count(pool: &PgPool, entity_id: Uuid) -> i64 {
         "SELECT COUNT(*) FROM credentials WHERE entity_id = $1 AND kind = 'certificate'",
     )
     .bind(entity_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn error_event_count(pool: &PgPool, event: &str, target_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM event_outbox
+           WHERE event = $1
+             AND (payload->>'target_id')::uuid = $2
+             AND payload->>'outcome' = 'error'
+             AND payload->'details'->>'transport' = 'graphql'"#,
+    )
+    .bind(event)
+    .bind(target_id)
     .fetch_one(pool)
     .await
     .unwrap()

--- a/tests/m33_pki_generated_issuance.rs
+++ b/tests/m33_pki_generated_issuance.rs
@@ -242,9 +242,9 @@ async fn managed_generated_key_issuance_enforces_the_pr006_contract() {
         credential_id.to_string()
     );
 
-    // A failure after signing but before persistence commits nothing and emits
-    // no operational record. The generated secret is dropped/zeroized by the
-    // service response wrapper and never appears in the returned error/logs.
+    // A failure after signing but before persistence commits no credential or
+    // success audit, but it does emit one error observation. The generated
+    // secret is dropped/zeroized and never appears in the returned error/logs.
     install_persistence_failure_trigger(&pool, entity_a).await;
     let before_credentials = certificate_count(&pool, entity_a).await;
     let before_audits = event_count(&pool, "audit_logs", entity_a).await;
@@ -267,8 +267,22 @@ async fn managed_generated_key_issuance_enforces_the_pr006_contract() {
     );
     assert_eq!(
         event_count(&pool, "event_outbox", entity_a).await,
-        before_events
+        before_events + 1
     );
+    let failure: (String, String) = sqlx::query_as(
+        r#"SELECT payload->>'outcome', payload->'details'->>'transport'
+           FROM event_outbox
+           WHERE event = 'certificate.issue'
+             AND actor_entity_id = $1
+             AND payload->>'outcome' = 'error'
+           ORDER BY created_at DESC
+           LIMIT 1"#,
+    )
+    .bind(entity_a)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(failure, ("error".into(), "graphql".into()));
 
     private_key_pem.zeroize();
 }

--- a/tests/m34_pki_renewal.rs
+++ b/tests/m34_pki_renewal.rs
@@ -602,7 +602,9 @@ async fn assert_audit_and_outbox_linkage(pool: &PgPool, old_id: Uuid, new_id: Uu
     assert_eq!(details["revoke_old"], false);
     let payload: Value = sqlx::query_scalar(
         r#"SELECT payload FROM event_outbox
-           WHERE event = 'certificate.renew' AND (payload->>'target_id')::uuid = $1"#,
+           WHERE event = 'certificate.renew'
+             AND payload->>'outcome' = 'allow'
+             AND (payload->>'target_id')::uuid = $1"#,
     )
     .bind(old_id)
     .fetch_one(pool)
@@ -610,7 +612,10 @@ async fn assert_audit_and_outbox_linkage(pool: &PgPool, old_id: Uuid, new_id: Uu
     .unwrap();
     assert_eq!(payload["details"]["new_credential_id"], new_id.to_string());
     let event_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM event_outbox WHERE event = 'certificate.renew' AND (payload->>'target_id')::uuid = $1",
+        "SELECT COUNT(*) FROM event_outbox
+         WHERE event = 'certificate.renew'
+           AND payload->>'outcome' = 'allow'
+           AND (payload->>'target_id')::uuid = $1",
     )
     .bind(old_id)
     .fetch_one(pool)

--- a/tests/m34_pki_renewal.rs
+++ b/tests/m34_pki_renewal.rs
@@ -257,6 +257,11 @@ async fn issuer_aware_renewal_enforces_the_pr007_contract() {
         ))
         .await;
     assert!(errors_contain(&revoked_operator.errors, "revoked"));
+    assert_eq!(
+        error_event_count(&pool, "certificate.renew", old_revoked.credential_id).await,
+        1,
+        "failed renewal must publish one error observation"
+    );
 
     // The certificate-authenticated service seam accepts an exact, valid
     // certificate in its profile window and rejects credential substitution.
@@ -628,6 +633,21 @@ async fn audit_details(pool: &PgPool, event: &str, old_id: Uuid) -> Value {
     )
     .bind(event)
     .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn error_event_count(pool: &PgPool, event: &str, target_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM event_outbox
+           WHERE event = $1
+             AND (payload->>'target_id')::uuid = $2
+             AND payload->>'outcome' = 'error'
+             AND payload->'details'->>'transport' = 'graphql'"#,
+    )
+    .bind(event)
+    .bind(target_id)
     .fetch_one(pool)
     .await
     .unwrap()


### PR DESCRIPTION
## Objective

Close the remaining post-merge review findings on PR-005, PR-006, and PR-007.

## Changes

- Roll back failed managed CSR issuance, generated-key issuance, and renewal transactions before external observation.
- Route service, transaction-start, and commit failures through `audit::observe_error` with non-secret GraphQL operation metadata.
- Preserve the existing success and idempotent-replay audit behavior.
- Add focused fresh-database assertions for error outbox events on all three managed paths.

## Review findings addressed

- absmach/atom#50: failed managed CSR issuance was not observed.
- absmach/atom#51: failed generated issuance was not observed. (The separate `issued_from_csr=false` metadata finding is already fixed on `certificates`.)
- absmach/atom#52: failed renewal was not observed.

## Validation

`git diff --check` passes locally. Rust formatting, locked Clippy, compilation, and the full fresh-PostgreSQL suite run in the hosted workflows.

## Scope

This PR targets `certificates` and contains only PR-005–007 corrective observation work.