### PR TITLE
[PKI PR-009/010 follow-up] Preserve revocation status and authorize OCSP

### DIFF
--- a/migrations/016_pki_durable_revocation_evidence.sql
+++ b/migrations/016_pki_durable_revocation_evidence.sql
@@ -1,0 +1,133 @@
+-- Revocation publication evidence must outlive the credential and identity
+-- rows that produced it. A still-valid revoked certificate remains revoked
+-- after an explicit entity/tenant purge, and its issuer keeps publishing that
+-- state until the certificate expires.
+
+DROP TRIGGER trg_certificate_revocations_immutable ON certificate_revocations;
+
+ALTER TABLE certificate_revocations
+    ADD COLUMN expires_at TIMESTAMPTZ;
+
+UPDATE certificate_revocations r
+   SET expires_at = COALESCE(c.expires_at, 'infinity'::timestamptz)
+  FROM credentials c
+ WHERE c.id = r.credential_id;
+
+UPDATE certificate_revocations
+   SET expires_at = 'infinity'::timestamptz
+ WHERE expires_at IS NULL;
+
+ALTER TABLE certificate_revocations
+    ALTER COLUMN expires_at SET NOT NULL,
+    DROP CONSTRAINT certificate_revocations_credential_id_fkey;
+
+CREATE UNIQUE INDEX idx_certificate_revocations_issuer_serial
+    ON certificate_revocations(issuer_id, serial_number)
+    WHERE issuer_id IS NOT NULL;
+
+CREATE INDEX idx_certificate_revocations_fingerprint_serial
+    ON certificate_revocations(issuer_fingerprint_sha256, serial_number)
+    WHERE issuer_fingerprint_sha256 IS NOT NULL;
+
+-- PR-009's issuer-keyed state function is retained here with one additional
+-- immutable value: the credential expiry copied at the revocation boundary.
+CREATE OR REPLACE FUNCTION record_certificate_revocation()
+RETURNS trigger AS $$
+DECLARE
+    event_time             TIMESTAMPTZ;
+    event_reason           TEXT;
+    event_actor            UUID;
+    issuer_fingerprint     TEXT;
+    existing_fingerprint   TEXT;
+    existing_issuer        UUID;
+BEGIN
+    IF NEW.kind <> 'certificate' OR NEW.status <> 'revoked' THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD.status = 'revoked' THEN
+        RETURN NEW;
+    END IF;
+
+    event_time := COALESCE((NEW.metadata->>'revoked_at')::timestamptz, now());
+    event_reason := left(
+        COALESCE(NULLIF(btrim(NEW.metadata->>'revocation_reason'), ''), 'unspecified'),
+        128
+    );
+    event_actor := NULLIF(NEW.metadata->>'revoked_by_entity_id', '')::uuid;
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT a.fingerprint_sha256
+          INTO issuer_fingerprint
+          FROM pki_authorities a
+         WHERE a.id = NEW.issuer_id;
+    END IF;
+    issuer_fingerprint := COALESCE(
+        issuer_fingerprint,
+        NULLIF(NEW.metadata->>'issuer_fingerprint_sha256', '')
+    );
+
+    INSERT INTO certificate_revocations (
+        credential_id, issuer_id, issuer_fingerprint_sha256, serial_number,
+        reason, actor_entity_id, revoked_at, expires_at
+    ) VALUES (
+        NEW.id, NEW.issuer_id, issuer_fingerprint, NEW.identifier,
+        event_reason, event_actor, event_time,
+        COALESCE(NEW.expires_at, 'infinity'::timestamptz)
+    )
+    ON CONFLICT (credential_id) DO NOTHING;
+
+    IF issuer_fingerprint IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT s.issuer_fingerprint_sha256
+          INTO existing_fingerprint
+          FROM certificate_crl_state s
+         WHERE s.issuer_id = NEW.issuer_id
+         FOR UPDATE;
+        IF FOUND THEN
+            IF existing_fingerprint <> issuer_fingerprint THEN
+                RAISE EXCEPTION 'certificate issuer artifact fingerprint mismatch'
+                    USING ERRCODE = '23514';
+            END IF;
+            UPDATE certificate_crl_state
+               SET dirty = TRUE, updated_at = now()
+             WHERE issuer_id = NEW.issuer_id;
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    SELECT s.issuer_id
+      INTO existing_issuer
+      FROM certificate_crl_state s
+     WHERE s.issuer_fingerprint_sha256 = issuer_fingerprint
+     FOR UPDATE;
+    IF FOUND
+       AND existing_issuer IS NOT NULL
+       AND existing_issuer IS DISTINCT FROM NEW.issuer_id THEN
+        RAISE EXCEPTION 'certificate artifact fingerprint belongs to another issuer'
+            USING ERRCODE = '23514';
+    END IF;
+
+    INSERT INTO certificate_crl_state (
+        issuer_fingerprint_sha256, issuer_id, crl_number, dirty
+    ) VALUES (
+        issuer_fingerprint, NEW.issuer_id, 0, TRUE
+    )
+    ON CONFLICT (issuer_fingerprint_sha256) DO UPDATE
+        SET dirty = TRUE,
+            issuer_id = COALESCE(
+                certificate_crl_state.issuer_id,
+                EXCLUDED.issuer_id
+            ),
+            updated_at = now();
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- The ledger no longer relies on a credential-delete cascade. Reject direct
+-- updates and deletes so revocation cannot disappear before expiry.
+CREATE TRIGGER trg_certificate_revocations_immutable
+    BEFORE UPDATE OR DELETE ON certificate_revocations
+    FOR EACH ROW EXECUTE FUNCTION prevent_certificate_revocation_mutation();

