### PR TITLE
[PKI PR-013 follow-up] Make provider mutations rollback safe

### DIFF
--- a/product-docs/development/pki/pr-013-hsm-kms-support.md
+++ b/product-docs/development/pki/pr-013-hsm-kms-support.md
@@ -17,6 +17,18 @@ PR-002 through PR-012 stable interfaces.
 - Key rotation, disable, destroy, backup/recovery policy where provider supports it.
 - Deployment and incident runbooks.
 
+Started persistent provider mutations have a soft deadline: Atom reports that
+the deadline was exceeded but waits for the provider's actual result before it
+returns or retries. Read-only operations retain the hard timeout. Blocking
+provider waits must use the runtime's blocking boundary so they do not pin an
+asynchronous worker.
+
+A generated provider key remains owned by the provisioning operation until the
+authority mutation and its audit event commit. CSR construction, signing,
+database, audit, or outer-transaction failure destroys that key before the
+operation returns; only a successful commit transfers ownership to the stored
+authority row.
+
 ## Non-goals
 
 Multi-cloud abstraction beyond approved providers, generic secrets management, or exposing HSM/KMS controls to tenants.
@@ -33,7 +45,11 @@ Multi-cloud abstraction beyond approved providers, generic secrets management, o
 
 ## Mandatory tests
 
-Provider emulator/SoftHSM signing, wrong key/certificate match, unavailable/throttled provider, timeout/retry idempotency, signer authentication, arbitrary-sign prevention, provider rotation, and recovery runbook exercise.
+Provider emulator/SoftHSM signing, wrong key/certificate match,
+unavailable/throttled provider, timeout/retry idempotency including late
+persistent mutations, async-runtime progress during provider waits,
+outer-transaction rollback cleanup, signer authentication, arbitrary-sign
+prevention, provider rotation, and recovery runbook exercise.
 
 ## AI execution prompt
 

--- a/src/certs/authority/graphql.rs
+++ b/src/certs/authority/graphql.rs
@@ -61,7 +61,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Platform).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome =
+            let mut outcome =
                 provisioning::import_root_mutation_in_tx(&mut tx, &certificate_pem).await?;
             commit_authority_mutation(
                 state,
@@ -75,6 +75,7 @@ impl AuthorityMutation {
                 serde_json::json!({"version": outcome.value.version}),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -101,7 +102,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Tenant(tenant_id)).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = provisioning::begin_tenant_authority_mutation_in_tx(
+            let mut outcome = provisioning::begin_tenant_authority_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
                 tenant_id,
@@ -119,6 +120,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -143,7 +145,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Platform).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = provisioning::begin_platform_leaf_issuer_mutation_in_tx(
+            let mut outcome = provisioning::begin_platform_leaf_issuer_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
             )
@@ -160,6 +162,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -184,7 +187,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Platform).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = provisioning::begin_platform_intermediate_mutation_in_tx(
+            let mut outcome = provisioning::begin_platform_intermediate_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
             )
