### PR TITLE
[PKI PR-014/015 follow-up] Close enrollment and lifecycle review gaps

### DIFF
--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -537,6 +537,9 @@ ATOM_PKI_ENROLLMENT_ENABLED=true
 ATOM_PKI_ENROLLMENT_LISTEN_ADDR=0.0.0.0:8443
 ATOM_PKI_ENROLLMENT_TLS_CERT_PATH=/certs/enrollment-server.crt
 ATOM_PKI_ENROLLMENT_TLS_KEY_PATH=/certs/enrollment-server.key
+ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS=10
+ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS=300
+ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS=30
 ```
 
 The cert/key identify the enrollment server. Client certificates are verified
@@ -550,6 +553,9 @@ The verifier refreshes the database trust bundle every 60 seconds by default,
 so newly provisioned or rotated authorities become eligible without restarting
 Atom. A refresh failure retains the last known-good verifier and emits a
 warning; tune the interval with `ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS`.
+Slow handshakes cannot hold a connection permit indefinitely, established
+connections have a configured lifetime, and shutdown waits for active
+connections only up to the configured drain deadline before aborting them.
 
 Per-entity (10/minute by default) and per-tenant (1000/minute) limits are stored
 atomically in PostgreSQL, so replicas share enforcement. `429` responses include
@@ -626,12 +632,17 @@ before pagination rather than by filtering returned rows.
 `bulkRevokeCertificates` revokes one bounded page selected by exactly one of
 `tenantId`, `issuerId`, or `principalGroupId`. It reports every attempted item
 and returns the last contiguous successful credential as
-`nextCursorCredentialId`. A caller can repair a failed item and resume from that
-cursor; already revoked credentials are not selected again. Bulk issuance and
+`nextCursor`. The first page also returns `snapshotAt`; every request carrying
+`afterCredentialId` must send that same snapshot timestamp. A caller can repair
+a failed item and resume from the cursor without absorbing certificates issued
+between pages; already revoked credentials are not selected again. A new bulk
+operation handles certificates created after the snapshot. Bulk issuance and
 notification delivery remain outside Atom.
 
 Prometheus metrics expose lifecycle operation counts, certificate expiry
 buckets, authority time to expiry, and CRL size and generation duration. Metric
 labels are deliberately bounded to operation, result, status, and time bucket;
 they never carry tenant, entity, credential, issuer, subject, serial, or key
-material.
+material. Operation successes are counted only after commit. If an authority
+kind is absent from the current fleet snapshot, its gauge is `NaN`, not a
+zero-second value that could produce a false expiry alert.

--- a/product-docs/12-certificates.md
+++ b/product-docs/12-certificates.md
@@ -216,7 +216,11 @@ The listener is opt-in with `ATOM_PKI_ENROLLMENT_ENABLED=true` and requires
 `ATOM_PKI_ENROLLMENT_TLS_KEY_PATH`. It binds
 `ATOM_PKI_ENROLLMENT_LISTEN_ADDR` (default `0.0.0.0:8443`). Expired, revoked,
 unknown, or otherwise inactive certificate subjects must recover through first
-enrollment with a still-active non-certificate credential.
+enrollment with a still-active non-certificate credential. TLS handshakes,
+connection lifetimes, and shutdown draining are bounded by
+`ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS`,
+`ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS`, and
+`ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS` respectively.
 
 PR-014b attaches RFC 7030 EST to that same listener and service boundary.
 `/.well-known/est/simpleenroll`, `simplereenroll`, `serverkeygen`, `csrattrs`,
@@ -321,15 +325,21 @@ configured rotation lead time.
 `bulkRevokeCertificates` accepts exactly one tenant, issuer, or principal-group
 selector and processes a bounded page. The result reports each attempted
 credential and a cursor after the last contiguous success, so a caller can fix a
-failure and resume without repeating completed revocations. Every successful
-item retains the normal per-certificate authorization, audit, outbox, immutable
-revocation evidence, and issuer-specific CRL-dirty behavior.
+failure and resume without repeating completed revocations. The first page also
+returns `snapshotAt`; a resumed request must pass it unchanged with
+`afterCredentialId`. This freezes the fleet membership so certificates issued
+between pages are handled by a subsequent operation rather than skipped by UUID
+ordering. Every successful item retains the normal per-certificate
+authorization, audit, outbox, immutable revocation evidence, and issuer-specific
+CRL-dirty behavior.
 
 Lifecycle metrics cover issuance, renewal, revocation, enrollment, expiry
 buckets, authority time to expiry, and CRL size and generation duration. They
 use bounded operational labels and omit identifiers, certificate subjects, key
 material, and other secrets. Disabling the sweeper preserves the existing
-interactive certificate behavior.
+interactive certificate behavior. Success counters are recorded only after the
+owning transaction commits, and an absent authority kind is represented as
+`NaN` rather than a false zero-second expiry.
 
 ---
 

--- a/product-docs/development/pki/pr-014-enrollment.md
+++ b/product-docs/development/pki/pr-014-enrollment.md
@@ -150,7 +150,11 @@ smuggled in here.
   credential, and that path must exist and be documented.
 - Renewal thresholds come from the profile, not a global constant.
 - The enrollment endpoint is a public network surface taking cryptographic input.
-  Malformed input must fail cheaply and must not allocate unboundedly.
+  Malformed input must fail cheaply and must not allocate unboundedly. TLS
+  handshakes and established connections have deadlines; shutdown tracks and
+  drains connection tasks for a bounded interval.
+- Durable rate-limit windows are removed with entity and tenant purge, so deleted
+  one-time subjects cannot leave unbounded counter rows.
 - The adapter boundary is verified by review, not by intent: a reviewer must be
   able to describe how a second adapter would attach without touching enrollment
   logic.
@@ -170,6 +174,8 @@ smuggled in here.
   the management API for the same entity.
 - Responses carry the renewal threshold from the certificate's profile.
 - Enrollment and re-enrollment are distinguishable in audit and events.
+- Native adapter denials and service failures use the same error-observation path
+  as other certificate transports, including a missing verified peer.
 - Rate limits are enforced and observable.
 - Enrollment logic sits behind an adapter boundary, with no protocol-specific
   behaviour below it and no enrollment behaviour above it.
@@ -182,7 +188,9 @@ header-injection rejection, self-scope violation, expired-certificate
 re-enrollment rejection plus documented recovery, cross-tenant attempts, global
 entity enrollment against the platform leaf issuer, malformed and oversized CSR
 input, rate-limit behaviour, profile application parity with the management API,
-renewal-threshold correctness, and independent verification of the issued chain.
+renewal-threshold correctness, bounded handshake/connection shutdown behaviour,
+purge cleanup for durable counters, error observation, and independent
+verification of the issued chain.
 
 ## AI execution prompt
 

--- a/product-docs/development/pki/pr-015-lifecycle-automation.md
+++ b/product-docs/development/pki/pr-015-lifecycle-automation.md
@@ -48,6 +48,10 @@ presentation belong to whoever consumes them.
   It must not double-emit; coordinate the same way existing periodic work does.
 - Batch operations must not hold a transaction across an unbounded row set, and
   must not open a second pool connection while a transaction is held.
+- A bulk operation freezes candidate membership at its first page. Its snapshot
+  must be returned with the UUID cursor and reused unchanged on resumption.
+- A delayed sweep still claims due windows after a certificate or authority has
+  crossed expiry; transient failures cannot erase an unclaimed notification.
 - Every emitted event carries issuer, credential, entity, and tenant identifiers
   and no secret material.
 - Renewal thresholds come from the certificate's profile, not from a global
@@ -59,10 +63,13 @@ presentation belong to whoever consumes them.
   across restarts and replicas.
 - Expiry listings are authorization-filtered and paginate over large fleets.
 - Bulk revocation reports per-item outcomes and is safely resumable after failure.
+- Certificates issued between bulk pages are excluded from that frozen operation
+  and remain eligible for a later operation.
 - An authority approaching expiry is surfaced with enough lead time to complete
   rotation.
 - Metrics expose the lifecycle state of the fleet without exposing key material or
-  subject secrets.
+  subject secrets. Success is recorded only after commit, and absent authority
+  kinds do not masquerade as zero-second expiries.
 - Disabling automation degrades to current behaviour rather than failing issuance.
 
 ## Mandatory tests
@@ -70,7 +77,9 @@ presentation belong to whoever consumes them.
 Sweeper idempotency across restart and concurrent replicas, event content and
 outbox transactionality, expiry-window boundary conditions, authorization
 filtering on listings, bulk revoke partial failure and resumption, authority
-expiry surfacing, and metric emission without secrets.
+expiry surfacing including overdue retry, frozen bulk-snapshot membership,
+post-commit metric emission, absent-authority semantics, and metric emission
+without secrets.
 
 ## AI execution prompt
 

--- a/src/certs/enrollment/http.rs
+++ b/src/certs/enrollment/http.rs
@@ -8,7 +8,7 @@ use axum::{
 use serde::Deserialize;
 use tower_http::trace::TraceLayer;
 
-use crate::{auth::AuthContext, error::AppError, state::AppState};
+use crate::{audit, auth::AuthContext, error::AppError, state::AppState};
 
 use super::{
     est,
@@ -62,9 +62,24 @@ async fn first_enrollment(
     auth: AuthContext,
     Json(request): Json<NativeEnrollmentRequest>,
 ) -> Result<Json<EnrollmentResponse>, AppError> {
-    service::enroll(&state, auth, request.into())
-        .await
-        .map(Json)
+    let result = service::enroll(&state, auth.clone(), request.into()).await;
+    if let Err(ref error) = result {
+        audit::observe_error(
+            &state.pool,
+            state.config.events.enabled(),
+            &audit::AuditMeta {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id: auth.tenant_id,
+                target_kind: "credential",
+                target_id: None,
+                event: "certificate.enroll",
+            },
+            &serde_json::json!({"mode": "first", "transport": "native"}),
+            error,
+        )
+        .await;
+    }
+    result.map(Json)
 }
 
 async fn re_enrollment(
@@ -72,10 +87,43 @@ async fn re_enrollment(
     peer: Option<Extension<VerifiedPeerCertificate>>,
     Json(request): Json<NativeEnrollmentRequest>,
 ) -> Result<Json<EnrollmentResponse>, AppError> {
-    let peer = peer
-        .map(|Extension(peer)| peer)
-        .ok_or_else(|| AppError::unauthorized("a verified client certificate is required"))?;
-    service::re_enroll(&state, peer, request.into())
-        .await
-        .map(Json)
+    let peer = match peer.map(|Extension(peer)| peer) {
+        Some(peer) => peer,
+        None => {
+            let error = AppError::unauthorized("a verified client certificate is required");
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &audit::AuditMeta {
+                    actor_entity_id: None,
+                    tenant_id: None,
+                    target_kind: "credential",
+                    target_id: None,
+                    event: "certificate.reenroll",
+                },
+                &serde_json::json!({"mode": "reenroll", "transport": "native"}),
+                &error,
+            )
+            .await;
+            return Err(error);
+        }
+    };
+    let result = service::re_enroll(&state, peer, request.into()).await;
+    if let Err(ref error) = result {
+        audit::observe_error(
+            &state.pool,
+            state.config.events.enabled(),
+            &audit::AuditMeta {
+                actor_entity_id: None,
+                tenant_id: None,
+                target_kind: "credential",
+                target_id: None,
+                event: "certificate.reenroll",
+            },
+            &serde_json::json!({"mode": "reenroll", "transport": "native"}),
+            error,
+        )
+        .await;
+    }
+    result.map(Json)
 }

--- a/src/certs/enrollment/service.rs
+++ b/src/certs/enrollment/service.rs
@@ -361,12 +361,23 @@ async fn commit_with_mode_audit(
         outcome: AuditOutcome::Allow,
         details,
     };
+    let operation = if event == "certificate.reenroll" {
+        "renewal"
+    } else {
+        "issuance"
+    };
     if replay {
-        tx.commit().await.map_err(AppError::Database)?;
+        let commit = tx.commit().await.map_err(AppError::Database);
+        certificates::record_lifecycle_commit(operation, &commit);
+        commit?;
         audit::write(&state.pool, false, audit_event).await;
         Ok(())
     } else {
-        audit::commit_with_audit(&state.pool, tx, state.config.events.enabled(), &audit_event).await
+        let commit =
+            audit::commit_with_audit(&state.pool, tx, state.config.events.enabled(), &audit_event)
+                .await;
+        certificates::record_lifecycle_commit(operation, &commit);
+        commit
     }
 }
 

--- a/src/certs/enrollment/tls.rs
+++ b/src/certs/enrollment/tls.rs
@@ -71,9 +71,7 @@ pub async fn prepare(state: &AppState) -> Result<Option<PreparedEnrollmentServer
         tls_handshake_timeout: Duration::from_secs(
             state.config.enrollment.tls_handshake_timeout_secs,
         ),
-        connection_timeout: Duration::from_secs(
-            state.config.enrollment.connection_timeout_secs,
-        ),
+        connection_timeout: Duration::from_secs(state.config.enrollment.connection_timeout_secs),
         shutdown_drain_timeout: Duration::from_secs(
             state.config.enrollment.shutdown_drain_timeout_secs,
         ),
@@ -195,7 +193,10 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
         let remaining = connections.len();
         connections.abort_all();
         while connections.join_next().await.is_some() {}
-        tracing::warn!(remaining, "aborted enrollment connections after shutdown drain deadline");
+        tracing::warn!(
+            remaining,
+            "aborted enrollment connections after shutdown drain deadline"
+        );
     }
     tracing::info!(%address, "PKI enrollment listener stopped");
     Ok(())

--- a/src/certs/enrollment/tls.rs
+++ b/src/certs/enrollment/tls.rs
@@ -1,6 +1,6 @@
 //! In-process TLS termination for the public enrollment listener.
 
-use std::{io::Cursor, net::SocketAddr, sync::Arc};
+use std::{io::Cursor, net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use hyper_util::{
@@ -9,7 +9,7 @@ use hyper_util::{
     service::TowerToHyperService,
 };
 use rustls::{server::WebPkiClientVerifier, RootCertStore, ServerConfig};
-use tokio::{net::TcpListener, sync::Semaphore};
+use tokio::{net::TcpListener, sync::Semaphore, task::JoinSet, time::timeout};
 use tokio_rustls::TlsAcceptor;
 
 use crate::{certs::authority::provisioning, config::EnrollmentTlsConfig, state::AppState};
@@ -29,6 +29,9 @@ pub struct PreparedEnrollmentServer {
     listener: TcpListener,
     acceptor: TlsAcceptor,
     max_connections: usize,
+    tls_handshake_timeout: Duration,
+    connection_timeout: Duration,
+    shutdown_drain_timeout: Duration,
 }
 
 impl PreparedEnrollmentServer {
@@ -65,17 +68,30 @@ pub async fn prepare(state: &AppState) -> Result<Option<PreparedEnrollmentServer
         listener,
         acceptor: TlsAcceptor::from(Arc::new(server_config)),
         max_connections: state.config.enrollment.max_connections,
+        tls_handshake_timeout: Duration::from_secs(
+            state.config.enrollment.tls_handshake_timeout_secs,
+        ),
+        connection_timeout: Duration::from_secs(
+            state.config.enrollment.connection_timeout_secs,
+        ),
+        shutdown_drain_timeout: Duration::from_secs(
+            state.config.enrollment.shutdown_drain_timeout_secs,
+        ),
     }))
 }
 
 pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Result<()> {
     let address = prepared.local_addr()?;
     let permits = Arc::new(Semaphore::new(prepared.max_connections));
+    let handshake_timeout = prepared.tls_handshake_timeout;
+    let connection_timeout = prepared.connection_timeout;
+    let shutdown_drain_timeout = prepared.shutdown_drain_timeout;
     let refresh_secs = state.config.enrollment.trust_bundle_refresh_secs;
     let refresh_state = state.clone();
     let router = http::create_router(state);
     let mut acceptor = prepared.acceptor;
     let mut trust_refresh = tokio::time::interval(std::time::Duration::from_secs(refresh_secs));
+    let mut connections = JoinSet::new();
     trust_refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     trust_refresh.tick().await;
     tracing::info!(%address, "PKI enrollment listener ready (in-process optional mTLS)");
@@ -99,6 +115,12 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
                 continue;
             },
             _ = crate::shutdown::shutdown_signal() => break,
+            joined = connections.join_next(), if !connections.is_empty() => {
+                if let Some(Err(error)) = joined {
+                    tracing::warn!(%error, "enrollment connection task failed");
+                }
+                continue;
+            },
         };
         let (stream, remote_addr) = match accepted {
             Ok(value) => value,
@@ -116,12 +138,16 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
         };
         let acceptor = acceptor.clone();
         let router = router.clone();
-        tokio::spawn(async move {
+        connections.spawn(async move {
             let _permit = permit;
-            let stream = match acceptor.accept(stream).await {
-                Ok(stream) => stream,
-                Err(error) => {
+            let stream = match timeout(handshake_timeout, acceptor.accept(stream)).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(error)) => {
                     tracing::warn!(%remote_addr, %error, "enrollment TLS handshake rejected");
+                    return;
+                }
+                Err(_) => {
+                    tracing::warn!(%remote_addr, "enrollment TLS handshake timed out");
                     return;
                 }
             };
@@ -139,13 +165,37 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
             };
             let service = TowerToHyperService::new(connection_router);
             let builder = Builder::new(TokioExecutor::new());
-            if let Err(error) = builder
-                .serve_connection(TokioIo::new(stream), service)
-                .await
+            match timeout(
+                connection_timeout,
+                builder.serve_connection(TokioIo::new(stream), service),
+            )
+            .await
             {
-                tracing::debug!(%remote_addr, %error, "enrollment connection closed with error");
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::debug!(%remote_addr, %error, "enrollment connection closed with error");
+                }
+                Err(_) => {
+                    tracing::warn!(%remote_addr, "enrollment connection deadline reached");
+                }
             }
         });
+    }
+
+    if timeout(shutdown_drain_timeout, async {
+        while let Some(joined) = connections.join_next().await {
+            if let Err(error) = joined {
+                tracing::warn!(%error, "enrollment connection task failed during shutdown");
+            }
+        }
+    })
+    .await
+    .is_err()
+    {
+        let remaining = connections.len();
+        connections.abort_all();
+        while connections.join_next().await.is_some() {}
+        tracing::warn!(remaining, "aborted enrollment connections after shutdown drain deadline");
     }
     tracing::info!(%address, "PKI enrollment listener stopped");
     Ok(())

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -116,6 +116,34 @@ fn parse_timestamp(value: &str, field: &str) -> Result<DateTime<Utc>> {
         .map_err(|_| async_graphql::Error::new(format!("{field} must be an RFC3339 timestamp")))
 }
 
+async fn commit_with_lifecycle_audit(
+    pool: &sqlx::PgPool,
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    events_enabled: bool,
+    event: &audit::AuditEvent<'_>,
+) -> std::result::Result<(), AppError> {
+    let result = audit::commit_with_audit(pool, tx, events_enabled, event).await;
+    let operation = match event.event {
+        "certificate.issue" => Some("issuance"),
+        "certificate.renew" => Some("renewal"),
+        "certificate.revoke" | "certificate.revoke_entity" => Some("revocation"),
+        _ => None,
+    };
+    if let Some(operation) = operation {
+        service::record_lifecycle_commit(operation, &result);
+    }
+    result
+}
+
+async fn commit_lifecycle_replay(
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    operation: &'static str,
+) -> std::result::Result<(), AppError> {
+    let result = tx.commit().await.map_err(AppError::Database);
+    service::record_lifecycle_commit(operation, &result);
+    result
+}
+
 #[derive(Default)]
 pub struct CertificateMutation;
 
@@ -145,7 +173,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -191,7 +219,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -240,7 +268,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -302,9 +330,9 @@ impl CertificateMutation {
             "replay": issued.idempotent_replay,
         });
         if issued.idempotent_replay {
-            tx.commit()
+            commit_lifecycle_replay(tx, "issuance")
                 .await
-                .map_err(|error| gql_error(db_err(error)))?;
+                .map_err(gql_error)?;
             audit::write(
                 &state.pool,
                 false,
@@ -320,7 +348,7 @@ impl CertificateMutation {
             )
             .await;
         } else {
-            audit::commit_with_audit(
+            commit_with_lifecycle_audit(
                 &state.pool,
                 tx,
                 state.config.events.enabled(),
@@ -364,7 +392,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -500,7 +528,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -558,12 +586,18 @@ impl CertificateMutation {
             .after_credential_id
             .map(|id| parse_id(id, "afterCredentialId"))
             .transpose()?;
+        let snapshot_at = input
+            .snapshot_at
+            .as_deref()
+            .map(|value| parse_timestamp(value, "snapshotAt"))
+            .transpose()?;
         lifecycle::bulk_revoke(
             state,
             selector,
             auth.entity_id,
             input.reason,
             after,
+            snapshot_at,
             input.limit.unwrap_or(100),
         )
         .await
@@ -609,9 +643,9 @@ async fn revoke_certificate_exact(
         "idempotent_replay": revoked.idempotent_replay,
     });
     if revoked.idempotent_replay {
-        tx.commit()
+        commit_lifecycle_replay(tx, "revocation")
             .await
-            .map_err(|error| gql_error(db_err(error)))?;
+            .map_err(gql_error)?;
         audit::write(
             &state.pool,
             false,
@@ -627,7 +661,7 @@ async fn revoke_certificate_exact(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -699,9 +733,9 @@ async fn renew_certificate_v2(
         "managed": true,
     });
     if issued.idempotent_replay {
-        tx.commit()
+        commit_lifecycle_replay(tx, "renewal")
             .await
-            .map_err(|error| gql_error(db_err(error)))?;
+            .map_err(gql_error)?;
         audit::write(
             &state.pool,
             false,
@@ -717,7 +751,7 @@ async fn renew_certificate_v2(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -813,6 +847,7 @@ pub struct BulkRevokeCertificatesInput {
     pub principal_group_id: Option<ID>,
     pub reason: Option<String>,
     pub after_credential_id: Option<ID>,
+    pub snapshot_at: Option<String>,
     pub limit: Option<i64>,
 }
 
@@ -829,6 +864,7 @@ pub struct BulkRevokeCertificateItem {
 #[derive(async_graphql::SimpleObject)]
 pub struct BulkRevokeCertificatesPayload {
     pub items: Vec<BulkRevokeCertificateItem>,
+    pub snapshot_at: String,
     pub next_cursor: Option<ID>,
     pub complete: bool,
 }
@@ -836,6 +872,7 @@ pub struct BulkRevokeCertificatesPayload {
 impl From<lifecycle::BulkRevocationBatch> for BulkRevokeCertificatesPayload {
     fn from(value: lifecycle::BulkRevocationBatch) -> Self {
         Self {
+            snapshot_at: value.snapshot_at.to_rfc3339(),
             items: value
                 .items
                 .into_iter()

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -6,7 +6,7 @@ use crate::{
     audit,
     auth::{has_capability_in_scope, AuthContext, Scope},
     certs::{lifecycle, service},
-    error::db_err,
+    error::{db_err, AppError},
     models::enums::AuditOutcome,
     state::AppState,
 };

--- a/src/certs/lifecycle/mod.rs
+++ b/src/certs/lifecycle/mod.rs
@@ -55,6 +55,10 @@ pub struct BulkRevocationItem {
 #[derive(Debug, Clone, Serialize)]
 pub struct BulkRevocationBatch {
     pub items: Vec<BulkRevocationItem>,
+    /// Freeze point for the operation. Pass it unchanged on every resumed
+    /// page so certificates issued while a batch is running are handled by a
+    /// later operation instead of being silently skipped by UUID pagination.
+    pub snapshot_at: DateTime<Utc>,
     /// Pass this value as `after_credential_id` to resume. On a failure it is
     /// the last contiguous success, so the failed item is selected again.
     pub next_cursor: Option<Uuid>,
@@ -243,6 +247,7 @@ pub async fn bulk_revoke(
     actor_entity_id: Uuid,
     reason: Option<String>,
     after_credential_id: Option<Uuid>,
+    snapshot_at: Option<DateTime<Utc>>,
     limit: i64,
 ) -> Result<BulkRevocationBatch, AppError> {
     if !(1..=MAX_BULK_BATCH_SIZE).contains(&limit) {
@@ -250,11 +255,29 @@ pub async fn bulk_revoke(
             "bulk revocation limit must be between 1 and {MAX_BULK_BATCH_SIZE}"
         )));
     }
+    if after_credential_id.is_some() && snapshot_at.is_none() {
+        return Err(AppError::bad_request(
+            "snapshotAt is required when afterCredentialId is provided",
+        ));
+    }
+    let database_now = repo::bulk_snapshot_at(&state.pool).await?;
+    if snapshot_at
+        .as_ref()
+        .is_some_and(|snapshot| snapshot > &database_now)
+    {
+        return Err(AppError::bad_request(
+            "snapshotAt cannot be later than the database clock",
+        ));
+    }
+    let snapshot_at = snapshot_at.unwrap_or(database_now);
+
     // One look-ahead row determines whether a successful page has more work.
+    // The creation-time cutoff freezes membership across all UUID pages.
     let candidates = repo::bulk_candidates(
         &state.pool,
         selector,
         after_credential_id,
+        &snapshot_at,
         limit.saturating_add(1),
     )
     .await?;
@@ -270,26 +293,26 @@ pub async fn bulk_revoke(
             }
             Err(error) => {
                 let error_code = public_error_code(&error);
-                audit::write(
+                audit::observe_error(
                     &state.pool,
                     state.config.events.enabled(),
-                    audit::AuditEvent {
+                    &audit::AuditMeta {
                         actor_entity_id: Some(actor_entity_id),
                         tenant_id: candidate.tenant_id,
-                        target_kind: Some("credential"),
+                        target_kind: "credential",
                         target_id: Some(candidate.credential_id),
                         event: "certificate.bulk_revoke",
-                        outcome: error.audit_outcome(),
-                        details: serde_json::json!({
-                            "selector_kind": selector.kind(),
-                            "selector_id": selector.id(),
-                            "issuer_id": candidate.issuer_id,
-                            "credential_id": candidate.credential_id,
-                            "entity_id": candidate.entity_id,
-                            "tenant_id": candidate.tenant_id,
-                            "error_code": error_code,
-                        }),
                     },
+                    &serde_json::json!({
+                        "selector_kind": selector.kind(),
+                        "selector_id": selector.id(),
+                        "issuer_id": candidate.issuer_id,
+                        "credential_id": candidate.credential_id,
+                        "entity_id": candidate.entity_id,
+                        "tenant_id": candidate.tenant_id,
+                        "error_code": error_code,
+                    }),
+                    &error,
                 )
                 .await;
                 items.push(BulkRevocationItem {
@@ -302,6 +325,7 @@ pub async fn bulk_revoke(
                 });
                 return Ok(BulkRevocationBatch {
                     items,
+                    snapshot_at,
                     next_cursor: last_success,
                     complete: false,
                 });
@@ -311,6 +335,7 @@ pub async fn bulk_revoke(
 
     Ok(BulkRevocationBatch {
         items,
+        snapshot_at,
         next_cursor: if has_more { last_success } else { None },
         complete: !has_more,
     })
@@ -351,7 +376,9 @@ async fn revoke_candidate(
         "idempotent_replay": revoked.idempotent_replay,
     });
     if revoked.idempotent_replay {
-        tx.commit().await.map_err(AppError::Database)?;
+        let commit = tx.commit().await.map_err(AppError::Database);
+        certificates::record_lifecycle_commit("revocation", &commit);
+        commit?;
         audit::write(
             &state.pool,
             false,
@@ -367,7 +394,7 @@ async fn revoke_candidate(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        let commit = audit::commit_with_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -381,7 +408,9 @@ async fn revoke_candidate(
                 details,
             },
         )
-        .await?;
+        .await;
+        certificates::record_lifecycle_commit("revocation", &commit);
+        commit?;
     }
 
     Ok(BulkRevocationItem {

--- a/src/certs/lifecycle/repo.rs
+++ b/src/certs/lifecycle/repo.rs
@@ -97,7 +97,6 @@ pub async fn due_certificate_windows(
             WHERE c.kind = 'certificate'
               AND c.status = 'active'
               AND c.expires_at IS NOT NULL
-              AND c.expires_at > $1
         ), due AS (
             SELECT credential_id, issuer_id, entity_id, tenant_id, expires_at,
                    'renewal'::text AS window_kind, renewal_at AS window_at
@@ -155,7 +154,6 @@ pub async fn due_authority_windows(
                a.not_after - ($2 * interval '1 second') AS window_at
         FROM pki_authorities a
         WHERE a.status IN ('active', 'retiring')
-          AND a.not_after > $1
           AND a.not_after - ($2 * interval '1 second') <= $1
           AND NOT EXISTS (
               SELECT 1 FROM pki_lifecycle_notifications n
@@ -276,10 +274,21 @@ pub async fn selector_tenant_id(
     }
 }
 
+/// Database-clock cutoff used to freeze the membership of a paginated bulk
+/// operation. Credential creation also uses the database clock, avoiding
+/// process/DB clock skew at the page boundary.
+pub async fn bulk_snapshot_at(pool: &PgPool) -> Result<DateTime<Utc>, AppError> {
+    sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(pool)
+        .await
+        .map_err(AppError::Database)
+}
+
 pub async fn bulk_candidates(
     pool: &PgPool,
     selector: BulkRevocationSelector,
     after: Option<Uuid>,
+    snapshot_at: &DateTime<Utc>,
     limit: i64,
 ) -> Result<Vec<BulkCandidate>, AppError> {
     match selector {
@@ -308,15 +317,17 @@ pub async fn bulk_candidates(
                 CROSS JOIN root_group root
                 WHERE c.kind = 'certificate'
                   AND c.status = 'active'
+                  AND c.created_at <= $3
                   AND e.tenant_id IS NOT DISTINCT FROM root.tenant_id
                   AND ($2::uuid IS NULL OR c.id > $2)
                 GROUP BY c.id, c.issuer_id, c.entity_id, e.tenant_id
                 ORDER BY c.id ASC
-                LIMIT $3
+                LIMIT $4
                 "#,
         )
         .bind(group_id)
         .bind(after)
+        .bind(snapshot_at)
         .bind(limit)
         .fetch_all(pool)
         .await
@@ -331,6 +342,8 @@ pub async fn bulk_candidates(
                   AND c.status = 'active'
                 "#,
             );
+            query.push(" AND c.created_at <= ");
+            query.push_bind(snapshot_at);
             match selector {
                 BulkRevocationSelector::Tenant(tenant_id) => {
                     query.push(" AND e.tenant_id = ");

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -506,10 +506,9 @@ pub async fn issue_certificate(
     issuer: Option<&CertificateIssuer>,
     input: IssueCertificate,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "issuance").await?;
     let issued = issue_certificate_in_tx(&mut tx, config, issuer, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "issuance").await
 }
 
 /// The caller owns the commit, so an audited caller can bind issuance and its
@@ -522,7 +521,7 @@ pub async fn issue_certificate_in_tx(
     input: IssueCertificate,
 ) -> Result<IssuedCertificate, AppError> {
     let result = issue_certificate_in_tx_inner(tx, config, issuer, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -629,10 +628,9 @@ pub async fn issue_certificate_from_csr(
     issuer: Option<&CertificateIssuer>,
     input: IssueCertificateFromCsr,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "issuance").await?;
     let issued = issue_certificate_from_csr_in_tx(&mut tx, config, issuer, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "issuance").await
 }
 
 /// See [`issue_certificate_in_tx`] — the caller owns the commit.
@@ -643,7 +641,7 @@ pub async fn issue_certificate_from_csr_in_tx(
     input: IssueCertificateFromCsr,
 ) -> Result<IssuedCertificate, AppError> {
     let result = issue_certificate_from_csr_in_tx_inner(tx, config, issuer, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -728,11 +726,10 @@ pub async fn issue_certificate_from_csr_v2(
     authorized_tenant_id: Option<Uuid>,
     input: IssueCertificateFromCsrV2,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "issuance").await?;
     let issued =
         issue_certificate_from_csr_v2_in_tx(&mut tx, config, authorized_tenant_id, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "issuance").await
 }
 
 /// Managed CSR issuance using only the caller's existing transaction and
@@ -745,7 +742,7 @@ pub async fn issue_certificate_from_csr_v2_in_tx(
 ) -> Result<IssuedCertificate, AppError> {
     let result =
         issue_certificate_from_csr_v2_in_tx_inner(tx, config, authorized_tenant_id, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -865,7 +862,7 @@ pub async fn issue_generated_certificate_v2_in_tx(
 ) -> Result<IssuedCertificate, AppError> {
     let result =
         issue_generated_certificate_v2_in_tx_inner(tx, config, authorized_tenant_id, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -972,10 +969,9 @@ pub async fn renew_certificate(
     issuer: Option<&CertificateIssuer>,
     input: RenewCertificate,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "renewal").await?;
     let issued = renew_certificate_in_tx(&mut tx, config, issuer, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "renewal").await
 }
 
 /// See [`issue_certificate_in_tx`] — the caller owns the commit. Renewal issues
@@ -988,7 +984,7 @@ pub async fn renew_certificate_in_tx(
     input: RenewCertificate,
 ) -> Result<IssuedCertificate, AppError> {
     let result = renew_certificate_in_tx_inner(tx, config, issuer, input).await;
-    record_lifecycle_operation("renewal", &result);
+    record_lifecycle_precommit_failure("renewal", &result);
     result
 }
 
@@ -1032,10 +1028,9 @@ pub async fn renew_certificate_v2(
     authorization: CertificateRenewalAuthorization,
     input: RenewCertificateV2,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "renewal").await?;
     let issued = renew_certificate_v2_in_tx(&mut tx, config, authorization, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "renewal").await
 }
 
 /// Exact-credential, issuer-aware renewal. Operator authorization is bound to
@@ -1049,7 +1044,7 @@ pub async fn renew_certificate_v2_in_tx(
     input: RenewCertificateV2,
 ) -> Result<IssuedCertificate, AppError> {
     let result = renew_certificate_v2_in_tx_inner(tx, config, authorization, input).await;
-    record_lifecycle_operation("renewal", &result);
+    record_lifecycle_precommit_failure("renewal", &result);
     result
 }
 
@@ -1265,10 +1260,9 @@ pub async fn revoke_certificate(
     serial_number: &str,
     reason: Option<String>,
 ) -> Result<CertificateRecord, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "revocation").await?;
     let record = revoke_certificate_in_tx(&mut tx, serial_number, reason).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(record)
+    commit_lifecycle_transaction(tx, record, "revocation").await
 }
 
 /// See [`issue_certificate_in_tx`] — the caller owns the commit. The revocation
@@ -1281,7 +1275,7 @@ pub async fn revoke_certificate_in_tx(
     reason: Option<String>,
 ) -> Result<CertificateRecord, AppError> {
     let result = revoke_certificate_in_tx_inner(tx, serial_number, reason).await;
-    record_lifecycle_operation("revocation", &result);
+    record_lifecycle_precommit_failure("revocation", &result);
     result
 }
 
@@ -1338,10 +1332,9 @@ pub async fn revoke_certificate_v2(
     pool: &sqlx::PgPool,
     input: RevokeCertificateV2,
 ) -> Result<CertificateRevocationResult, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "revocation").await?;
     let result = revoke_certificate_v2_in_tx(&mut tx, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(result)
+    commit_lifecycle_transaction(tx, result, "revocation").await
 }
 
 /// Revoke one exact certificate. The row lock makes first-write semantics and
@@ -1353,7 +1346,7 @@ pub async fn revoke_certificate_v2_in_tx(
     input: RevokeCertificateV2,
 ) -> Result<CertificateRevocationResult, AppError> {
     let result = revoke_certificate_v2_in_tx_inner(tx, input).await;
-    record_lifecycle_operation("revocation", &result);
+    record_lifecycle_precommit_failure("revocation", &result);
     result
 }
 
@@ -1428,10 +1421,9 @@ pub async fn revoke_entity_certificates(
     entity_id: Uuid,
     reason: Option<String>,
 ) -> Result<usize, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "revocation").await?;
     let count = revoke_entity_certificates_in_tx(&mut tx, entity_id, reason).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(count)
+    commit_lifecycle_transaction(tx, count, "revocation").await
 }
 
 /// See [`revoke_certificate_in_tx`] — the caller owns the commit. Revoking an
@@ -1458,7 +1450,7 @@ pub async fn revoke_entity_certificates_v2_in_tx(
 ) -> Result<BulkCertificateRevocationResult, AppError> {
     let result =
         revoke_entity_certificates_v2_in_tx_inner(tx, entity_id, reason, actor_entity_id).await;
-    record_lifecycle_operation("revocation", &result);
+    record_lifecycle_precommit_failure("revocation", &result);
     result
 }
 
@@ -2995,7 +2987,45 @@ fn is_unique_violation(err: &AppError) -> bool {
     )
 }
 
-fn record_lifecycle_operation<T>(operation: &'static str, result: &Result<T, AppError>) {
+async fn begin_lifecycle_transaction<'a>(
+    pool: &'a sqlx::PgPool,
+    operation: &'static str,
+) -> Result<sqlx::Transaction<'a, sqlx::Postgres>, AppError> {
+    match pool.begin().await {
+        Ok(tx) => Ok(tx),
+        Err(error) => {
+            crate::metrics::record_pki_lifecycle_operation(operation, "failure");
+            Err(AppError::Database(error))
+        }
+    }
+}
+
+async fn commit_lifecycle_transaction<T>(
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    value: T,
+    operation: &'static str,
+) -> Result<T, AppError> {
+    let result = tx.commit().await;
+    record_lifecycle_commit(operation, &result);
+    result.map(|_| value).map_err(AppError::Database)
+}
+
+fn record_lifecycle_precommit_failure<T>(
+    operation: &'static str,
+    result: &Result<T, AppError>,
+) {
+    if result.is_err() {
+        crate::metrics::record_pki_lifecycle_operation(operation, "failure");
+    }
+}
+
+/// Record an operation only after the owner of a transaction has observed its
+/// final commit result. Transactional transports use this after their audit +
+/// mutation commit; `_in_tx` helpers record only pre-commit failures.
+pub(crate) fn record_lifecycle_commit<T, E>(
+    operation: &'static str,
+    result: &Result<T, E>,
+) {
     crate::metrics::record_pki_lifecycle_operation(
         operation,
         if result.is_ok() { "success" } else { "failure" },

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -3010,10 +3010,7 @@ async fn commit_lifecycle_transaction<T>(
     result.map(|_| value).map_err(AppError::Database)
 }
 
-fn record_lifecycle_precommit_failure<T>(
-    operation: &'static str,
-    result: &Result<T, AppError>,
-) {
+fn record_lifecycle_precommit_failure<T>(operation: &'static str, result: &Result<T, AppError>) {
     if result.is_err() {
         crate::metrics::record_pki_lifecycle_operation(operation, "failure");
     }
@@ -3022,10 +3019,7 @@ fn record_lifecycle_precommit_failure<T>(
 /// Record an operation only after the owner of a transaction has observed its
 /// final commit result. Transactional transports use this after their audit +
 /// mutation commit; `_in_tx` helpers record only pre-commit failures.
-pub(crate) fn record_lifecycle_commit<T, E>(
-    operation: &'static str,
-    result: &Result<T, E>,
-) {
+pub(crate) fn record_lifecycle_commit<T, E>(operation: &'static str, result: &Result<T, E>) {
     crate::metrics::record_pki_lifecycle_operation(
         operation,
         if result.is_ok() { "success" } else { "failure" },

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,6 +334,9 @@ pub struct EnrollmentConfig {
     pub max_csr_bytes: usize,
     pub max_connections: usize,
     pub trust_bundle_refresh_secs: u64,
+    pub tls_handshake_timeout_secs: u64,
+    pub connection_timeout_secs: u64,
+    pub shutdown_drain_timeout_secs: u64,
 }
 
 impl Default for EnrollmentConfig {
@@ -353,6 +356,9 @@ impl Default for EnrollmentConfig {
             max_csr_bytes: 64 * 1024,
             max_connections: 256,
             trust_bundle_refresh_secs: 60,
+            tls_handshake_timeout_secs: 10,
+            connection_timeout_secs: 300,
+            shutdown_drain_timeout_secs: 30,
         }
     }
 }
@@ -1295,6 +1301,18 @@ fn enrollment_from_env() -> Result<EnrollmentConfig> {
             "ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS",
             default.trust_bundle_refresh_secs,
         )?,
+        tls_handshake_timeout_secs: env_parse(
+            "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS",
+            default.tls_handshake_timeout_secs,
+        )?,
+        connection_timeout_secs: env_parse(
+            "ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS",
+            default.connection_timeout_secs,
+        )?,
+        shutdown_drain_timeout_secs: env_parse(
+            "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS",
+            default.shutdown_drain_timeout_secs,
+        )?,
     };
     if cfg.max_csr_bytes == 0 {
         anyhow::bail!("ATOM_PKI_ENROLLMENT_MAX_CSR_BYTES must be greater than zero");
@@ -1304,6 +1322,19 @@ fn enrollment_from_env() -> Result<EnrollmentConfig> {
     }
     if cfg.trust_bundle_refresh_secs == 0 {
         anyhow::bail!("ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS must be greater than zero");
+    }
+    if cfg.tls_handshake_timeout_secs == 0 {
+        anyhow::bail!(
+            "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS must be greater than zero"
+        );
+    }
+    if cfg.connection_timeout_secs == 0 {
+        anyhow::bail!("ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS must be greater than zero");
+    }
+    if cfg.shutdown_drain_timeout_secs == 0 {
+        anyhow::bail!(
+            "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS must be greater than zero"
+        );
     }
     Ok(cfg)
 }
@@ -1729,6 +1760,9 @@ mod tests {
         assert!(!cfg.enrollment.enabled);
         assert!(cfg.enrollment.tls.is_none());
         assert_eq!(cfg.enrollment.max_csr_bytes, 64 * 1024);
+        assert_eq!(cfg.enrollment.tls_handshake_timeout_secs, 10);
+        assert_eq!(cfg.enrollment.connection_timeout_secs, 300);
+        assert_eq!(cfg.enrollment.shutdown_drain_timeout_secs, 30);
 
         std::env::set_var("ATOM_PKI_ENROLLMENT_ENABLED", "true");
         let err = Config::from_env().expect_err("enabled listener without TLS");
@@ -1741,10 +1775,16 @@ mod tests {
         std::env::set_var("ATOM_PKI_ENROLLMENT_TLS_KEY_PATH", "/tls/server-key.pem");
         std::env::set_var("ATOM_PKI_ENROLLMENT_ENTITY_RATE_LIMIT", "7");
         std::env::set_var("ATOM_PKI_ENROLLMENT_TENANT_RATE_LIMIT", "70");
+        std::env::set_var("ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS", "11");
+        std::env::set_var("ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS", "301");
+        std::env::set_var("ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS", "31");
         let cfg = Config::from_env().expect("enrollment config");
         assert!(cfg.enrollment.enabled);
         assert_eq!(cfg.enrollment.entity_rate_limit.max_requests, 7);
         assert_eq!(cfg.enrollment.tenant_rate_limit.max_requests, 70);
+        assert_eq!(cfg.enrollment.tls_handshake_timeout_secs, 11);
+        assert_eq!(cfg.enrollment.connection_timeout_secs, 301);
+        assert_eq!(cfg.enrollment.shutdown_drain_timeout_secs, 31);
         assert_eq!(
             cfg.enrollment
                 .tls
@@ -1880,6 +1920,9 @@ mod tests {
             "ATOM_PKI_ENROLLMENT_MAX_CSR_BYTES",
             "ATOM_PKI_ENROLLMENT_MAX_CONNECTIONS",
             "ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS",
+            "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS",
+            "ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS",
+            "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS",
             "ATOM_PKI_LIFECYCLE_ENABLED",
             "ATOM_PKI_LIFECYCLE_INTERVAL_SECS",
             "ATOM_PKI_LIFECYCLE_BATCH_SIZE",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1324,17 +1324,13 @@ fn enrollment_from_env() -> Result<EnrollmentConfig> {
         anyhow::bail!("ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS must be greater than zero");
     }
     if cfg.tls_handshake_timeout_secs == 0 {
-        anyhow::bail!(
-            "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS must be greater than zero"
-        );
+        anyhow::bail!("ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS must be greater than zero");
     }
     if cfg.connection_timeout_secs == 0 {
         anyhow::bail!("ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS must be greater than zero");
     }
     if cfg.shutdown_drain_timeout_secs == 0 {
-        anyhow::bail!(
-            "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS must be greater than zero"
-        );
+        anyhow::bail!("ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS must be greater than zero");
     }
     Ok(cfg)
 }

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -426,7 +426,7 @@ impl CertificateService for AtomCertificates {
         )
         .await
         .map_err(Status::from)?;
-        audit::commit_with_audit(
+        let commit = audit::commit_with_audit(
             &self.state.pool,
             tx,
             self.state.config.events.enabled(),
@@ -446,8 +446,9 @@ impl CertificateService for AtomCertificates {
                 }),
             },
         )
-        .await
-        .map_err(Status::from)?;
+        .await;
+        certs::service::record_lifecycle_commit("revocation", &commit);
+        commit.map_err(Status::from)?;
 
         Ok(Response::new(RevokeEntityCertificatesResponse {
             revoked: revoked.count as u64,

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -897,6 +897,18 @@ pub async fn purge_entity_with_audit(
             .await
             .map_err(db_err)?;
 
+    // Enrollment counters intentionally have no FK because a scope may be
+    // admitted before all subject reads finish. Purge them explicitly so a
+    // one-time subject cannot leave durable abuse-control state behind.
+    sqlx::query(
+        "DELETE FROM pki_enrollment_rate_windows
+         WHERE scope_kind = 'entity' AND scope_id = $1",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await
+    .map_err(db_err)?;
+
     let purged_tenant_id: Option<Option<Uuid>> = sqlx::query_scalar(
         "DELETE FROM entities WHERE id = $1 AND deleted_at IS NOT NULL RETURNING tenant_id",
     )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -197,8 +197,12 @@ mod backend {
             "platform_leaf_issuer",
             "tenant_intermediate",
         ];
+        // Prometheus recorders cannot unregister one labeled gauge through
+        // the facade. NaN explicitly represents an absent authority kind and
+        // prevents a missing fleet from looking like a real zero-second CA,
+        // which would otherwise trigger false expiry alerts.
         for kind in AUTHORITY_KINDS {
-            metrics::gauge!(PKI_AUTHORITY_TIME_TO_EXPIRY, "kind" => kind).set(0.0);
+            metrics::gauge!(PKI_AUTHORITY_TIME_TO_EXPIRY, "kind" => kind).set(f64::NAN);
         }
         for row in authority_rows {
             let Some(kind) = AUTHORITY_KINDS

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -110,6 +110,13 @@ pub async fn purge_expired(pool: &PgPool, cfg: PurgeConfig) -> Result<PurgeSumma
     // Entities: capture cascaded credential ids before the delete removes them.
     let entity_ids = select_doomed(&mut tx, "entities", cutoff, cfg.batch_size).await?;
     if !entity_ids.is_empty() {
+        sqlx::query(
+            "DELETE FROM pki_enrollment_rate_windows
+             WHERE scope_kind = 'entity' AND scope_id = ANY($1)",
+        )
+        .bind(&entity_ids)
+        .execute(&mut *tx)
+        .await?;
         let credential_ids: Vec<Uuid> =
             sqlx::query_scalar("SELECT id FROM credentials WHERE entity_id = ANY($1)")
                 .bind(&entity_ids)

--- a/src/tenants/repo.rs
+++ b/src/tenants/repo.rs
@@ -736,6 +736,21 @@ pub(crate) async fn purge_tenant_pki_in_tx(
         return Ok(());
     }
 
+    // Rate-limit rows are deliberately independent of subject FKs. Remove
+    // both tenant and child-entity scopes while those entities are still
+    // available to identify, before the tenant cascade runs.
+    sqlx::query(
+        r#"DELETE FROM pki_enrollment_rate_windows
+           WHERE (scope_kind = 'tenant' AND scope_id = ANY($1))
+              OR (scope_kind = 'entity' AND scope_id IN (
+                    SELECT id FROM entities WHERE tenant_id = ANY($1)
+                 ))"#,
+    )
+    .bind(tenant_ids)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+
     // Credentials restrict authority deletion, and authorities belong to the
     // tenant being purged. Remove them in dependency order before the tenant.
     sqlx::query(

--- a/tests/m21_soft_delete.rs
+++ b/tests/m21_soft_delete.rs
@@ -1799,6 +1799,22 @@ async fn tombstoned_tenant_cannot_be_reactivated_or_authorized() {
 async fn purge_tenant_removes_owned_objects_instead_of_orphaning_them() {
     let pool = common::pool().await;
     let tenant_id = make_tenant(&pool, &format!("sd-purge-ten-{}", Uuid::new_v4())).await;
+    let entity_id = make_entity(
+        &pool,
+        &format!("sd-purge-rate-{}", Uuid::new_v4()),
+        Some(tenant_id),
+    )
+    .await;
+    sqlx::query(
+        "INSERT INTO pki_enrollment_rate_windows
+         (scope_kind, scope_id, window_start, request_count)
+         VALUES ('tenant', $1, now(), 1), ('entity', $2, now(), 1)",
+    )
+    .bind(tenant_id)
+    .bind(entity_id)
+    .execute(&pool)
+    .await
+    .expect("enrollment rate windows");
     let role_id = Uuid::new_v4();
     sqlx::query("INSERT INTO roles (id, name, tenant_id) VALUES ($1, $2, $3)")
         .bind(role_id)
@@ -1849,4 +1865,18 @@ async fn purge_tenant_removes_owned_objects_instead_of_orphaning_them() {
             "{table} row must be purged with the tenant, not orphaned"
         );
     }
+    let abandoned_rate_windows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pki_enrollment_rate_windows
+         WHERE (scope_kind = 'tenant' AND scope_id = $1)
+            OR (scope_kind = 'entity' AND scope_id = $2)",
+    )
+    .bind(tenant_id)
+    .bind(entity_id)
+    .fetch_one(&pool)
+    .await
+    .expect("rate window count");
+    assert_eq!(
+        abandoned_rate_windows, 0,
+        "tenant purge must drop tenant and child enrollment counters"
+    );
 }

--- a/tests/m22_restore.rs
+++ b/tests/m22_restore.rs
@@ -47,7 +47,6 @@ async fn restore_entity_reverses_soft_delete_but_keeps_credentials_revoked() {
         .execute(&pool)
         .await
         .expect("insert credential");
-
     atom::identity::repo::delete_entity(&pool, id, None)
         .await
         .expect("soft delete entity");
@@ -353,6 +352,15 @@ async fn purge_entity_physically_removes_a_tombstoned_row_and_cascades() {
         .execute(&pool)
         .await
         .expect("insert credential");
+    sqlx::query(
+        "INSERT INTO pki_enrollment_rate_windows
+         (scope_kind, scope_id, window_start, request_count)
+         VALUES ('entity', $1, now(), 1)",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .expect("insert enrollment rate window");
 
     atom::identity::repo::delete_entity(&pool, id, None)
         .await
@@ -374,6 +382,20 @@ async fn purge_entity_physically_removes_a_tombstoned_row_and_cascades() {
         .await
         .expect("credential lookup");
     assert!(cred_exists.is_none(), "FK cascade must drop credentials");
+    let rate_window_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM pki_enrollment_rate_windows
+            WHERE scope_kind = 'entity' AND scope_id = $1
+         )",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .expect("rate window lookup");
+    assert!(
+        !rate_window_exists,
+        "purge must drop the entity's durable enrollment counter"
+    );
 }
 
 #[tokio::test]

--- a/tests/m39_pki_enrollment.rs
+++ b/tests/m39_pki_enrollment.rs
@@ -282,6 +282,20 @@ async fn native_enrollment_enforces_the_pr014_contract() {
     .await
     .unwrap();
     assert_eq!(injected.status, 401, "{}", injected.body);
+    let native_denial: (String, String) = sqlx::query_as(
+        r#"SELECT payload->>'outcome', payload->'details'->>'transport'
+           FROM event_outbox
+           WHERE event = 'certificate.reenroll'
+             AND payload->>'outcome' = 'deny'
+             AND payload->'details'->>'transport' = 'native'
+           ORDER BY created_at DESC
+           LIMIT 1"#,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(native_denial.0, "deny");
+    assert_eq!(native_denial.1, "native");
 
     // A certificate asserted in the TLS handshake but signed outside Atom's
     // trust bundle is rejected during the in-process handshake.

--- a/tests/m40_pki_lifecycle_automation.rs
+++ b/tests/m40_pki_lifecycle_automation.rs
@@ -22,7 +22,7 @@ use atom::{
 use chrono::{DateTime, Duration, Utc};
 use rcgen::{CertificateParams, KeyPair};
 use serde_json::{json, Value};
-use sqlx::PgPool;
+use sqlx::{Acquire, PgPool};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -154,6 +154,46 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     assert_eq!(
         marker_count(&pool, future.credential_id, "renewal").await,
         0
+    );
+
+    // A delayed or failed sweep still claims windows after the subject has
+    // crossed its expiry timestamp; those events must not disappear merely
+    // because the next successful retry is late.
+    let overdue = issue(&pool, &config, tenant_b, entity_b, "overdue").await;
+    set_expiry_and_renewal(
+        &pool,
+        overdue.credential_id,
+        now - Duration::minutes(1),
+        now - Duration::hours(2),
+    )
+    .await;
+    let overdue_authority_tenant =
+        common::pki::create_tenant(&pool, "pki-life-overdue-authority").await;
+    let overdue_authority = common::pki::provision_tenant_issuer(
+        &pool,
+        &config,
+        &root,
+        overdue_authority_tenant,
+    )
+    .await;
+    sqlx::query("UPDATE pki_authorities SET not_after = $2 WHERE id = $1")
+        .bind(overdue_authority.id)
+        .bind(now - Duration::minutes(1))
+        .execute(&pool)
+        .await
+        .unwrap();
+    let overdue_sweep = lifecycle::sweep_once(&pool, config.pki_lifecycle, true, now)
+        .await
+        .unwrap();
+    assert_eq!(overdue_sweep.certificate_events, 2);
+    assert_eq!(overdue_sweep.authority_events, 1);
+    assert_eq!(
+        marker_count(&pool, overdue.credential_id, "expiry").await,
+        1
+    );
+    assert_eq!(
+        marker_count(&pool, overdue_authority.id, "authority_expiry").await,
+        1
     );
 
     // The marker and outbox insert are one transaction: a forced outbox error
@@ -358,21 +398,22 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     assert_eq!(partial["items"][1]["outcome"], "failed");
     assert_eq!(partial["items"][1]["errorCode"], "internal");
     assert_eq!(partial["nextCursor"], ordered[0].to_string());
-    let failed_audit: (String, String) = sqlx::query_as(
+    let partial_snapshot = partial["snapshotAt"].as_str().unwrap().to_string();
+    let failed_observation: (String, String) = sqlx::query_as(
         r#"
-        SELECT outcome, details->>'error_code'
-        FROM audit_logs
-        WHERE event = 'certificate.bulk_revoke' AND target_id = $1
+        SELECT payload->>'outcome', payload->'details'->>'error_code'
+        FROM event_outbox
+        WHERE event = 'certificate.bulk_revoke' AND payload->>'target_id' = $1
         ORDER BY created_at DESC
         LIMIT 1
         "#,
     )
-    .bind(ordered[1])
+    .bind(ordered[1].to_string())
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(failed_audit.0, "error");
-    assert_eq!(failed_audit.1, "internal");
+    assert_eq!(failed_observation.0, "error");
+    assert_eq!(failed_observation.1, "internal");
     sqlx::query("UPDATE credentials SET metadata = $2 WHERE id = $1")
         .bind(ordered[1])
         .bind(original_metadata)
@@ -387,6 +428,7 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
             "tenantId": tenant_c,
             "reason": "key_compromise",
             "afterCredentialId": ordered[0],
+            "snapshotAt": partial_snapshot,
             "limit": 10
         }),
     )
@@ -395,6 +437,72 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     assert_eq!(resumed["items"].as_array().unwrap().len(), 1);
     assert_eq!(resumed["items"][0]["credentialId"], ordered[1].to_string());
     assert_eq!(resumed["items"][0]["outcome"], "revoked");
+
+    // A bulk operation freezes its membership at page one. Certificates
+    // issued between pages are deliberately excluded even when their random
+    // UUID sorts after the cursor; a later operation then picks them up.
+    let tenant_d = common::pki::create_tenant(&pool, "pki-life-d").await;
+    common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_d).await;
+    let entity_d = common::pki::create_entity(&pool, tenant_d, "pki-life-d").await;
+    issue(&pool, &config, tenant_d, entity_d, "snapshot-one").await;
+    issue(&pool, &config, tenant_d, entity_d, "snapshot-two").await;
+    let snapshot_first = execute_bulk(
+        &schema,
+        common::admin_id(),
+        None,
+        json!({"tenantId": tenant_d, "reason": "superseded", "limit": 1}),
+    )
+    .await;
+    assert!(!snapshot_first["complete"].as_bool().unwrap());
+    let snapshot_cursor = Uuid::parse_str(snapshot_first["nextCursor"].as_str().unwrap()).unwrap();
+    let snapshot_at = snapshot_first["snapshotAt"].as_str().unwrap().to_string();
+    let mut issued_during_scan = None;
+    for index in 0..32 {
+        let issued = issue(
+            &pool,
+            &config,
+            tenant_d,
+            entity_d,
+            &format!("snapshot-late-{index}"),
+        )
+        .await;
+        if issued.credential_id > snapshot_cursor {
+            issued_during_scan = Some(issued);
+            break;
+        }
+    }
+    let issued_during_scan = issued_during_scan.expect("random UUID after first-page cursor");
+    let snapshot_resumed = execute_bulk(
+        &schema,
+        common::admin_id(),
+        None,
+        json!({
+            "tenantId": tenant_d,
+            "reason": "superseded",
+            "afterCredentialId": snapshot_cursor,
+            "snapshotAt": snapshot_at,
+            "limit": 100
+        }),
+    )
+    .await;
+    assert!(snapshot_resumed["complete"].as_bool().unwrap());
+    assert_eq!(
+        certificate_status(&pool, issued_during_scan.credential_id).await,
+        "active",
+        "the frozen operation must not absorb certificates issued between pages"
+    );
+    let catch_up = execute_bulk(
+        &schema,
+        common::admin_id(),
+        None,
+        json!({"tenantId": tenant_d, "reason": "superseded", "limit": 100}),
+    )
+    .await;
+    assert!(catch_up["complete"].as_bool().unwrap());
+    assert_eq!(
+        certificate_status(&pool, issued_during_scan.credential_id).await,
+        "revoked"
+    );
 
     // First enrollment is included in the unified lifecycle operation metric;
     // a deliberately invalid issuance and unknown revocation prove failures.
@@ -441,6 +549,36 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
         .await
         .unwrap();
     assert!(!crl.der.is_empty());
+
+    // `_in_tx` success is provisional. Rolling the caller-owned transaction
+    // back must not publish a successful issuance sample.
+    let before_rollback = lifecycle_metric_value(
+        &metrics::render(&pool),
+        "issuance",
+        "success",
+    );
+    let mut rollback_tx = pool.begin().await.unwrap();
+    service::issue_certificate_from_csr_v2_in_tx(
+        &mut rollback_tx,
+        &config,
+        Some(tenant_b),
+        service::IssueCertificateFromCsrV2 {
+            entity_id: entity_b,
+            ttl_secs: None,
+            csr_pem: csr(),
+            idempotency_key: "m40-rolled-back-issuance".into(),
+        },
+    )
+    .await
+    .unwrap();
+    rollback_tx.rollback().await.unwrap();
+    let after_rollback = lifecycle_metric_value(
+        &metrics::render(&pool),
+        "issuance",
+        "success",
+    );
+    assert_eq!(before_rollback, after_rollback);
+
     let rendered = metrics::render(&pool);
     for metric in [
         metrics::PKI_LIFECYCLE_OPERATIONS,
@@ -467,6 +605,29 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     ] {
         assert!(!rendered.contains(&secret_or_identifier));
     }
+    metrics::record_pki_fleet_snapshot(&[], &[]);
+    let absent_snapshot = metrics::render(&pool);
+    assert!(
+        absent_snapshot.lines().any(|line| {
+            line.starts_with(metrics::PKI_AUTHORITY_TIME_TO_EXPIRY)
+                && line.contains("kind=\"root\"")
+                && line.ends_with(" NaN")
+        }),
+        "an absent authority kind must be explicit rather than a false zero: {absent_snapshot}"
+    );
+}
+
+fn lifecycle_metric_value(rendered: &str, operation: &str, outcome: &str) -> f64 {
+    rendered
+        .lines()
+        .find(|line| {
+            line.starts_with(metrics::PKI_LIFECYCLE_OPERATIONS)
+                && line.contains(&format!("operation=\"{operation}\""))
+                && line.contains(&format!("outcome=\"{outcome}\""))
+        })
+        .and_then(|line| line.rsplit_once(' '))
+        .and_then(|(_, value)| value.parse().ok())
+        .unwrap_or(0.0)
 }
 
 async fn issue(
@@ -738,6 +899,7 @@ async fn execute_bulk(
                 r#"mutation Bulk($input: BulkRevokeCertificatesInput!) {
                     bulkRevokeCertificates(input: $input) {
                         complete
+                        snapshotAt
                         nextCursor
                         items { credentialId issuerId entityId tenantId outcome errorCode }
                     }

--- a/tests/m40_pki_lifecycle_automation.rs
+++ b/tests/m40_pki_lifecycle_automation.rs
@@ -169,13 +169,8 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     .await;
     let overdue_authority_tenant =
         common::pki::create_tenant(&pool, "pki-life-overdue-authority").await;
-    let overdue_authority = common::pki::provision_tenant_issuer(
-        &pool,
-        &config,
-        &root,
-        overdue_authority_tenant,
-    )
-    .await;
+    let overdue_authority =
+        common::pki::provision_tenant_issuer(&pool, &config, &root, overdue_authority_tenant).await;
     sqlx::query("UPDATE pki_authorities SET not_after = $2 WHERE id = $1")
         .bind(overdue_authority.id)
         .bind(now - Duration::minutes(1))
@@ -552,11 +547,7 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
 
     // `_in_tx` success is provisional. Rolling the caller-owned transaction
     // back must not publish a successful issuance sample.
-    let before_rollback = lifecycle_metric_value(
-        &metrics::render(&pool),
-        "issuance",
-        "success",
-    );
+    let before_rollback = lifecycle_metric_value(&metrics::render(&pool), "issuance", "success");
     let mut rollback_tx = pool.begin().await.unwrap();
     service::issue_certificate_from_csr_v2_in_tx(
         &mut rollback_tx,
@@ -572,11 +563,7 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     .await
     .unwrap();
     rollback_tx.rollback().await.unwrap();
-    let after_rollback = lifecycle_metric_value(
-        &metrics::render(&pool),
-        "issuance",
-        "success",
-    );
+    let after_rollback = lifecycle_metric_value(&metrics::render(&pool), "issuance", "success");
     assert_eq!(before_rollback, after_rollback);
 
     let rendered = metrics::render(&pool);


### PR DESCRIPTION
## Summary

Closes the remaining post-merge review gaps for PR-014 enrollment and PR-015 lifecycle automation.

- bounds TLS handshakes, connection lifetimes, and shutdown draining while tracking connection tasks
- observes native enrollment failures and removes durable rate-limit rows during entity/tenant purge
- freezes bulk-revocation membership with a database-clock `snapshotAt` carried across UUID pages
- preserves overdue certificate/authority notification claims after expiry
- observes per-item bulk failures through the error path
- records lifecycle success only after the owning transaction commits
- represents absent authority kinds as `NaN` instead of a false zero-second expiry
- updates product/operator documentation and database-backed coverage

## Validation

- API documentation workflow
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- compile and full fresh-database test matrix

Draft while hosted validation runs.