--- a/src/certs/authority/http.rs
+++ b/src/certs/authority/http.rs
@@ -42,7 +42,7 @@ pub async fn trust_bundle(
     Ok((StatusCode::OK, response_headers, bundle.pem).into_response())
 }
 
-fn etag_matches(if_none_match: &str, current: &str) -> bool {
+pub(crate) fn etag_matches(if_none_match: &str, current: &str) -> bool {
     if_none_match.split(',').any(|candidate| {
         let candidate = candidate.trim();
         candidate == "*" || candidate == current || candidate.strip_prefix("W/") == Some(current)

--- a/src/certs/authority/provisioning.rs
+++ b/src/certs/authority/provisioning.rs
@@ -66,6 +66,7 @@ struct ParsedAuthorityCertificate {
     not_before: DateTime<Utc>,
     not_after: DateTime<Utc>,
     path_len_constraint: Option<u32>,
+    digital_signature: bool,
 }
 
 struct ProviderSigningKey<'a> {
@@ -760,6 +761,11 @@ fn validate_ca_shape(
     if certificate.not_after <= now {
         return Err(AppError::bad_request("authority certificate is expired"));
     }
+    if kind.can_issue_leaf_credentials() && !certificate.digital_signature {
+        return Err(AppError::bad_request(
+            "leaf-issuing authority key usage must include digitalSignature",
+        ));
+    }
     match kind {
         AuthorityKind::TenantIntermediate | AuthorityKind::PlatformLeafIssuer
             if certificate.path_len_constraint != Some(0) =>
@@ -886,6 +892,7 @@ fn parse_authority_certificate(
         not_before,
         not_after,
         path_len_constraint: basic.value.path_len_constraint,
+        digital_signature: usage.value.digital_signature(),
     })
 }
 
@@ -924,6 +931,9 @@ fn ca_certificate_params(
     };
     params.is_ca = IsCa::Ca(BasicConstraints::Constrained(path_len));
     params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    if kind.can_issue_leaf_credentials() {
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    }
     params.key_identifier_method = KeyIdMethod::Sha256;
     Ok(params)
 }
@@ -1043,7 +1053,11 @@ mod tests {
             .distinguished_name
             .push(DnType::CommonName, common_name);
         params.is_ca = IsCa::Ca(BasicConstraints::Constrained(path_len));
-        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
         params.key_identifier_method = KeyIdMethod::Sha256;
         params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
         params.not_after = OffsetDateTime::now_utc() + Duration::days(30);

--- a/src/certs/http.rs
+++ b/src/certs/http.rs
@@ -9,6 +9,8 @@ use uuid::Uuid;
 
 use crate::{certs::service, error::AppError, state::AppState};
 
+use super::authority::http::etag_matches;
+
 pub async fn ca_chain(State(state): State<AppState>) -> Result<Response, AppError> {
     let pem = service::ca_chain(&state.config, state.certificate_issuer.as_deref())?;
     let mut headers = HeaderMap::new();
@@ -64,9 +66,7 @@ pub async fn issuer_crl(
     let not_modified = request_headers
         .get(header::IF_NONE_MATCH)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| {
-            value == "*" || value.split(',').any(|candidate| candidate.trim() == etag)
-        });
+        .is_some_and(|value| etag_matches(value, &etag));
     if not_modified {
         return Ok((StatusCode::NOT_MODIFIED, headers).into_response());
     }

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -302,9 +302,10 @@ impl PkiArtifactSigner {
     ) -> Result<PkiArtifactSignature, AppError> {
         let certificate_der =
             one_certificate_der(&self.certificate_pem, "OCSP signer certificate")?;
-        let (_, certificate) = x509_parser::parse_x509_certificate(&certificate_der).map_err(
-            |_| AppError::Internal(anyhow::anyhow!("stored invalid OCSP signer certificate")),
-        )?;
+        let (_, certificate) =
+            x509_parser::parse_x509_certificate(&certificate_der).map_err(|_| {
+                AppError::Internal(anyhow::anyhow!("stored invalid OCSP signer certificate"))
+            })?;
         let usage = certificate
             .tbs_certificate
             .key_usage()

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -300,6 +300,23 @@ impl PkiArtifactSigner {
         &self,
         response_data_der: &[u8],
     ) -> Result<PkiArtifactSignature, AppError> {
+        let certificate_der =
+            one_certificate_der(&self.certificate_pem, "OCSP signer certificate")?;
+        let (_, certificate) = x509_parser::parse_x509_certificate(&certificate_der).map_err(
+            |_| AppError::Internal(anyhow::anyhow!("stored invalid OCSP signer certificate")),
+        )?;
+        let usage = certificate
+            .tbs_certificate
+            .key_usage()
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid OCSP signer key usage")))?
+            .ok_or_else(|| {
+                AppError::Internal(anyhow::anyhow!("OCSP signer is missing key usage"))
+            })?;
+        if !usage.value.digital_signature() {
+            return Err(AppError::bad_request(
+                "authority certificate is not authorized for OCSP response signing",
+            ));
+        }
         let algorithm = pki_signature_algorithm(self.signing_key.algorithm())?;
         let bytes = self
             .signing_key

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -785,6 +785,29 @@ where
     .map_err(db_err)
 }
 
+pub async fn certificate_revocation_by_issuer_serial<'e, E>(
+    executor: E,
+    issuer_id: Uuid,
+    serial_number: &str,
+) -> Result<Option<CertificateRevocationRecord>, AppError>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, CertificateRevocationRecord>(
+        r#"
+        SELECT credential_id, issuer_id, issuer_fingerprint_sha256,
+               serial_number, reason, actor_entity_id, revoked_at
+        FROM certificate_revocations
+        WHERE issuer_id = $1 AND serial_number = $2
+        "#,
+    )
+    .bind(issuer_id)
+    .bind(serial_number)
+    .fetch_optional(executor)
+    .await
+    .map_err(AppError::Database)
+}
+
 pub async fn active_entity_certificates<'e, E>(
     executor: E,
     entity_id: Uuid,
@@ -808,28 +831,24 @@ where
     .map_err(AppError::Database)
 }
 
-/// Revoked certificates issued by one issuer, for that issuer's CRL. A CRL is
-/// signed by its issuer and covers only certificates the issuer signed, so the
-/// filter is a correctness requirement, not an optimisation — and it also keeps
-/// certificate rows created outside the issuance path (no full metadata, e.g.
-/// externally provisioned or test fixtures) from breaking CRL generation.
-pub async fn revoked_certificates(
-    pool: &PgPool,
+/// Unexpired durable revocations for a legacy file issuer. The caller's
+/// transaction already owns the legacy CRL state lock; querying through it
+/// avoids a nested pool acquire and keeps the published snapshot consistent.
+pub async fn revocations_by_fingerprint_tx(
+    tx: &mut Transaction<'_, Postgres>,
     issuer_fingerprint_sha256: &str,
-) -> Result<Vec<CertificateCredential>, AppError> {
-    sqlx::query_as::<_, CertificateCredential>(
+) -> Result<Vec<IssuerRevocationEntry>, AppError> {
+    sqlx::query_as::<_, IssuerRevocationEntry>(
         r#"
-        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
-               c.expires_at, c.created_at
-        FROM credentials c
-        JOIN entities e ON e.id = c.entity_id
-        WHERE c.kind = 'certificate' AND c.status = 'revoked'
-          AND c.metadata->>'issuer_fingerprint_sha256' = $1
-        ORDER BY c.created_at ASC
+        SELECT credential_id, serial_number, reason, revoked_at
+        FROM certificate_revocations
+        WHERE issuer_fingerprint_sha256 = $1
+          AND expires_at > now()
+        ORDER BY revoked_at, credential_id
         "#,
     )
     .bind(issuer_fingerprint_sha256)
-    .fetch_all(pool)
+    .fetch_all(&mut **tx)
     .await
     .map_err(AppError::Database)
 }
@@ -970,6 +989,7 @@ pub async fn issuer_revocations_tx(
         SELECT credential_id, serial_number, reason, revoked_at
         FROM certificate_revocations
         WHERE issuer_id = $1
+          AND expires_at > now()
         ORDER BY revoked_at, credential_id
         "#,
     )

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -1596,15 +1596,17 @@ pub async fn generate_crl(
     }
 
     let generation_started = Instant::now();
-    let revoked = repo::revoked_certificates(pool, &loaded.issuer_fingerprint_sha256).await?;
-    let revoked_certs = revoked
+    let revoked_certs = repo::revocations_by_fingerprint_tx(
+        &mut tx,
+        &loaded.issuer_fingerprint_sha256,
+    )
+    .await?
         .into_iter()
-        .map(|cert| {
-            let metadata = metadata_from_value(&cert.metadata)?;
+        .map(|entry| {
             Ok(RevokedCertParams {
-                serial_number: SerialNumber::from(serial_bytes(&cert.identifier)?),
-                revocation_time: to_offset(metadata.revoked_at.unwrap_or_else(Utc::now))?,
-                reason_code: Some(RevocationReason::Unspecified),
+                serial_number: SerialNumber::from(serial_bytes(&entry.serial_number)?),
+                revocation_time: to_offset(entry.revoked_at)?,
+                reason_code: Some(crl_revocation_reason(&entry.reason)),
                 invalidity_date: None,
             })
         })
@@ -2836,6 +2838,14 @@ async fn managed_ocsp_status(
     issuer_id: Uuid,
     serial_number: &str,
 ) -> Result<CertStatus, AppError> {
+    if let Some(revocation) =
+        repo::certificate_revocation_by_issuer_serial(pool, issuer_id, serial_number).await?
+    {
+        return Ok(CertStatus::revoked(RevokedInfo {
+            revocation_time: ocsp_time(revocation.revoked_at)?,
+            revocation_reason: Some(ocsp_revocation_reason(&revocation.reason)),
+        }));
+    }
     let certificate = match repo::certificate_by_issuer_serial(pool, issuer_id, serial_number).await
     {
         Ok(certificate) => certificate,
@@ -2844,25 +2854,9 @@ async fn managed_ocsp_status(
     };
     match certificate.status.as_str() {
         "active" => Ok(CertStatus::good()),
-        "revoked" => {
-            let revocation = repo::certificate_revocation_by_id(pool, certificate.id)
-                .await
-                .map_err(|error| {
-                    AppError::Internal(anyhow::anyhow!(
-                        "revoked certificate has no immutable revocation record: {error}"
-                    ))
-                })?;
-            if revocation.issuer_id != Some(issuer_id) || revocation.serial_number != serial_number
-            {
-                return Err(AppError::Internal(anyhow::anyhow!(
-                    "certificate revocation record does not match its issuer identity"
-                )));
-            }
-            Ok(CertStatus::revoked(RevokedInfo {
-                revocation_time: ocsp_time(revocation.revoked_at)?,
-                revocation_reason: Some(ocsp_revocation_reason(&revocation.reason)),
-            }))
-        }
+        "revoked" => Err(AppError::Internal(anyhow::anyhow!(
+            "revoked certificate has no immutable revocation record"
+        ))),
         _ => Ok(CertStatus::unknown()),
     }
 }

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -1596,21 +1596,19 @@ pub async fn generate_crl(
     }
 
     let generation_started = Instant::now();
-    let revoked_certs = repo::revocations_by_fingerprint_tx(
-        &mut tx,
-        &loaded.issuer_fingerprint_sha256,
-    )
-    .await?
-        .into_iter()
-        .map(|entry| {
-            Ok(RevokedCertParams {
-                serial_number: SerialNumber::from(serial_bytes(&entry.serial_number)?),
-                revocation_time: to_offset(entry.revoked_at)?,
-                reason_code: Some(crl_revocation_reason(&entry.reason)),
-                invalidity_date: None,
+    let revoked_certs =
+        repo::revocations_by_fingerprint_tx(&mut tx, &loaded.issuer_fingerprint_sha256)
+            .await?
+            .into_iter()
+            .map(|entry| {
+                Ok(RevokedCertParams {
+                    serial_number: SerialNumber::from(serial_bytes(&entry.serial_number)?),
+                    revocation_time: to_offset(entry.revoked_at)?,
+                    reason_code: Some(crl_revocation_reason(&entry.reason)),
+                    invalidity_date: None,
+                })
             })
-        })
-        .collect::<Result<Vec<_>, AppError>>()?;
+            .collect::<Result<Vec<_>, AppError>>()?;
     let now = OffsetDateTime::now_utc();
     let next_update = now + Duration::hours(CRL_TTL_HOURS);
     let crl_number = state.crl_number + 1;

--- a/tests/m17_certificates.rs
+++ b/tests/m17_certificates.rs
@@ -17,8 +17,8 @@ use der::{
 use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose};
 use ring::digest;
 use spki::AlgorithmIdentifierOwned;
-use sqlx::PgPool;
-use std::{fs, path::PathBuf};
+use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::{fs, path::PathBuf, time::Duration as StdDuration};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 use x509_ocsp::{CertId, OcspRequest, Request as OcspSingleRequest, TbsRequest};
@@ -260,9 +260,18 @@ async fn certificate_lifecycle_with_database() {
             .unwrap();
     assert!(revoked_count >= 2);
 
-    let crl = service::generate_crl(&pool, &cfg, Some(&issuer))
+    let single_connection_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&std::env::var("DATABASE_URL").unwrap())
         .await
         .unwrap();
+    let crl = tokio::time::timeout(
+        StdDuration::from_secs(5),
+        service::generate_crl(&single_connection_pool, &cfg, Some(&issuer)),
+    )
+    .await
+    .expect("legacy CRL generation must not perform a nested pool acquire")
+    .unwrap();
     let (_, parsed_crl) = x509_parser::parse_x509_crl(&crl).unwrap();
     let serial = hex::decode(&issued.certificate.serial_number).unwrap();
     assert!(parsed_crl

--- a/tests/m30_pki_ca_provisioning.rs
+++ b/tests/m30_pki_ca_provisioning.rs
@@ -447,6 +447,12 @@ fn assert_generated_ca_csr(authority: &AuthorityRecord, expected: BasicConstrain
         .key_usages
         .contains(&KeyUsagePurpose::KeyCertSign));
     assert!(parsed.params.key_usages.contains(&KeyUsagePurpose::CrlSign));
+    if expected == BasicConstraints::Constrained(0) {
+        assert!(parsed
+            .params
+            .key_usages
+            .contains(&KeyUsagePurpose::DigitalSignature));
+    }
 }
 
 fn assert_failed(outcome: provisioning::AuthorityImportOutcome) {

--- a/tests/m36_pki_issuer_crls.rs
+++ b/tests/m36_pki_issuer_crls.rs
@@ -148,6 +148,7 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         empty_a.der
     );
     let not_modified = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
@@ -162,6 +163,18 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         .await
         .unwrap()
         .is_empty());
+    let weak_not_modified = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
+                .header(header::IF_NONE_MATCH, format!("W/{etag}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(weak_not_modified.status(), StatusCode::NOT_MODIFIED);
 
     let key_compromise = issue_managed(&pool, &config, tenant_a, entity_a, "key-compromise").await;
     revoke(
@@ -270,6 +283,9 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         .unwrap();
     assert!(after_restart.cache_hit);
     assert_eq!(after_restart.der, repaired.der);
+
+    let purge_entity = common::pki::create_entity(&pool, tenant_a, "pki-crl-purge").await;
+    let purge_leaf = issue_managed(&pool, &config, tenant_a, purge_entity, "purge").await;
 
     // Rotation retains old-authority publication. One old leaf is revoked
     // while the issuer is retiring and another after it is retired; neither
@@ -415,6 +431,38 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
             .der,
         retired_crl.der
     );
+
+    // Revocation publication evidence is independent of credential/entity
+    // retention. Purging the owning entity before regeneration cannot remove
+    // a still-valid serial from the issuer's next CRL.
+    revoke(
+        &pool,
+        purge_leaf.credential_id,
+        purge_entity,
+        tenant_a,
+        "key_compromise",
+    )
+    .await;
+    sqlx::query("DELETE FROM entities WHERE id = $1")
+        .bind(purge_entity)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM certificate_revocations WHERE credential_id = $1",
+        )
+        .bind(purge_leaf.credential_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap(),
+        1
+    );
+    let after_purge = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(after_purge.crl_number, 8);
+    assert!(crl_contains(&after_purge.der, &purge_leaf.serial_number));
 }
 
 async fn issue_managed(

--- a/tests/m36_pki_issuer_crls.rs
+++ b/tests/m36_pki_issuer_crls.rs
@@ -152,7 +152,7 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         .oneshot(
             Request::builder()
                 .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
-                .header(header::IF_NONE_MATCH, etag)
+                .header(header::IF_NONE_MATCH, &etag)
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -74,6 +74,14 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
     let leaf_b = issue_managed(&pool, &config, tenant_b, entity_b, "leaf-b").await;
     let issuer_a_pem = issuer_a.certificate_pem.as_deref().unwrap();
     let issuer_b_pem = issuer_b.certificate_pem.as_deref().unwrap();
+    let issuer_a_der = parse_x509_pem(issuer_a_pem.as_bytes()).unwrap().1.contents;
+    let (_, parsed_issuer_a) = x509_parser::parse_x509_certificate(&issuer_a_der).unwrap();
+    assert!(parsed_issuer_a
+        .key_usage()
+        .unwrap()
+        .unwrap()
+        .value
+        .digital_signature());
 
     // Both RFC-required SHA-1 CertIDs and reviewed SHA-256 CertIDs resolve to
     // good. The managed issuer currently supports ECDSA P-256, and the
@@ -323,6 +331,19 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
             .await
             .unwrap();
     assert_status(&duplicate_b_after_revoke, CertStatus::good());
+
+    // A physical credential purge must not turn a revoked issuer/serial into
+    // unknown while the certificate is still valid.
+    sqlx::query("DELETE FROM credentials WHERE id = $1")
+        .bind(leaf_a.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let revoked_after_purge =
+        service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+            .await
+            .unwrap();
+    assert_status(&revoked_after_purge, CertStatus::revoked(revoked));
 
     // Rotation retains responder availability while the old authority is
     // retiring and after it is retired. No delegated responder is used: the


### PR DESCRIPTION
## Objective

Close the five remaining post-merge findings shared by PR-009 (CRL) and PR-010 (OCSP).

## Changes

- Decouple immutable revocation evidence from credential/entity lifetime and retain certificate expiry with each ledger row.
- Publish managed and legacy CRLs from the durable ledger, filtering only expired evidence and reusing the transaction that owns the CRL state lock.
- Resolve OCSP revocation by exact issuer+serial from the ledger before consulting live credentials, so purge cannot change `revoked` to `unknown`.
- Add `digitalSignature` KeyUsage to newly provisioned managed leaf issuers, require it at import, and fail closed before direct OCSP signing when absent.
- Reuse the trust-bundle weak/list/wildcard ETag matcher for issuer CRLs.

## Review findings addressed

- absmach/atom#54: revocation evidence disappeared after credential purge.
- absmach/atom#54: legacy CRL generation could deadlock on a nested pool acquire.
- absmach/atom#54: weak `If-None-Match` validators were not accepted.
- absmach/atom#55: managed OCSP responses used a certificate without `digitalSignature` authorization.
- absmach/atom#55: purged credentials changed OCSP status from revoked to unknown.

## Validation

Added coverage for one-connection legacy CRL generation, weak ETags, purge-before-CRL regeneration, purge-before-OCSP lookup, and managed issuer KeyUsage. `git diff --check` passes locally; hosted workflows run formatting, locked Clippy, compilation, fresh-database tests, and interoperability checks.

## Scope

This PR targets `certificates` and contains only PR-009/010 corrective work.