@@ -201,6 +204,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -231,14 +235,14 @@ impl AuthorityMutation {
             observed_tenant_id = existing.tenant_id;
             require_mutation_access(state, &auth, authority_scope(&existing)).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let mutation = provisioning::import_signed_authority_mutation_in_tx(
+            let mut mutation = provisioning::import_signed_authority_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
                 authority_id,
                 &certificate_pem,
             )
             .await?;
-            let outcome = mutation.value;
+            let outcome = &mutation.value;
             let audit_outcome = if outcome.succeeded() {
                 AuditOutcome::Allow
             } else {
@@ -248,7 +252,7 @@ impl AuthorityMutation {
                 "kind": authority_kind(&outcome.authority),
                 "version": outcome.authority.version,
                 "status": authority_status(&outcome.authority),
-                "replaced_authorities": outcome.replaced_authorities,
+                "replaced_authorities": outcome.replaced_authorities.clone(),
                 "validation_succeeded": outcome.succeeded()
             });
             commit_authority_mutation(
@@ -263,7 +267,8 @@ impl AuthorityMutation {
                 details,
             )
             .await?;
-            Ok(outcome.into())
+            mutation.commit_generated_key();
+            Ok(mutation.value.into())
         }
         .await;
         observe_authority_result(
@@ -303,13 +308,13 @@ impl AuthorityMutation {
             )
             .await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let mutation = provisioning::provision_tenant_automatically_mutation_in_tx(
+            let mut mutation = provisioning::provision_tenant_automatically_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
                 tenant_id,
             )
             .await?;
-            let outcome = mutation.value;
+            let outcome = &mutation.value;
             commit_authority_mutation(
                 state,
                 tx,
@@ -322,11 +327,12 @@ impl AuthorityMutation {
                 serde_json::json!({
                     "kind": authority_kind(&outcome.authority),
                     "version": outcome.authority.version,
-                    "replaced_authorities": outcome.replaced_authorities
+                    "replaced_authorities": outcome.replaced_authorities.clone()
                 }),
             )
             .await?;
-            Ok(outcome.into())
+            mutation.commit_generated_key();
+            Ok(mutation.value.into())
         }
         .await;
         observe_authority_result(
@@ -384,7 +390,7 @@ impl AuthorityMutation {
             observed_tenant_id = existing.tenant_id;
             require_mutation_access(state, &auth, authority_scope(&existing)).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = if complete {
+            let mut outcome = if complete {
                 provisioning::complete_retirement_mutation_in_tx(&mut tx, authority_id).await?
             } else {
                 provisioning::begin_retirement_mutation_in_tx(
@@ -406,6 +412,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;

--- a/src/certs/authority/key_provider/pkcs11.rs
+++ b/src/certs/authority/key_provider/pkcs11.rs
@@ -235,6 +235,35 @@ impl Drop for InFlightGuard {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OperationClass {
+    ReadOnly,
+    Mutating,
+}
+
+fn wait_for_worker<T>(
+    receiver: &mpsc::Receiver<T>,
+    timeout: Duration,
+) -> Result<T, mpsc::RecvTimeoutError> {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(|| receiver.recv_timeout(timeout))
+    } else {
+        receiver.recv_timeout(timeout)
+    }
+}
+
+fn wait_for_worker_completion<T>(receiver: &mpsc::Receiver<T>) -> Result<T, mpsc::RecvError> {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(|| receiver.recv())
+    } else {
+        receiver.recv()
+    }
+}
+
 #[derive(Clone)]
 pub struct Pkcs11KeyProvider {
     config: PkiPkcs11Config,
@@ -271,6 +300,7 @@ impl Pkcs11KeyProvider {
     fn execute<T, F>(
         &self,
         operation: &'static str,
+        class: OperationClass,
         function: F,
     ) -> Result<T, AuthorityKeyProviderError>
     where
@@ -312,8 +342,23 @@ impl Pkcs11KeyProvider {
                     .record_failure(&error, self.config.circuit_failure_threshold);
                 final_result = Err(error);
             } else {
-                final_result = match receiver.recv_timeout(timeout) {
+                final_result = match wait_for_worker(&receiver, timeout) {
                     Ok(result) => result,
+                    Err(mpsc::RecvTimeoutError::Timeout) if class == OperationClass::Mutating => {
+                        // A PKCS#11 worker cannot be cancelled safely once the token has
+                        // accepted a persistent mutation. Keep the mutation's lifecycle
+                        // serialized and observe its real result before returning or
+                        // retrying; otherwise a late generate/destroy could become an
+                        // invisible side effect or race the next attempt.
+                        tracing::warn!(
+                            provider = PROVIDER_NAME,
+                            operation,
+                            "PKCS#11 mutation exceeded its soft deadline; waiting for completion"
+                        );
+                        wait_for_worker_completion(&receiver).unwrap_or(Err(
+                            AuthorityKeyProviderError::ProviderUnavailable,
+                        ))
+                    }
                     Err(mpsc::RecvTimeoutError::Timeout) => {
                         Err(AuthorityKeyProviderError::OperationTimedOut)
                     }
@@ -563,7 +608,9 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         let status = if self.runtime.circuit_open(reset_after) {
             AuthorityKeyProviderStatus::CircuitOpen
         } else {
-            match self.execute("health", |provider| provider.probe_once()) {
+            match self.execute("health", OperationClass::ReadOnly, |provider| {
+                provider.probe_once()
+            }) {
                 Ok(()) => AuthorityKeyProviderStatus::Ready,
                 Err(AuthorityKeyProviderError::CircuitOpen) => {
                     AuthorityKeyProviderStatus::CircuitOpen
@@ -585,7 +632,9 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         if algorithm != AuthorityKeyAlgorithm::EcdsaP256Sha256 {
             return Err(AuthorityKeyProviderError::UnsupportedKeyAlgorithm);
         }
-        let result = self.execute("generate", move |provider| provider.generate_once(context));
+        let result = self.execute("generate", OperationClass::Mutating, move |provider| {
+            provider.generate_once(context)
+        });
         Self::audit_result("generate", context, result)
     }
 
@@ -595,7 +644,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         key: &Self::Key,
     ) -> Result<AuthorityPublicKey, AuthorityKeyProviderError> {
         let key = key.clone();
-        let result = self.execute("public_key", move |provider| {
+        let result = self.execute("public_key", OperationClass::ReadOnly, move |provider| {
             provider.public_key_once(context, &key)
         });
         Self::audit_result("public_key", context, result)
@@ -609,7 +658,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
     ) -> Result<AuthoritySignature, AuthorityKeyProviderError> {
         let key = key.clone();
         let message = message.to_vec();
-        let result = self.execute("sign", move |provider| {
+        let result = self.execute("sign", OperationClass::ReadOnly, move |provider| {
             provider.sign_once(context, &key, &message)
         });
         Self::audit_result("sign", context, result)
@@ -621,7 +670,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         key: &Self::Key,
     ) -> Result<(), AuthorityKeyProviderError> {
         let key = key.clone();
-        let result = self.execute("retire", move |provider| {
+        let result = self.execute("retire", OperationClass::ReadOnly, move |provider| {
             provider.retire_once(context, &key)
         });
         Self::audit_result("retire", context, result)
@@ -633,7 +682,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         key: &mut Self::Key,
     ) -> Result<(), AuthorityKeyProviderError> {
         let owned = key.clone();
-        let result = self.execute("destroy", move |provider| {
+        let result = self.execute("destroy", OperationClass::Mutating, move |provider| {
             provider.destroy_once(context, &owned)
         });
         if result.is_ok() {
@@ -814,7 +863,7 @@ mod tests {
         let provider = Pkcs11KeyProvider::new(executor_config("timeout-throttle"));
         assert_eq!(
             provider
-                .execute("test_timeout", |_| {
+                .execute("test_timeout", OperationClass::ReadOnly, |_| {
                     thread::sleep(Duration::from_millis(100));
                     Ok(())
                 })
@@ -823,7 +872,7 @@ mod tests {
         );
         assert_eq!(
             provider
-                .execute("test_throttle", |_| Ok(()))
+                .execute("test_throttle", OperationClass::ReadOnly, |_| Ok(()))
                 .expect_err("late worker occupies the only slot"),
             AuthorityKeyProviderError::ProviderThrottled
         );
@@ -839,7 +888,7 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let observed = Arc::clone(&calls);
         retry_provider
-            .execute("test_retry", move |_| {
+            .execute("test_retry", OperationClass::ReadOnly, move |_| {
                 if observed.fetch_add(1, Ordering::SeqCst) == 0 {
                     Err(AuthorityKeyProviderError::ProviderUnavailable)
                 } else {
@@ -855,7 +904,7 @@ mod tests {
         let circuit_provider = Pkcs11KeyProvider::new(circuit_config);
         assert_eq!(
             circuit_provider
-                .execute("test_circuit_timeout", |_| {
+                .execute("test_circuit_timeout", OperationClass::ReadOnly, |_| {
                     thread::sleep(Duration::from_millis(100));
                     Ok(())
                 })
@@ -864,10 +913,53 @@ mod tests {
         );
         assert_eq!(
             circuit_provider
-                .execute("test_circuit_open", |_| Ok(()))
+                .execute("test_circuit_open", OperationClass::ReadOnly, |_| Ok(()))
                 .expect_err("circuit is open"),
             AuthorityKeyProviderError::CircuitOpen
         );
         thread::sleep(Duration::from_millis(110));
+    }
+
+    #[test]
+    fn mutating_executor_waits_for_started_operation_before_returning() {
+        let mut config = executor_config("mutating-soft-timeout");
+        config.max_retries = 2;
+        let provider = Pkcs11KeyProvider::new(config);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&calls);
+        let started = Instant::now();
+
+        provider
+            .execute("test_mutation", OperationClass::Mutating, move |_| {
+                observed.fetch_add(1, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(50));
+                Ok(())
+            })
+            .expect("started mutation returns its actual result");
+
+        assert!(started.elapsed() >= Duration::from_millis(50));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn executor_wait_does_not_starve_the_async_runtime() {
+        let mut config = executor_config("runtime-progress");
+        config.operation_timeout_ms = 200;
+        let provider = Pkcs11KeyProvider::new(config);
+        let progressed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = Arc::clone(&progressed);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            observed.store(true, Ordering::SeqCst);
+        });
+
+        provider
+            .execute("test_runtime", OperationClass::ReadOnly, |_| {
+                thread::sleep(Duration::from_millis(50));
+                Ok(())
+            })
+            .expect("worker completes");
+
+        assert!(progressed.load(Ordering::SeqCst));
     }
 }

--- a/src/certs/authority/key_provider/pkcs11.rs
+++ b/src/certs/authority/key_provider/pkcs11.rs
@@ -355,9 +355,8 @@ impl Pkcs11KeyProvider {
                             operation,
                             "PKCS#11 mutation exceeded its soft deadline; waiting for completion"
                         );
-                        wait_for_worker_completion(&receiver).unwrap_or(Err(
-                            AuthorityKeyProviderError::ProviderUnavailable,
-                        ))
+                        wait_for_worker_completion(&receiver)
+                            .unwrap_or(Err(AuthorityKeyProviderError::ProviderUnavailable))
                     }
                     Err(mpsc::RecvTimeoutError::Timeout) => {
                         Err(AuthorityKeyProviderError::OperationTimedOut)

--- a/src/certs/authority/provisioning.rs
+++ b/src/certs/authority/provisioning.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, ops::Deref};
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
@@ -44,6 +44,101 @@ impl AuthorityImportOutcome {
 pub struct AuthorityMutationOutcome<T> {
     pub value: T,
     pub changed: bool,
+    generated_key: Option<GeneratedAuthorityKeyGuard>,
+}
+
+impl<T> AuthorityMutationOutcome<T> {
+    fn unchanged(value: T) -> Self {
+        Self {
+            value,
+            changed: false,
+            generated_key: None,
+        }
+    }
+
+    fn changed(value: T) -> Self {
+        Self {
+            value,
+            changed: true,
+            generated_key: None,
+        }
+    }
+
+    fn with_generated_key(value: T, generated_key: GeneratedAuthorityKeyGuard) -> Self {
+        Self {
+            value,
+            changed: true,
+            generated_key: Some(generated_key),
+        }
+    }
+
+    /// Transfer ownership of a newly generated provider key to the committed
+    /// authority row. Until this is called, dropping the outcome destroys the
+    /// key so a failed or rolled-back transaction cannot orphan token objects.
+    pub fn commit_generated_key(&mut self) {
+        if let Some(mut generated_key) = self.generated_key.take() {
+            generated_key.disarm();
+        }
+    }
+}
+
+impl<T> Deref for AuthorityMutationOutcome<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+#[derive(Debug)]
+struct GeneratedAuthorityKeyGuard {
+    provider: ManagedAuthorityKeyProvider,
+    context: AuthorityKeyContext,
+    key: Option<ManagedAuthorityKey>,
+}
+
+impl GeneratedAuthorityKeyGuard {
+    fn new(
+        provider: ManagedAuthorityKeyProvider,
+        context: AuthorityKeyContext,
+        key: ManagedAuthorityKey,
+    ) -> Self {
+        Self {
+            provider,
+            context,
+            key: Some(key),
+        }
+    }
+
+    fn provider(&self) -> &ManagedAuthorityKeyProvider {
+        &self.provider
+    }
+
+    fn key(&self) -> &ManagedAuthorityKey {
+        self.key
+            .as_ref()
+            .expect("generated authority key guard is armed")
+    }
+
+    fn disarm(&mut self) {
+        self.key = None;
+    }
+}
+
+impl Drop for GeneratedAuthorityKeyGuard {
+    fn drop(&mut self) {
+        let Some(mut key) = self.key.take() else {
+            return;
+        };
+        if let Err(error) = self.provider.destroy(self.context, &mut key) {
+            tracing::error!(
+                provider = ?self.provider.backend(),
+                authority_id = %self.context.authority_id,
+                error = %error,
+                "failed to remove uncommitted authority key"
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,10 +226,7 @@ pub async fn import_root_mutation_in_tx(
 
     if let Some(existing) = repo::authority_by_fingerprint(tx, &parsed.fingerprint_sha256).await? {
         if existing.kind == AuthorityKind::Root {
-            return Ok(AuthorityMutationOutcome {
-                value: existing,
-                changed: false,
-            });
+            return Ok(AuthorityMutationOutcome::unchanged(existing));
         }
         return Err(AppError::conflict(
             "certificate fingerprint already belongs to another authority",
@@ -144,22 +236,15 @@ pub async fn import_root_mutation_in_tx(
     let version = repo::next_authority_version(tx, AuthorityKind::Root, None).await?;
     let completed = completed_authority(&parsed, &parsed.pem);
     let authority = repo::insert_root_authority(tx, Uuid::new_v4(), version, &completed).await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::changed(authority))
 }
 
 pub async fn begin_tenant_authority_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
-) -> Result<AuthorityRecord, AppError> {
-    Ok(
-        begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id)
-            .await?
-            .value,
-    )
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id).await
 }
 
 pub async fn begin_tenant_authority_mutation_in_tx(
@@ -179,10 +264,8 @@ pub async fn begin_tenant_authority_mutation_in_tx(
 pub async fn begin_platform_leaf_issuer_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
-) -> Result<AuthorityRecord, AppError> {
-    Ok(begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys)
-        .await?
-        .value)
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys).await
 }
 
 pub async fn begin_platform_leaf_issuer_mutation_in_tx(
@@ -196,10 +279,8 @@ pub async fn begin_platform_leaf_issuer_mutation_in_tx(
 pub async fn begin_platform_intermediate_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
-) -> Result<AuthorityRecord, AppError> {
-    Ok(begin_platform_intermediate_mutation_in_tx(tx, ca_keys)
-        .await?
-        .value)
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_platform_intermediate_mutation_in_tx(tx, ca_keys).await
 }
 
 pub async fn begin_platform_intermediate_mutation_in_tx(
@@ -222,10 +303,7 @@ async fn begin_offline_authority_mutation_in_tx(
     }
     if let Some(existing) = repo::pending_authority_for_scope(tx, kind, tenant_id).await? {
         if existing.provisioning_mode == "offline" {
-            return Ok(AuthorityMutationOutcome {
-                value: existing,
-                changed: false,
-            });
+            return Ok(AuthorityMutationOutcome::unchanged(existing));
         }
         return Err(AppError::conflict(
             "authority provisioning already exists for this scope",
@@ -234,24 +312,20 @@ async fn begin_offline_authority_mutation_in_tx(
 
     let parent = repo::active_root(tx).await?;
     ensure_parent_available(&parent)?;
-    let authority =
+    let (authority, generated_key) =
         create_pending_authority(tx, ca_keys, kind, tenant_id, &parent, "offline").await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::with_generated_key(
+        authority,
+        generated_key,
+    ))
 }
 
 pub async fn provision_tenant_automatically_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
-) -> Result<AuthorityImportOutcome, AppError> {
-    Ok(
-        provision_tenant_automatically_mutation_in_tx(tx, ca_keys, tenant_id)
-            .await?
-            .value,
-    )
+) -> Result<AuthorityMutationOutcome<AuthorityImportOutcome>, AppError> {
+    provision_tenant_automatically_mutation_in_tx(tx, ca_keys, tenant_id).await
 }
 
 pub async fn provision_tenant_automatically_mutation_in_tx(
@@ -266,14 +340,13 @@ pub async fn provision_tenant_automatically_mutation_in_tx(
         repo::active_authority_for_scope(tx, AuthorityKind::TenantIntermediate, Some(tenant_id))
             .await?
     {
-        return Ok(AuthorityMutationOutcome {
-            value: AuthorityImportOutcome {
+        return Ok(AuthorityMutationOutcome::unchanged(
+            AuthorityImportOutcome {
                 authority: active,
                 validation_error: None,
                 replaced_authorities: Vec::new(),
             },
-            changed: false,
-        });
+        ));
     }
     if let Some(existing) =
         repo::pending_authority_for_scope(tx, AuthorityKind::TenantIntermediate, Some(tenant_id))
@@ -287,7 +360,7 @@ pub async fn provision_tenant_automatically_mutation_in_tx(
 
     let parent = repo::active_platform_intermediate(tx).await?;
     ensure_parent_available(&parent)?;
-    let pending = create_pending_authority(
+    let (pending, generated_key) = create_pending_authority(
         tx,
         ca_keys,
         AuthorityKind::TenantIntermediate,
@@ -298,10 +371,10 @@ pub async fn provision_tenant_automatically_mutation_in_tx(
     .await?;
     let certificate_pem = sign_pending_authority(ca_keys, &pending, &parent)?;
     let outcome = import_signed_authority_locked(tx, ca_keys, pending, &certificate_pem).await?;
-    Ok(AuthorityMutationOutcome {
-        value: outcome,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::with_generated_key(
+        outcome,
+        generated_key,
+    ))
 }
 
 pub async fn import_signed_authority_in_tx(
@@ -327,9 +400,10 @@ pub async fn import_signed_authority_mutation_in_tx(
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
     let was_active = authority.status == AuthorityStatus::Active;
     let outcome = import_signed_authority_locked(tx, ca_keys, authority, certificate_pem).await?;
-    Ok(AuthorityMutationOutcome {
-        value: outcome,
-        changed: !was_active,
+    Ok(if was_active {
+        AuthorityMutationOutcome::unchanged(outcome)
+    } else {
+        AuthorityMutationOutcome::changed(outcome)
     })
 }
 
@@ -457,10 +531,7 @@ pub async fn begin_retirement_mutation_in_tx(
         ));
     }
     if authority.status == AuthorityStatus::Retiring {
-        return Ok(AuthorityMutationOutcome {
-            value: authority,
-            changed: false,
-        });
+        return Ok(AuthorityMutationOutcome::unchanged(authority));
     }
     if authority.status != AuthorityStatus::Active {
         return Err(AppError::conflict("only an active authority can retire"));
@@ -480,10 +551,7 @@ pub async fn begin_retirement_mutation_in_tx(
         AuthorityStatus::Retiring,
     )
     .await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::changed(authority))
 }
 
 pub async fn complete_retirement_in_tx(
@@ -502,10 +570,7 @@ pub async fn complete_retirement_mutation_in_tx(
     repo::lock_provisioning(tx).await?;
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
     if authority.status == AuthorityStatus::Retired {
-        return Ok(AuthorityMutationOutcome {
-            value: authority,
-            changed: false,
-        });
+        return Ok(AuthorityMutationOutcome::unchanged(authority));
     }
     let authority = repo::transition_authority(
         tx,
@@ -514,10 +579,7 @@ pub async fn complete_retirement_mutation_in_tx(
         AuthorityStatus::Retired,
     )
     .await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::changed(authority))
 }
 
 pub async fn trust_bundle(pool: &PgPool) -> Result<TrustBundle, AppError> {
@@ -557,7 +619,7 @@ async fn create_pending_authority(
     tenant_id: Option<Uuid>,
     parent: &AuthorityRecord,
     provisioning_mode: &str,
-) -> Result<AuthorityRecord, AppError> {
+) -> Result<(AuthorityRecord, GeneratedAuthorityKeyGuard), AppError> {
     let version = repo::next_authority_version(tx, kind, tenant_id).await?;
     let authority_id = Uuid::new_v4();
     let context = AuthorityKeyContext {
@@ -570,14 +632,15 @@ async fn create_pending_authority(
     let generated = provider
         .generate(context, AuthorityKeyAlgorithm::EcdsaP256Sha256)
         .map_err(key_provider_error)?;
-    let signing_key = ProviderSigningKey::new(&provider, context, &generated.key)?;
+    let generated_key = GeneratedAuthorityKeyGuard::new(provider, context, generated.key);
+    let signing_key =
+        ProviderSigningKey::new(generated_key.provider(), context, generated_key.key())?;
     let subject = authority_common_name(kind, tenant_id, version)?;
     let params = ca_certificate_params(kind, &subject)?;
     let csr = params
         .serialize_request(&signing_key)
         .map_err(rcgen_error)?;
     let csr_pem = csr.pem().map_err(rcgen_error)?;
-    let mut key = generated.key;
     let inserted = repo::insert_pending_authority(
         tx,
         &repo::PendingAuthorityInsert {
@@ -589,21 +652,11 @@ async fn create_pending_authority(
             subject: &subject,
             csr_pem: &csr_pem,
             provisioning_mode,
-            key: &key,
+            key: generated_key.key(),
         },
     )
-    .await;
-    if inserted.is_err() {
-        if let Err(error) = provider.destroy(context, &mut key) {
-            tracing::error!(
-                provider = ?provider.backend(),
-                authority_id = %authority_id,
-                error = %error,
-                "failed to remove authority key after database insertion failure"
-            );
-        }
-    }
-    inserted
+    .await?;
+    Ok((inserted, generated_key))
 }
 
 fn sign_pending_authority(

--- a/tests/common/pki.rs
+++ b/tests/common/pki.rs
@@ -81,10 +81,11 @@ pub async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, &config.pki_ca_keys)
+    let mut pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, &config.pki_ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported = provisioning::import_signed_authority_in_tx(
@@ -99,7 +100,7 @@ pub async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let provisioned =
+    let mut provisioned =
         provisioning::provision_tenant_automatically_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
             .await
             .unwrap();
@@ -109,6 +110,7 @@ pub async fn provision_tenant_issuer(
         provisioned.validation_error
     );
     tx.commit().await.unwrap();
+    provisioned.commit_generated_key();
     sqlx::query(
         r#"UPDATE pki_authorities
            SET ocsp_url = $2, ca_issuers_url = $3,
@@ -139,10 +141,11 @@ pub async fn provision_platform_leaf_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let pending = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &config.pki_ca_keys)
+    let mut pending = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &config.pki_ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported = provisioning::import_signed_authority_in_tx(
@@ -180,11 +183,12 @@ pub async fn rotate_tenant_issuer(
     tenant_id: Uuid,
 ) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let pending =
+    let mut pending =
         provisioning::begin_tenant_authority_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
             .await
             .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported = provisioning::import_signed_authority_in_tx(

--- a/tests/m30_pki_ca_provisioning.rs
+++ b/tests/m30_pki_ca_provisioning.rs
@@ -507,9 +507,10 @@ async fn provision_automatically(
     tenant_id: Uuid,
 ) -> provisioning::AuthorityImportOutcome {
     let mut tx = pool.begin().await.unwrap();
-    let mut outcome = provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
-        .await
-        .unwrap();
+    let mut outcome =
+        provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
+            .await
+            .unwrap();
     tx.commit().await.unwrap();
     outcome.commit_generated_key();
     outcome.value

--- a/tests/m30_pki_ca_provisioning.rs
+++ b/tests/m30_pki_ca_provisioning.rs
@@ -465,11 +465,12 @@ async fn import_root(pool: &PgPool, pem: &str) -> AuthorityRecord {
 
 async fn begin_tenant(pool: &PgPool, ca_keys: &PkiCaKeyConfig, tenant_id: Uuid) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let authority = provisioning::begin_tenant_authority_in_tx(&mut tx, ca_keys, tenant_id)
+    let mut authority = provisioning::begin_tenant_authority_in_tx(&mut tx, ca_keys, tenant_id)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    authority
+    authority.commit_generated_key();
+    authority.value
 }
 
 async fn begin_tenant_owned(
@@ -482,20 +483,22 @@ async fn begin_tenant_owned(
 
 async fn begin_platform_leaf(pool: &PgPool, ca_keys: &PkiCaKeyConfig) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let authority = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, ca_keys)
+    let mut authority = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    authority
+    authority.commit_generated_key();
+    authority.value
 }
 
 async fn begin_platform_intermediate(pool: &PgPool, ca_keys: &PkiCaKeyConfig) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let authority = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
+    let mut authority = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    authority
+    authority.commit_generated_key();
+    authority.value
 }
 
 async fn provision_automatically(
@@ -504,11 +507,12 @@ async fn provision_automatically(
     tenant_id: Uuid,
 ) -> provisioning::AuthorityImportOutcome {
     let mut tx = pool.begin().await.unwrap();
-    let outcome = provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
+    let mut outcome = provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    outcome
+    outcome.commit_generated_key();
+    outcome.value
 }
 
 async fn import_signed(

--- a/tests/m32_pki_csr_issuance.rs
+++ b/tests/m32_pki_csr_issuance.rs
@@ -540,10 +540,11 @@ async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
+    let mut pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported =
@@ -554,7 +555,7 @@ async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let provisioned =
+    let mut provisioned =
         provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
             .await
             .unwrap();
@@ -564,6 +565,7 @@ async fn provision_tenant_issuer(
         provisioned.validation_error
     );
     tx.commit().await.unwrap();
+    provisioned.commit_generated_key();
     sqlx::query(
         r#"UPDATE pki_authorities
            SET ocsp_url = $2, ca_issuers_url = $3,

--- a/tests/m41_pki_est.rs
+++ b/tests/m41_pki_est.rs
@@ -77,7 +77,7 @@ async fn est_adapter_interoperates_and_enforces_the_pr014b_contract() {
     let issuer = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant).await;
     let other_issuer = {
         let mut tx = pool.begin().await.unwrap();
-        let provisioned = provisioning::provision_tenant_automatically_in_tx(
+        let mut provisioned = provisioning::provision_tenant_automatically_in_tx(
             &mut tx,
             &config.pki_ca_keys,
             other_tenant,
@@ -90,6 +90,7 @@ async fn est_adapter_interoperates_and_enforces_the_pr014b_contract() {
             provisioned.validation_error
         );
         tx.commit().await.unwrap();
+        provisioned.commit_generated_key();
         sqlx::query(
             r#"UPDATE pki_authorities
                SET ocsp_url = $2, ca_issuers_url = $3,

--- a/tests/m42_pki_pkcs11.rs
+++ b/tests/m42_pki_pkcs11.rs
@@ -11,7 +11,8 @@ use atom::{
             key_provider::{
                 validate_startup, AuthorityKeyAlgorithm, AuthorityKeyContext, AuthorityKeyProvider,
                 AuthorityKeyProviderError, AuthorityKeyProviderStatus,
-                EncryptedDatabaseKeyProvider, ManagedAuthorityKeyProvider, Pkcs11KeyProvider,
+                EncryptedDatabaseKeyProvider, ManagedAuthorityKeyProvider, Pkcs11AuthorityKey,
+                Pkcs11KeyProvider,
             },
             provisioning, repo as authority_repo, AuthorityKeyBackend,
         },
@@ -258,16 +259,41 @@ async fn softhsm_enforces_the_pr013_provider_contract() {
         "provider outage cannot corrupt authority lifecycle state"
     );
 
+    // The key is generated before the caller-owned SQL transaction commits.
+    // Rolling that outer transaction back must also remove the token objects;
+    // otherwise retries would accumulate usable keys with no authority row.
+    let mut tx = pool.begin().await.expect("rollback transaction");
+    let rolled_back =
+        provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &app_config.pki_ca_keys)
+            .await
+            .expect("generate rollback candidate");
+    let rolled_back_context = AuthorityKeyContext {
+        authority_id: rolled_back.id,
+        tenant_id: rolled_back.tenant_id,
+        version: rolled_back.version,
+    };
+    let rolled_back_key =
+        Pkcs11AuthorityKey::from_authority(&rolled_back.value).expect("rollback key reference");
+    tx.rollback().await.expect("rollback generated authority");
+    drop(rolled_back);
+    assert_eq!(
+        provider
+            .public_key(rolled_back_context, &rolled_back_key)
+            .expect_err("rolled-back token key must be destroyed"),
+        AuthorityKeyProviderError::KeyNotFound
+    );
+
     let rotated_tenant = common::pki::create_tenant(&pool, "encrypted-rotation").await;
     let mut rotated_keys = app_config.pki_ca_keys.clone();
     rotated_keys.provisioning_backend = PkiCaProvisioningBackend::EncryptedDatabase;
     let mut tx = pool.begin().await.expect("rotation transaction");
-    let rotated =
+    let mut rotated =
         provisioning::provision_tenant_automatically_in_tx(&mut tx, &rotated_keys, rotated_tenant)
             .await
             .expect("cross-provider rotation");
     assert!(rotated.succeeded(), "{:?}", rotated.validation_error);
     tx.commit().await.expect("commit rotated authority");
+    rotated.commit_generated_key();
     assert_eq!(
         rotated.authority.key_backend,
         AuthorityKeyBackend::EncryptedDatabase


### PR DESCRIPTION
## Objective

Close the remaining post-merge review findings on PR-013.

## Changes

- Classify PKCS#11 operations as read-only or persistent mutations.
- Run synchronous provider waits through Tokio's blocking boundary on the production runtime.
- Treat the configured deadline as soft once a persistent generate/destroy mutation has started, observing its actual result before any return or retry.
- Carry an armed generated-key guard through CSR construction, signing, SQL work, audit work, and the caller-owned commit.
- Destroy the generated provider key on every failure or outer transaction rollback; transfer ownership only after a successful database/audit commit.
- Document the ownership and timeout contracts.
- Add executor timing/runtime-progress tests and a SoftHSM outer-rollback cleanup test.

## Review findings addressed

- absmach/atom#67: timed-out PKCS#11 mutations could complete invisibly or overlap a retry.
- absmach/atom#67: synchronous receiver waits could pin Tokio workers.
- absmach/atom#67: generated non-exportable token keys could survive provisioning failures or outer commit rollback.

## Validation

`git diff --check` passes locally. Rust formatting, locked Clippy, compilation, the full fresh-PostgreSQL suite, SoftHSM contract tests, and the recovery runbook run in the hosted workflows.

## Scope

This PR targets `certificates` and contains PR-013 corrective work only.