### PR TITLE
[PKI completion] Close remaining certificate review gaps

### DIFF
--- a/docs/content/docs/authentication/certificates.mdx
+++ b/docs/content/docs/authentication/certificates.mdx
@@ -537,6 +537,9 @@ ATOM_PKI_ENROLLMENT_ENABLED=true
 ATOM_PKI_ENROLLMENT_LISTEN_ADDR=0.0.0.0:8443
 ATOM_PKI_ENROLLMENT_TLS_CERT_PATH=/certs/enrollment-server.crt
 ATOM_PKI_ENROLLMENT_TLS_KEY_PATH=/certs/enrollment-server.key
+ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS=10
+ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS=300
+ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS=30
 ```
 
 The cert/key identify the enrollment server. Client certificates are verified
@@ -550,6 +553,9 @@ The verifier refreshes the database trust bundle every 60 seconds by default,
 so newly provisioned or rotated authorities become eligible without restarting
 Atom. A refresh failure retains the last known-good verifier and emits a
 warning; tune the interval with `ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS`.
+Slow handshakes cannot hold a connection permit indefinitely, established
+connections have a configured lifetime, and shutdown waits for active
+connections only up to the configured drain deadline before aborting them.
 
 Per-entity (10/minute by default) and per-tenant (1000/minute) limits are stored
 atomically in PostgreSQL, so replicas share enforcement. `429` responses include
@@ -626,12 +632,17 @@ before pagination rather than by filtering returned rows.
 `bulkRevokeCertificates` revokes one bounded page selected by exactly one of
 `tenantId`, `issuerId`, or `principalGroupId`. It reports every attempted item
 and returns the last contiguous successful credential as
-`nextCursorCredentialId`. A caller can repair a failed item and resume from that
-cursor; already revoked credentials are not selected again. Bulk issuance and
+`nextCursor`. The first page also returns `snapshotAt`; every request carrying
+`afterCredentialId` must send that same snapshot timestamp. A caller can repair
+a failed item and resume from the cursor without absorbing certificates issued
+between pages; already revoked credentials are not selected again. A new bulk
+operation handles certificates created after the snapshot. Bulk issuance and
 notification delivery remain outside Atom.
 
 Prometheus metrics expose lifecycle operation counts, certificate expiry
 buckets, authority time to expiry, and CRL size and generation duration. Metric
 labels are deliberately bounded to operation, result, status, and time bucket;
 they never carry tenant, entity, credential, issuer, subject, serial, or key
-material.
+material. Operation successes are counted only after commit. If an authority
+kind is absent from the current fleet snapshot, its gauge is `NaN`, not a
+zero-second value that could produce a false expiry alert.

--- a/migrations/015_pki_profile_usage_invariants.sql
+++ b/migrations/015_pki_profile_usage_invariants.sql
@@ -1,0 +1,10 @@
+-- An empty KeyUsage or ExtendedKeyUsage extension is not a restriction. When
+-- rcgen receives an empty list it omits the extension, and relying parties can
+-- interpret the certificate as valid for unrestricted purposes. Every stored
+-- leaf profile must therefore name at least one usage in both categories.
+
+ALTER TABLE certificate_profiles
+    ADD CONSTRAINT chk_certificate_profiles_nonempty_key_usages
+        CHECK (cardinality(key_usages) > 0),
+    ADD CONSTRAINT chk_certificate_profiles_nonempty_extended_key_usages
+        CHECK (cardinality(extended_key_usages) > 0);

--- a/migrations/016_pki_durable_revocation_evidence.sql
+++ b/migrations/016_pki_durable_revocation_evidence.sql
@@ -1,0 +1,133 @@
+-- Revocation publication evidence must outlive the credential and identity
+-- rows that produced it. A still-valid revoked certificate remains revoked
+-- after an explicit entity/tenant purge, and its issuer keeps publishing that
+-- state until the certificate expires.
+
+DROP TRIGGER trg_certificate_revocations_immutable ON certificate_revocations;
+
+ALTER TABLE certificate_revocations
+    ADD COLUMN expires_at TIMESTAMPTZ;
+
+UPDATE certificate_revocations r
+   SET expires_at = COALESCE(c.expires_at, 'infinity'::timestamptz)
+  FROM credentials c
+ WHERE c.id = r.credential_id;
+
+UPDATE certificate_revocations
+   SET expires_at = 'infinity'::timestamptz
+ WHERE expires_at IS NULL;
+
+ALTER TABLE certificate_revocations
+    ALTER COLUMN expires_at SET NOT NULL,
+    DROP CONSTRAINT certificate_revocations_credential_id_fkey;
+
+CREATE UNIQUE INDEX idx_certificate_revocations_issuer_serial
+    ON certificate_revocations(issuer_id, serial_number)
+    WHERE issuer_id IS NOT NULL;
+
+CREATE INDEX idx_certificate_revocations_fingerprint_serial
+    ON certificate_revocations(issuer_fingerprint_sha256, serial_number)
+    WHERE issuer_fingerprint_sha256 IS NOT NULL;
+
+-- PR-009's issuer-keyed state function is retained here with one additional
+-- immutable value: the credential expiry copied at the revocation boundary.
+CREATE OR REPLACE FUNCTION record_certificate_revocation()
+RETURNS trigger AS $$
+DECLARE
+    event_time             TIMESTAMPTZ;
+    event_reason           TEXT;
+    event_actor            UUID;
+    issuer_fingerprint     TEXT;
+    existing_fingerprint   TEXT;
+    existing_issuer        UUID;
+BEGIN
+    IF NEW.kind <> 'certificate' OR NEW.status <> 'revoked' THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD.status = 'revoked' THEN
+        RETURN NEW;
+    END IF;
+
+    event_time := COALESCE((NEW.metadata->>'revoked_at')::timestamptz, now());
+    event_reason := left(
+        COALESCE(NULLIF(btrim(NEW.metadata->>'revocation_reason'), ''), 'unspecified'),
+        128
+    );
+    event_actor := NULLIF(NEW.metadata->>'revoked_by_entity_id', '')::uuid;
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT a.fingerprint_sha256
+          INTO issuer_fingerprint
+          FROM pki_authorities a
+         WHERE a.id = NEW.issuer_id;
+    END IF;
+    issuer_fingerprint := COALESCE(
+        issuer_fingerprint,
+        NULLIF(NEW.metadata->>'issuer_fingerprint_sha256', '')
+    );
+
+    INSERT INTO certificate_revocations (
+        credential_id, issuer_id, issuer_fingerprint_sha256, serial_number,
+        reason, actor_entity_id, revoked_at, expires_at
+    ) VALUES (
+        NEW.id, NEW.issuer_id, issuer_fingerprint, NEW.identifier,
+        event_reason, event_actor, event_time,
+        COALESCE(NEW.expires_at, 'infinity'::timestamptz)
+    )
+    ON CONFLICT (credential_id) DO NOTHING;
+
+    IF issuer_fingerprint IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.issuer_id IS NOT NULL THEN
+        SELECT s.issuer_fingerprint_sha256
+          INTO existing_fingerprint
+          FROM certificate_crl_state s
+         WHERE s.issuer_id = NEW.issuer_id
+         FOR UPDATE;
+        IF FOUND THEN
+            IF existing_fingerprint <> issuer_fingerprint THEN
+                RAISE EXCEPTION 'certificate issuer artifact fingerprint mismatch'
+                    USING ERRCODE = '23514';
+            END IF;
+            UPDATE certificate_crl_state
+               SET dirty = TRUE, updated_at = now()
+             WHERE issuer_id = NEW.issuer_id;
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    SELECT s.issuer_id
+      INTO existing_issuer
+      FROM certificate_crl_state s
+     WHERE s.issuer_fingerprint_sha256 = issuer_fingerprint
+     FOR UPDATE;
+    IF FOUND
+       AND existing_issuer IS NOT NULL
+       AND existing_issuer IS DISTINCT FROM NEW.issuer_id THEN
+        RAISE EXCEPTION 'certificate artifact fingerprint belongs to another issuer'
+            USING ERRCODE = '23514';
+    END IF;
+
+    INSERT INTO certificate_crl_state (
+        issuer_fingerprint_sha256, issuer_id, crl_number, dirty
+    ) VALUES (
+        issuer_fingerprint, NEW.issuer_id, 0, TRUE
+    )
+    ON CONFLICT (issuer_fingerprint_sha256) DO UPDATE
+        SET dirty = TRUE,
+            issuer_id = COALESCE(
+                certificate_crl_state.issuer_id,
+                EXCLUDED.issuer_id
+            ),
+            updated_at = now();
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- The ledger no longer relies on a credential-delete cascade. Reject direct
+-- updates and deletes so revocation cannot disappear before expiry.
+CREATE TRIGGER trg_certificate_revocations_immutable
+    BEFORE UPDATE OR DELETE ON certificate_revocations
+    FOR EACH ROW EXECUTE FUNCTION prevent_certificate_revocation_mutation();

--- a/product-docs/12-certificates.md
+++ b/product-docs/12-certificates.md
@@ -216,7 +216,11 @@ The listener is opt-in with `ATOM_PKI_ENROLLMENT_ENABLED=true` and requires
 `ATOM_PKI_ENROLLMENT_TLS_KEY_PATH`. It binds
 `ATOM_PKI_ENROLLMENT_LISTEN_ADDR` (default `0.0.0.0:8443`). Expired, revoked,
 unknown, or otherwise inactive certificate subjects must recover through first
-enrollment with a still-active non-certificate credential.
+enrollment with a still-active non-certificate credential. TLS handshakes,
+connection lifetimes, and shutdown draining are bounded by
+`ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS`,
+`ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS`, and
+`ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS` respectively.
 
 PR-014b attaches RFC 7030 EST to that same listener and service boundary.
 `/.well-known/est/simpleenroll`, `simplereenroll`, `serverkeygen`, `csrattrs`,
@@ -321,15 +325,21 @@ configured rotation lead time.
 `bulkRevokeCertificates` accepts exactly one tenant, issuer, or principal-group
 selector and processes a bounded page. The result reports each attempted
 credential and a cursor after the last contiguous success, so a caller can fix a
-failure and resume without repeating completed revocations. Every successful
-item retains the normal per-certificate authorization, audit, outbox, immutable
-revocation evidence, and issuer-specific CRL-dirty behavior.
+failure and resume without repeating completed revocations. The first page also
+returns `snapshotAt`; a resumed request must pass it unchanged with
+`afterCredentialId`. This freezes the fleet membership so certificates issued
+between pages are handled by a subsequent operation rather than skipped by UUID
+ordering. Every successful item retains the normal per-certificate
+authorization, audit, outbox, immutable revocation evidence, and issuer-specific
+CRL-dirty behavior.
 
 Lifecycle metrics cover issuance, renewal, revocation, enrollment, expiry
 buckets, authority time to expiry, and CRL size and generation duration. They
 use bounded operational labels and omit identifiers, certificate subjects, key
 material, and other secrets. Disabling the sweeper preserves the existing
-interactive certificate behavior.
+interactive certificate behavior. Success counters are recorded only after the
+owning transaction commits, and an absent authority kind is represented as
+`NaN` rather than a false zero-second expiry.
 
 ---
 

--- a/product-docs/development/pki/pr-013-hsm-kms-support.md
+++ b/product-docs/development/pki/pr-013-hsm-kms-support.md
@@ -17,6 +17,18 @@ PR-002 through PR-012 stable interfaces.
 - Key rotation, disable, destroy, backup/recovery policy where provider supports it.
 - Deployment and incident runbooks.
 
+Started persistent provider mutations have a soft deadline: Atom reports that
+the deadline was exceeded but waits for the provider's actual result before it
+returns or retries. Read-only operations retain the hard timeout. Blocking
+provider waits must use the runtime's blocking boundary so they do not pin an
+asynchronous worker.
+
+A generated provider key remains owned by the provisioning operation until the
+authority mutation and its audit event commit. CSR construction, signing,
+database, audit, or outer-transaction failure destroys that key before the
+operation returns; only a successful commit transfers ownership to the stored
+authority row.
+
 ## Non-goals
 
 Multi-cloud abstraction beyond approved providers, generic secrets management, or exposing HSM/KMS controls to tenants.
@@ -33,7 +45,11 @@ Multi-cloud abstraction beyond approved providers, generic secrets management, o
 
 ## Mandatory tests
 
-Provider emulator/SoftHSM signing, wrong key/certificate match, unavailable/throttled provider, timeout/retry idempotency, signer authentication, arbitrary-sign prevention, provider rotation, and recovery runbook exercise.
+Provider emulator/SoftHSM signing, wrong key/certificate match,
+unavailable/throttled provider, timeout/retry idempotency including late
+persistent mutations, async-runtime progress during provider waits,
+outer-transaction rollback cleanup, signer authentication, arbitrary-sign
+prevention, provider rotation, and recovery runbook exercise.
 
 ## AI execution prompt
 

--- a/product-docs/development/pki/pr-014-enrollment.md
+++ b/product-docs/development/pki/pr-014-enrollment.md
@@ -150,7 +150,11 @@ smuggled in here.
   credential, and that path must exist and be documented.
 - Renewal thresholds come from the profile, not a global constant.
 - The enrollment endpoint is a public network surface taking cryptographic input.
-  Malformed input must fail cheaply and must not allocate unboundedly.
+  Malformed input must fail cheaply and must not allocate unboundedly. TLS
+  handshakes and established connections have deadlines; shutdown tracks and
+  drains connection tasks for a bounded interval.
+- Durable rate-limit windows are removed with entity and tenant purge, so deleted
+  one-time subjects cannot leave unbounded counter rows.
 - The adapter boundary is verified by review, not by intent: a reviewer must be
   able to describe how a second adapter would attach without touching enrollment
   logic.
@@ -170,6 +174,8 @@ smuggled in here.
   the management API for the same entity.
 - Responses carry the renewal threshold from the certificate's profile.
 - Enrollment and re-enrollment are distinguishable in audit and events.
+- Native adapter denials and service failures use the same error-observation path
+  as other certificate transports, including a missing verified peer.
 - Rate limits are enforced and observable.
 - Enrollment logic sits behind an adapter boundary, with no protocol-specific
   behaviour below it and no enrollment behaviour above it.
@@ -182,7 +188,9 @@ header-injection rejection, self-scope violation, expired-certificate
 re-enrollment rejection plus documented recovery, cross-tenant attempts, global
 entity enrollment against the platform leaf issuer, malformed and oversized CSR
 input, rate-limit behaviour, profile application parity with the management API,
-renewal-threshold correctness, and independent verification of the issued chain.
+renewal-threshold correctness, bounded handshake/connection shutdown behaviour,
+purge cleanup for durable counters, error observation, and independent
+verification of the issued chain.
 
 ## AI execution prompt
 

--- a/product-docs/development/pki/pr-015-lifecycle-automation.md
+++ b/product-docs/development/pki/pr-015-lifecycle-automation.md
@@ -48,6 +48,10 @@ presentation belong to whoever consumes them.
   It must not double-emit; coordinate the same way existing periodic work does.
 - Batch operations must not hold a transaction across an unbounded row set, and
   must not open a second pool connection while a transaction is held.
+- A bulk operation freezes candidate membership at its first page. Its snapshot
+  must be returned with the UUID cursor and reused unchanged on resumption.
+- A delayed sweep still claims due windows after a certificate or authority has
+  crossed expiry; transient failures cannot erase an unclaimed notification.
 - Every emitted event carries issuer, credential, entity, and tenant identifiers
   and no secret material.
 - Renewal thresholds come from the certificate's profile, not from a global
@@ -59,10 +63,13 @@ presentation belong to whoever consumes them.
   across restarts and replicas.
 - Expiry listings are authorization-filtered and paginate over large fleets.
 - Bulk revocation reports per-item outcomes and is safely resumable after failure.
+- Certificates issued between bulk pages are excluded from that frozen operation
+  and remain eligible for a later operation.
 - An authority approaching expiry is surfaced with enough lead time to complete
   rotation.
 - Metrics expose the lifecycle state of the fleet without exposing key material or
-  subject secrets.
+  subject secrets. Success is recorded only after commit, and absent authority
+  kinds do not masquerade as zero-second expiries.
 - Disabling automation degrades to current behaviour rather than failing issuance.
 
 ## Mandatory tests
@@ -70,7 +77,9 @@ presentation belong to whoever consumes them.
 Sweeper idempotency across restart and concurrent replicas, event content and
 outbox transactionality, expiry-window boundary conditions, authorization
 filtering on listings, bulk revoke partial failure and resumption, authority
-expiry surfacing, and metric emission without secrets.
+expiry surfacing including overdue retry, frozen bulk-snapshot membership,
+post-commit metric emission, absent-authority semantics, and metric emission
+without secrets.
 
 ## AI execution prompt
 

--- a/src/certs/authority/graphql.rs
+++ b/src/certs/authority/graphql.rs
@@ -61,7 +61,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Platform).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome =
+            let mut outcome =
                 provisioning::import_root_mutation_in_tx(&mut tx, &certificate_pem).await?;
             commit_authority_mutation(
                 state,
@@ -75,6 +75,7 @@ impl AuthorityMutation {
                 serde_json::json!({"version": outcome.value.version}),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -101,7 +102,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Tenant(tenant_id)).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = provisioning::begin_tenant_authority_mutation_in_tx(
+            let mut outcome = provisioning::begin_tenant_authority_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
                 tenant_id,
@@ -119,6 +120,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -143,7 +145,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Platform).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = provisioning::begin_platform_leaf_issuer_mutation_in_tx(
+            let mut outcome = provisioning::begin_platform_leaf_issuer_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
             )
@@ -160,6 +162,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -184,7 +187,7 @@ impl AuthorityMutation {
         let result = async {
             require_mutation_access(state, &auth, Scope::Platform).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = provisioning::begin_platform_intermediate_mutation_in_tx(
+            let mut outcome = provisioning::begin_platform_intermediate_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
             )
@@ -201,6 +204,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;
@@ -231,14 +235,14 @@ impl AuthorityMutation {
             observed_tenant_id = existing.tenant_id;
             require_mutation_access(state, &auth, authority_scope(&existing)).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let mutation = provisioning::import_signed_authority_mutation_in_tx(
+            let mut mutation = provisioning::import_signed_authority_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
                 authority_id,
                 &certificate_pem,
             )
             .await?;
-            let outcome = mutation.value;
+            let outcome = &mutation.value;
             let audit_outcome = if outcome.succeeded() {
                 AuditOutcome::Allow
             } else {
@@ -248,7 +252,7 @@ impl AuthorityMutation {
                 "kind": authority_kind(&outcome.authority),
                 "version": outcome.authority.version,
                 "status": authority_status(&outcome.authority),
-                "replaced_authorities": outcome.replaced_authorities,
+                "replaced_authorities": outcome.replaced_authorities.clone(),
                 "validation_succeeded": outcome.succeeded()
             });
             commit_authority_mutation(
@@ -263,7 +267,8 @@ impl AuthorityMutation {
                 details,
             )
             .await?;
-            Ok(outcome.into())
+            mutation.commit_generated_key();
+            Ok(mutation.value.into())
         }
         .await;
         observe_authority_result(
@@ -303,13 +308,13 @@ impl AuthorityMutation {
             )
             .await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let mutation = provisioning::provision_tenant_automatically_mutation_in_tx(
+            let mut mutation = provisioning::provision_tenant_automatically_mutation_in_tx(
                 &mut tx,
                 &state.config.pki_ca_keys,
                 tenant_id,
             )
             .await?;
-            let outcome = mutation.value;
+            let outcome = &mutation.value;
             commit_authority_mutation(
                 state,
                 tx,
@@ -322,11 +327,12 @@ impl AuthorityMutation {
                 serde_json::json!({
                     "kind": authority_kind(&outcome.authority),
                     "version": outcome.authority.version,
-                    "replaced_authorities": outcome.replaced_authorities
+                    "replaced_authorities": outcome.replaced_authorities.clone()
                 }),
             )
             .await?;
-            Ok(outcome.into())
+            mutation.commit_generated_key();
+            Ok(mutation.value.into())
         }
         .await;
         observe_authority_result(
@@ -384,7 +390,7 @@ impl AuthorityMutation {
             observed_tenant_id = existing.tenant_id;
             require_mutation_access(state, &auth, authority_scope(&existing)).await?;
             let mut tx = state.pool.begin().await.map_err(db_err)?;
-            let outcome = if complete {
+            let mut outcome = if complete {
                 provisioning::complete_retirement_mutation_in_tx(&mut tx, authority_id).await?
             } else {
                 provisioning::begin_retirement_mutation_in_tx(
@@ -406,6 +412,7 @@ impl AuthorityMutation {
                 lifecycle_details(&outcome.value),
             )
             .await?;
+            outcome.commit_generated_key();
             Ok(outcome.value.into())
         }
         .await;

--- a/src/certs/authority/http.rs
+++ b/src/certs/authority/http.rs
@@ -42,7 +42,7 @@ pub async fn trust_bundle(
     Ok((StatusCode::OK, response_headers, bundle.pem).into_response())
 }
 
-fn etag_matches(if_none_match: &str, current: &str) -> bool {
+pub(crate) fn etag_matches(if_none_match: &str, current: &str) -> bool {
     if_none_match.split(',').any(|candidate| {
         let candidate = candidate.trim();
         candidate == "*" || candidate == current || candidate.strip_prefix("W/") == Some(current)

--- a/src/certs/authority/key_provider/pkcs11.rs
+++ b/src/certs/authority/key_provider/pkcs11.rs
@@ -235,6 +235,35 @@ impl Drop for InFlightGuard {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OperationClass {
+    ReadOnly,
+    Mutating,
+}
+
+fn wait_for_worker<T>(
+    receiver: &mpsc::Receiver<T>,
+    timeout: Duration,
+) -> Result<T, mpsc::RecvTimeoutError> {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(|| receiver.recv_timeout(timeout))
+    } else {
+        receiver.recv_timeout(timeout)
+    }
+}
+
+fn wait_for_worker_completion<T>(receiver: &mpsc::Receiver<T>) -> Result<T, mpsc::RecvError> {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(|| receiver.recv())
+    } else {
+        receiver.recv()
+    }
+}
+
 #[derive(Clone)]
 pub struct Pkcs11KeyProvider {
     config: PkiPkcs11Config,
@@ -271,6 +300,7 @@ impl Pkcs11KeyProvider {
     fn execute<T, F>(
         &self,
         operation: &'static str,
+        class: OperationClass,
         function: F,
     ) -> Result<T, AuthorityKeyProviderError>
     where
@@ -312,8 +342,22 @@ impl Pkcs11KeyProvider {
                     .record_failure(&error, self.config.circuit_failure_threshold);
                 final_result = Err(error);
             } else {
-                final_result = match receiver.recv_timeout(timeout) {
+                final_result = match wait_for_worker(&receiver, timeout) {
                     Ok(result) => result,
+                    Err(mpsc::RecvTimeoutError::Timeout) if class == OperationClass::Mutating => {
+                        // A PKCS#11 worker cannot be cancelled safely once the token has
+                        // accepted a persistent mutation. Keep the mutation's lifecycle
+                        // serialized and observe its real result before returning or
+                        // retrying; otherwise a late generate/destroy could become an
+                        // invisible side effect or race the next attempt.
+                        tracing::warn!(
+                            provider = PROVIDER_NAME,
+                            operation,
+                            "PKCS#11 mutation exceeded its soft deadline; waiting for completion"
+                        );
+                        wait_for_worker_completion(&receiver)
+                            .unwrap_or(Err(AuthorityKeyProviderError::ProviderUnavailable))
+                    }
                     Err(mpsc::RecvTimeoutError::Timeout) => {
                         Err(AuthorityKeyProviderError::OperationTimedOut)
                     }
@@ -563,7 +607,9 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         let status = if self.runtime.circuit_open(reset_after) {
             AuthorityKeyProviderStatus::CircuitOpen
         } else {
-            match self.execute("health", |provider| provider.probe_once()) {
+            match self.execute("health", OperationClass::ReadOnly, |provider| {
+                provider.probe_once()
+            }) {
                 Ok(()) => AuthorityKeyProviderStatus::Ready,
                 Err(AuthorityKeyProviderError::CircuitOpen) => {
                     AuthorityKeyProviderStatus::CircuitOpen
@@ -585,7 +631,9 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         if algorithm != AuthorityKeyAlgorithm::EcdsaP256Sha256 {
             return Err(AuthorityKeyProviderError::UnsupportedKeyAlgorithm);
         }
-        let result = self.execute("generate", move |provider| provider.generate_once(context));
+        let result = self.execute("generate", OperationClass::Mutating, move |provider| {
+            provider.generate_once(context)
+        });
         Self::audit_result("generate", context, result)
     }
 
@@ -595,7 +643,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         key: &Self::Key,
     ) -> Result<AuthorityPublicKey, AuthorityKeyProviderError> {
         let key = key.clone();
-        let result = self.execute("public_key", move |provider| {
+        let result = self.execute("public_key", OperationClass::ReadOnly, move |provider| {
             provider.public_key_once(context, &key)
         });
         Self::audit_result("public_key", context, result)
@@ -609,7 +657,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
     ) -> Result<AuthoritySignature, AuthorityKeyProviderError> {
         let key = key.clone();
         let message = message.to_vec();
-        let result = self.execute("sign", move |provider| {
+        let result = self.execute("sign", OperationClass::ReadOnly, move |provider| {
             provider.sign_once(context, &key, &message)
         });
         Self::audit_result("sign", context, result)
@@ -621,7 +669,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         key: &Self::Key,
     ) -> Result<(), AuthorityKeyProviderError> {
         let key = key.clone();
-        let result = self.execute("retire", move |provider| {
+        let result = self.execute("retire", OperationClass::ReadOnly, move |provider| {
             provider.retire_once(context, &key)
         });
         Self::audit_result("retire", context, result)
@@ -633,7 +681,7 @@ impl AuthorityKeyProvider for Pkcs11KeyProvider {
         key: &mut Self::Key,
     ) -> Result<(), AuthorityKeyProviderError> {
         let owned = key.clone();
-        let result = self.execute("destroy", move |provider| {
+        let result = self.execute("destroy", OperationClass::Mutating, move |provider| {
             provider.destroy_once(context, &owned)
         });
         if result.is_ok() {
@@ -814,7 +862,7 @@ mod tests {
         let provider = Pkcs11KeyProvider::new(executor_config("timeout-throttle"));
         assert_eq!(
             provider
-                .execute("test_timeout", |_| {
+                .execute("test_timeout", OperationClass::ReadOnly, |_| {
                     thread::sleep(Duration::from_millis(100));
                     Ok(())
                 })
@@ -823,7 +871,7 @@ mod tests {
         );
         assert_eq!(
             provider
-                .execute("test_throttle", |_| Ok(()))
+                .execute("test_throttle", OperationClass::ReadOnly, |_| Ok(()))
                 .expect_err("late worker occupies the only slot"),
             AuthorityKeyProviderError::ProviderThrottled
         );
@@ -839,7 +887,7 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let observed = Arc::clone(&calls);
         retry_provider
-            .execute("test_retry", move |_| {
+            .execute("test_retry", OperationClass::ReadOnly, move |_| {
                 if observed.fetch_add(1, Ordering::SeqCst) == 0 {
                     Err(AuthorityKeyProviderError::ProviderUnavailable)
                 } else {
@@ -855,7 +903,7 @@ mod tests {
         let circuit_provider = Pkcs11KeyProvider::new(circuit_config);
         assert_eq!(
             circuit_provider
-                .execute("test_circuit_timeout", |_| {
+                .execute("test_circuit_timeout", OperationClass::ReadOnly, |_| {
                     thread::sleep(Duration::from_millis(100));
                     Ok(())
                 })
@@ -864,10 +912,53 @@ mod tests {
         );
         assert_eq!(
             circuit_provider
-                .execute("test_circuit_open", |_| Ok(()))
+                .execute("test_circuit_open", OperationClass::ReadOnly, |_| Ok(()))
                 .expect_err("circuit is open"),
             AuthorityKeyProviderError::CircuitOpen
         );
         thread::sleep(Duration::from_millis(110));
+    }
+
+    #[test]
+    fn mutating_executor_waits_for_started_operation_before_returning() {
+        let mut config = executor_config("mutating-soft-timeout");
+        config.max_retries = 2;
+        let provider = Pkcs11KeyProvider::new(config);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&calls);
+        let started = Instant::now();
+
+        provider
+            .execute("test_mutation", OperationClass::Mutating, move |_| {
+                observed.fetch_add(1, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(50));
+                Ok(())
+            })
+            .expect("started mutation returns its actual result");
+
+        assert!(started.elapsed() >= Duration::from_millis(50));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn executor_wait_does_not_starve_the_async_runtime() {
+        let mut config = executor_config("runtime-progress");
+        config.operation_timeout_ms = 200;
+        let provider = Pkcs11KeyProvider::new(config);
+        let progressed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = Arc::clone(&progressed);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            observed.store(true, Ordering::SeqCst);
+        });
+
+        provider
+            .execute("test_runtime", OperationClass::ReadOnly, |_| {
+                thread::sleep(Duration::from_millis(50));
+                Ok(())
+            })
+            .expect("worker completes");
+
+        assert!(progressed.load(Ordering::SeqCst));
     }
 }

--- a/src/certs/authority/provisioning.rs
+++ b/src/certs/authority/provisioning.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, ops::Deref};
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
@@ -44,6 +44,101 @@ impl AuthorityImportOutcome {
 pub struct AuthorityMutationOutcome<T> {
     pub value: T,
     pub changed: bool,
+    generated_key: Option<GeneratedAuthorityKeyGuard>,
+}
+
+impl<T> AuthorityMutationOutcome<T> {
+    fn unchanged(value: T) -> Self {
+        Self {
+            value,
+            changed: false,
+            generated_key: None,
+        }
+    }
+
+    fn changed(value: T) -> Self {
+        Self {
+            value,
+            changed: true,
+            generated_key: None,
+        }
+    }
+
+    fn with_generated_key(value: T, generated_key: GeneratedAuthorityKeyGuard) -> Self {
+        Self {
+            value,
+            changed: true,
+            generated_key: Some(generated_key),
+        }
+    }
+
+    /// Transfer ownership of a newly generated provider key to the committed
+    /// authority row. Until this is called, dropping the outcome destroys the
+    /// key so a failed or rolled-back transaction cannot orphan token objects.
+    pub fn commit_generated_key(&mut self) {
+        if let Some(mut generated_key) = self.generated_key.take() {
+            generated_key.disarm();
+        }
+    }
+}
+
+impl<T> Deref for AuthorityMutationOutcome<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+#[derive(Debug)]
+struct GeneratedAuthorityKeyGuard {
+    provider: ManagedAuthorityKeyProvider,
+    context: AuthorityKeyContext,
+    key: Option<ManagedAuthorityKey>,
+}
+
+impl GeneratedAuthorityKeyGuard {
+    fn new(
+        provider: ManagedAuthorityKeyProvider,
+        context: AuthorityKeyContext,
+        key: ManagedAuthorityKey,
+    ) -> Self {
+        Self {
+            provider,
+            context,
+            key: Some(key),
+        }
+    }
+
+    fn provider(&self) -> &ManagedAuthorityKeyProvider {
+        &self.provider
+    }
+
+    fn key(&self) -> &ManagedAuthorityKey {
+        self.key
+            .as_ref()
+            .expect("generated authority key guard is armed")
+    }
+
+    fn disarm(&mut self) {
+        self.key = None;
+    }
+}
+
+impl Drop for GeneratedAuthorityKeyGuard {
+    fn drop(&mut self) {
+        let Some(mut key) = self.key.take() else {
+            return;
+        };
+        if let Err(error) = self.provider.destroy(self.context, &mut key) {
+            tracing::error!(
+                provider = ?self.provider.backend(),
+                authority_id = %self.context.authority_id,
+                error = %error,
+                "failed to remove uncommitted authority key"
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,6 +161,7 @@ struct ParsedAuthorityCertificate {
     not_before: DateTime<Utc>,
     not_after: DateTime<Utc>,
     path_len_constraint: Option<u32>,
+    digital_signature: bool,
 }
 
 struct ProviderSigningKey<'a> {
@@ -131,10 +227,7 @@ pub async fn import_root_mutation_in_tx(
 
     if let Some(existing) = repo::authority_by_fingerprint(tx, &parsed.fingerprint_sha256).await? {
         if existing.kind == AuthorityKind::Root {
-            return Ok(AuthorityMutationOutcome {
-                value: existing,
-                changed: false,
-            });
+            return Ok(AuthorityMutationOutcome::unchanged(existing));
         }
         return Err(AppError::conflict(
             "certificate fingerprint already belongs to another authority",
@@ -144,22 +237,15 @@ pub async fn import_root_mutation_in_tx(
     let version = repo::next_authority_version(tx, AuthorityKind::Root, None).await?;
     let completed = completed_authority(&parsed, &parsed.pem);
     let authority = repo::insert_root_authority(tx, Uuid::new_v4(), version, &completed).await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::changed(authority))
 }
 
 pub async fn begin_tenant_authority_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
-) -> Result<AuthorityRecord, AppError> {
-    Ok(
-        begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id)
-            .await?
-            .value,
-    )
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_tenant_authority_mutation_in_tx(tx, ca_keys, tenant_id).await
 }
 
 pub async fn begin_tenant_authority_mutation_in_tx(
@@ -179,10 +265,8 @@ pub async fn begin_tenant_authority_mutation_in_tx(
 pub async fn begin_platform_leaf_issuer_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
-) -> Result<AuthorityRecord, AppError> {
-    Ok(begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys)
-        .await?
-        .value)
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_platform_leaf_issuer_mutation_in_tx(tx, ca_keys).await
 }
 
 pub async fn begin_platform_leaf_issuer_mutation_in_tx(
@@ -196,10 +280,8 @@ pub async fn begin_platform_leaf_issuer_mutation_in_tx(
 pub async fn begin_platform_intermediate_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
-) -> Result<AuthorityRecord, AppError> {
-    Ok(begin_platform_intermediate_mutation_in_tx(tx, ca_keys)
-        .await?
-        .value)
+) -> Result<AuthorityMutationOutcome<AuthorityRecord>, AppError> {
+    begin_platform_intermediate_mutation_in_tx(tx, ca_keys).await
 }
 
 pub async fn begin_platform_intermediate_mutation_in_tx(
@@ -222,10 +304,7 @@ async fn begin_offline_authority_mutation_in_tx(
     }
     if let Some(existing) = repo::pending_authority_for_scope(tx, kind, tenant_id).await? {
         if existing.provisioning_mode == "offline" {
-            return Ok(AuthorityMutationOutcome {
-                value: existing,
-                changed: false,
-            });
+            return Ok(AuthorityMutationOutcome::unchanged(existing));
         }
         return Err(AppError::conflict(
             "authority provisioning already exists for this scope",
@@ -234,24 +313,20 @@ async fn begin_offline_authority_mutation_in_tx(
 
     let parent = repo::active_root(tx).await?;
     ensure_parent_available(&parent)?;
-    let authority =
+    let (authority, generated_key) =
         create_pending_authority(tx, ca_keys, kind, tenant_id, &parent, "offline").await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::with_generated_key(
+        authority,
+        generated_key,
+    ))
 }
 
 pub async fn provision_tenant_automatically_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     ca_keys: &PkiCaKeyConfig,
     tenant_id: Uuid,
-) -> Result<AuthorityImportOutcome, AppError> {
-    Ok(
-        provision_tenant_automatically_mutation_in_tx(tx, ca_keys, tenant_id)
-            .await?
-            .value,
-    )
+) -> Result<AuthorityMutationOutcome<AuthorityImportOutcome>, AppError> {
+    provision_tenant_automatically_mutation_in_tx(tx, ca_keys, tenant_id).await
 }
 
 pub async fn provision_tenant_automatically_mutation_in_tx(
@@ -266,14 +341,13 @@ pub async fn provision_tenant_automatically_mutation_in_tx(
         repo::active_authority_for_scope(tx, AuthorityKind::TenantIntermediate, Some(tenant_id))
             .await?
     {
-        return Ok(AuthorityMutationOutcome {
-            value: AuthorityImportOutcome {
+        return Ok(AuthorityMutationOutcome::unchanged(
+            AuthorityImportOutcome {
                 authority: active,
                 validation_error: None,
                 replaced_authorities: Vec::new(),
             },
-            changed: false,
-        });
+        ));
     }
     if let Some(existing) =
         repo::pending_authority_for_scope(tx, AuthorityKind::TenantIntermediate, Some(tenant_id))
@@ -287,7 +361,7 @@ pub async fn provision_tenant_automatically_mutation_in_tx(
 
     let parent = repo::active_platform_intermediate(tx).await?;
     ensure_parent_available(&parent)?;
-    let pending = create_pending_authority(
+    let (pending, generated_key) = create_pending_authority(
         tx,
         ca_keys,
         AuthorityKind::TenantIntermediate,
@@ -298,10 +372,10 @@ pub async fn provision_tenant_automatically_mutation_in_tx(
     .await?;
     let certificate_pem = sign_pending_authority(ca_keys, &pending, &parent)?;
     let outcome = import_signed_authority_locked(tx, ca_keys, pending, &certificate_pem).await?;
-    Ok(AuthorityMutationOutcome {
-        value: outcome,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::with_generated_key(
+        outcome,
+        generated_key,
+    ))
 }
 
 pub async fn import_signed_authority_in_tx(
@@ -327,9 +401,10 @@ pub async fn import_signed_authority_mutation_in_tx(
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
     let was_active = authority.status == AuthorityStatus::Active;
     let outcome = import_signed_authority_locked(tx, ca_keys, authority, certificate_pem).await?;
-    Ok(AuthorityMutationOutcome {
-        value: outcome,
-        changed: !was_active,
+    Ok(if was_active {
+        AuthorityMutationOutcome::unchanged(outcome)
+    } else {
+        AuthorityMutationOutcome::changed(outcome)
     })
 }
 
@@ -457,10 +532,7 @@ pub async fn begin_retirement_mutation_in_tx(
         ));
     }
     if authority.status == AuthorityStatus::Retiring {
-        return Ok(AuthorityMutationOutcome {
-            value: authority,
-            changed: false,
-        });
+        return Ok(AuthorityMutationOutcome::unchanged(authority));
     }
     if authority.status != AuthorityStatus::Active {
         return Err(AppError::conflict("only an active authority can retire"));
@@ -480,10 +552,7 @@ pub async fn begin_retirement_mutation_in_tx(
         AuthorityStatus::Retiring,
     )
     .await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::changed(authority))
 }
 
 pub async fn complete_retirement_in_tx(
@@ -502,10 +571,7 @@ pub async fn complete_retirement_mutation_in_tx(
     repo::lock_provisioning(tx).await?;
     let authority = repo::authority_by_id_for_update(tx, authority_id).await?;
     if authority.status == AuthorityStatus::Retired {
-        return Ok(AuthorityMutationOutcome {
-            value: authority,
-            changed: false,
-        });
+        return Ok(AuthorityMutationOutcome::unchanged(authority));
     }
     let authority = repo::transition_authority(
         tx,
@@ -514,10 +580,7 @@ pub async fn complete_retirement_mutation_in_tx(
         AuthorityStatus::Retired,
     )
     .await?;
-    Ok(AuthorityMutationOutcome {
-        value: authority,
-        changed: true,
-    })
+    Ok(AuthorityMutationOutcome::changed(authority))
 }
 
 pub async fn trust_bundle(pool: &PgPool) -> Result<TrustBundle, AppError> {
@@ -557,7 +620,7 @@ async fn create_pending_authority(
     tenant_id: Option<Uuid>,
     parent: &AuthorityRecord,
     provisioning_mode: &str,
-) -> Result<AuthorityRecord, AppError> {
+) -> Result<(AuthorityRecord, GeneratedAuthorityKeyGuard), AppError> {
     let version = repo::next_authority_version(tx, kind, tenant_id).await?;
     let authority_id = Uuid::new_v4();
     let context = AuthorityKeyContext {
@@ -570,14 +633,15 @@ async fn create_pending_authority(
     let generated = provider
         .generate(context, AuthorityKeyAlgorithm::EcdsaP256Sha256)
         .map_err(key_provider_error)?;
-    let signing_key = ProviderSigningKey::new(&provider, context, &generated.key)?;
+    let generated_key = GeneratedAuthorityKeyGuard::new(provider, context, generated.key);
+    let signing_key =
+        ProviderSigningKey::new(generated_key.provider(), context, generated_key.key())?;
     let subject = authority_common_name(kind, tenant_id, version)?;
     let params = ca_certificate_params(kind, &subject)?;
     let csr = params
         .serialize_request(&signing_key)
         .map_err(rcgen_error)?;
     let csr_pem = csr.pem().map_err(rcgen_error)?;
-    let mut key = generated.key;
     let inserted = repo::insert_pending_authority(
         tx,
         &repo::PendingAuthorityInsert {
@@ -589,21 +653,11 @@ async fn create_pending_authority(
             subject: &subject,
             csr_pem: &csr_pem,
             provisioning_mode,
-            key: &key,
+            key: generated_key.key(),
         },
     )
-    .await;
-    if inserted.is_err() {
-        if let Err(error) = provider.destroy(context, &mut key) {
-            tracing::error!(
-                provider = ?provider.backend(),
-                authority_id = %authority_id,
-                error = %error,
-                "failed to remove authority key after database insertion failure"
-            );
-        }
-    }
-    inserted
+    .await?;
+    Ok((inserted, generated_key))
 }
 
 fn sign_pending_authority(
@@ -760,6 +814,11 @@ fn validate_ca_shape(
     if certificate.not_after <= now {
         return Err(AppError::bad_request("authority certificate is expired"));
     }
+    if kind.can_issue_leaf_credentials() && !certificate.digital_signature {
+        return Err(AppError::bad_request(
+            "leaf-issuing authority key usage must include digitalSignature",
+        ));
+    }
     match kind {
         AuthorityKind::TenantIntermediate | AuthorityKind::PlatformLeafIssuer
             if certificate.path_len_constraint != Some(0) =>
@@ -886,6 +945,7 @@ fn parse_authority_certificate(
         not_before,
         not_after,
         path_len_constraint: basic.value.path_len_constraint,
+        digital_signature: usage.value.digital_signature(),
     })
 }
 
@@ -924,6 +984,9 @@ fn ca_certificate_params(
     };
     params.is_ca = IsCa::Ca(BasicConstraints::Constrained(path_len));
     params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    if kind.can_issue_leaf_credentials() {
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    }
     params.key_identifier_method = KeyIdMethod::Sha256;
     Ok(params)
 }
@@ -1043,7 +1106,11 @@ mod tests {
             .distinguished_name
             .push(DnType::CommonName, common_name);
         params.is_ca = IsCa::Ca(BasicConstraints::Constrained(path_len));
-        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
         params.key_identifier_method = KeyIdMethod::Sha256;
         params.not_before = OffsetDateTime::now_utc() - Duration::minutes(1);
         params.not_after = OffsetDateTime::now_utc() + Duration::days(30);

--- a/src/certs/enrollment/http.rs
+++ b/src/certs/enrollment/http.rs
@@ -8,7 +8,7 @@ use axum::{
 use serde::Deserialize;
 use tower_http::trace::TraceLayer;
 
-use crate::{auth::AuthContext, error::AppError, state::AppState};
+use crate::{audit, auth::AuthContext, error::AppError, state::AppState};
 
 use super::{
     est,
@@ -62,9 +62,24 @@ async fn first_enrollment(
     auth: AuthContext,
     Json(request): Json<NativeEnrollmentRequest>,
 ) -> Result<Json<EnrollmentResponse>, AppError> {
-    service::enroll(&state, auth, request.into())
-        .await
-        .map(Json)
+    let result = service::enroll(&state, auth.clone(), request.into()).await;
+    if let Err(ref error) = result {
+        audit::observe_error(
+            &state.pool,
+            state.config.events.enabled(),
+            &audit::AuditMeta {
+                actor_entity_id: Some(auth.entity_id),
+                tenant_id: auth.tenant_id,
+                target_kind: "credential",
+                target_id: None,
+                event: "certificate.enroll",
+            },
+            &serde_json::json!({"mode": "first", "transport": "native"}),
+            error,
+        )
+        .await;
+    }
+    result.map(Json)
 }
 
 async fn re_enrollment(
@@ -72,10 +87,43 @@ async fn re_enrollment(
     peer: Option<Extension<VerifiedPeerCertificate>>,
     Json(request): Json<NativeEnrollmentRequest>,
 ) -> Result<Json<EnrollmentResponse>, AppError> {
-    let peer = peer
-        .map(|Extension(peer)| peer)
-        .ok_or_else(|| AppError::unauthorized("a verified client certificate is required"))?;
-    service::re_enroll(&state, peer, request.into())
-        .await
-        .map(Json)
+    let peer = match peer.map(|Extension(peer)| peer) {
+        Some(peer) => peer,
+        None => {
+            let error = AppError::unauthorized("a verified client certificate is required");
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &audit::AuditMeta {
+                    actor_entity_id: None,
+                    tenant_id: None,
+                    target_kind: "credential",
+                    target_id: None,
+                    event: "certificate.reenroll",
+                },
+                &serde_json::json!({"mode": "reenroll", "transport": "native"}),
+                &error,
+            )
+            .await;
+            return Err(error);
+        }
+    };
+    let result = service::re_enroll(&state, peer, request.into()).await;
+    if let Err(ref error) = result {
+        audit::observe_error(
+            &state.pool,
+            state.config.events.enabled(),
+            &audit::AuditMeta {
+                actor_entity_id: None,
+                tenant_id: None,
+                target_kind: "credential",
+                target_id: None,
+                event: "certificate.reenroll",
+            },
+            &serde_json::json!({"mode": "reenroll", "transport": "native"}),
+            error,
+        )
+        .await;
+    }
+    result.map(Json)
 }

--- a/src/certs/enrollment/service.rs
+++ b/src/certs/enrollment/service.rs
@@ -361,12 +361,23 @@ async fn commit_with_mode_audit(
         outcome: AuditOutcome::Allow,
         details,
     };
+    let operation = if event == "certificate.reenroll" {
+        "renewal"
+    } else {
+        "issuance"
+    };
     if replay {
-        tx.commit().await.map_err(AppError::Database)?;
+        let commit = tx.commit().await.map_err(AppError::Database);
+        certificates::record_lifecycle_commit(operation, &commit);
+        commit?;
         audit::write(&state.pool, false, audit_event).await;
         Ok(())
     } else {
-        audit::commit_with_audit(&state.pool, tx, state.config.events.enabled(), &audit_event).await
+        let commit =
+            audit::commit_with_audit(&state.pool, tx, state.config.events.enabled(), &audit_event)
+                .await;
+        certificates::record_lifecycle_commit(operation, &commit);
+        commit
     }
 }
 

--- a/src/certs/enrollment/tls.rs
+++ b/src/certs/enrollment/tls.rs
@@ -1,6 +1,6 @@
 //! In-process TLS termination for the public enrollment listener.
 
-use std::{io::Cursor, net::SocketAddr, sync::Arc};
+use std::{io::Cursor, net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use hyper_util::{
@@ -9,7 +9,7 @@ use hyper_util::{
     service::TowerToHyperService,
 };
 use rustls::{server::WebPkiClientVerifier, RootCertStore, ServerConfig};
-use tokio::{net::TcpListener, sync::Semaphore};
+use tokio::{net::TcpListener, sync::Semaphore, task::JoinSet, time::timeout};
 use tokio_rustls::TlsAcceptor;
 
 use crate::{certs::authority::provisioning, config::EnrollmentTlsConfig, state::AppState};
@@ -29,6 +29,9 @@ pub struct PreparedEnrollmentServer {
     listener: TcpListener,
     acceptor: TlsAcceptor,
     max_connections: usize,
+    tls_handshake_timeout: Duration,
+    connection_timeout: Duration,
+    shutdown_drain_timeout: Duration,
 }
 
 impl PreparedEnrollmentServer {
@@ -65,17 +68,28 @@ pub async fn prepare(state: &AppState) -> Result<Option<PreparedEnrollmentServer
         listener,
         acceptor: TlsAcceptor::from(Arc::new(server_config)),
         max_connections: state.config.enrollment.max_connections,
+        tls_handshake_timeout: Duration::from_secs(
+            state.config.enrollment.tls_handshake_timeout_secs,
+        ),
+        connection_timeout: Duration::from_secs(state.config.enrollment.connection_timeout_secs),
+        shutdown_drain_timeout: Duration::from_secs(
+            state.config.enrollment.shutdown_drain_timeout_secs,
+        ),
     }))
 }
 
 pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Result<()> {
     let address = prepared.local_addr()?;
     let permits = Arc::new(Semaphore::new(prepared.max_connections));
+    let handshake_timeout = prepared.tls_handshake_timeout;
+    let connection_timeout = prepared.connection_timeout;
+    let shutdown_drain_timeout = prepared.shutdown_drain_timeout;
     let refresh_secs = state.config.enrollment.trust_bundle_refresh_secs;
     let refresh_state = state.clone();
     let router = http::create_router(state);
     let mut acceptor = prepared.acceptor;
     let mut trust_refresh = tokio::time::interval(std::time::Duration::from_secs(refresh_secs));
+    let mut connections = JoinSet::new();
     trust_refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     trust_refresh.tick().await;
     tracing::info!(%address, "PKI enrollment listener ready (in-process optional mTLS)");
@@ -99,6 +113,12 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
                 continue;
             },
             _ = crate::shutdown::shutdown_signal() => break,
+            joined = connections.join_next(), if !connections.is_empty() => {
+                if let Some(Err(error)) = joined {
+                    tracing::warn!(%error, "enrollment connection task failed");
+                }
+                continue;
+            },
         };
         let (stream, remote_addr) = match accepted {
             Ok(value) => value,
@@ -116,12 +136,16 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
         };
         let acceptor = acceptor.clone();
         let router = router.clone();
-        tokio::spawn(async move {
+        connections.spawn(async move {
             let _permit = permit;
-            let stream = match acceptor.accept(stream).await {
-                Ok(stream) => stream,
-                Err(error) => {
+            let stream = match timeout(handshake_timeout, acceptor.accept(stream)).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(error)) => {
                     tracing::warn!(%remote_addr, %error, "enrollment TLS handshake rejected");
+                    return;
+                }
+                Err(_) => {
+                    tracing::warn!(%remote_addr, "enrollment TLS handshake timed out");
                     return;
                 }
             };
@@ -139,13 +163,40 @@ pub async fn serve(prepared: PreparedEnrollmentServer, state: AppState) -> Resul
             };
             let service = TowerToHyperService::new(connection_router);
             let builder = Builder::new(TokioExecutor::new());
-            if let Err(error) = builder
-                .serve_connection(TokioIo::new(stream), service)
-                .await
+            match timeout(
+                connection_timeout,
+                builder.serve_connection(TokioIo::new(stream), service),
+            )
+            .await
             {
-                tracing::debug!(%remote_addr, %error, "enrollment connection closed with error");
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::debug!(%remote_addr, %error, "enrollment connection closed with error");
+                }
+                Err(_) => {
+                    tracing::warn!(%remote_addr, "enrollment connection deadline reached");
+                }
             }
         });
+    }
+
+    if timeout(shutdown_drain_timeout, async {
+        while let Some(joined) = connections.join_next().await {
+            if let Err(error) = joined {
+                tracing::warn!(%error, "enrollment connection task failed during shutdown");
+            }
+        }
+    })
+    .await
+    .is_err()
+    {
+        let remaining = connections.len();
+        connections.abort_all();
+        while connections.join_next().await.is_some() {}
+        tracing::warn!(
+            remaining,
+            "aborted enrollment connections after shutdown drain deadline"
+        );
     }
     tracing::info!(%address, "PKI enrollment listener stopped");
     Ok(())

--- a/src/certs/graphql.rs
+++ b/src/certs/graphql.rs
@@ -6,7 +6,7 @@ use crate::{
     audit,
     auth::{has_capability_in_scope, AuthContext, Scope},
     certs::{lifecycle, service},
-    error::db_err,
+    error::{db_err, AppError},
     models::enums::AuditOutcome,
     state::AppState,
 };
@@ -116,6 +116,34 @@ fn parse_timestamp(value: &str, field: &str) -> Result<DateTime<Utc>> {
         .map_err(|_| async_graphql::Error::new(format!("{field} must be an RFC3339 timestamp")))
 }
 
+async fn commit_with_lifecycle_audit(
+    pool: &sqlx::PgPool,
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    events_enabled: bool,
+    event: &audit::AuditEvent<'_>,
+) -> std::result::Result<(), AppError> {
+    let result = audit::commit_with_audit(pool, tx, events_enabled, event).await;
+    let operation = match event.event {
+        "certificate.issue" => Some("issuance"),
+        "certificate.renew" => Some("renewal"),
+        "certificate.revoke" | "certificate.revoke_entity" => Some("revocation"),
+        _ => None,
+    };
+    if let Some(operation) = operation {
+        service::record_lifecycle_commit(operation, &result);
+    }
+    result
+}
+
+async fn commit_lifecycle_replay(
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    operation: &'static str,
+) -> std::result::Result<(), AppError> {
+    let result = tx.commit().await.map_err(AppError::Database);
+    service::record_lifecycle_commit(operation, &result);
+    result
+}
+
 #[derive(Default)]
 pub struct CertificateMutation;
 
@@ -145,7 +173,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -179,8 +207,35 @@ impl CertificateMutation {
         let state = ctx.data::<AppState>()?;
         let entity_id = parse_id(input.entity_id, "entityId")?;
         let tenant_id = require_credential_management(state, &auth, entity_id).await?;
-        let mut tx = state.pool.begin().await.map_err(|e| gql_error(db_err(e)))?;
-        let issued = service::issue_generated_certificate_v2_in_tx(
+        let error_meta = audit::AuditMeta {
+            actor_entity_id: Some(auth.entity_id),
+            tenant_id,
+            target_kind: "entity",
+            target_id: Some(entity_id),
+            event: "certificate.issue",
+        };
+        let error_details = serde_json::json!({
+            "csr": false,
+            "generated_key": true,
+            "managed": true,
+            "transport": "graphql",
+        });
+        let mut tx = match state.pool.begin().await {
+            Ok(tx) => tx,
+            Err(error) => {
+                let error = db_err(error);
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
+        let issued = match service::issue_generated_certificate_v2_in_tx(
             &mut tx,
             &state.config,
             tenant_id,
@@ -190,8 +245,26 @@ impl CertificateMutation {
             },
         )
         .await
-        .map_err(gql_error)?;
-        audit::commit_with_audit(
+        {
+            Ok(issued) => issued,
+            Err(error) => {
+                if let Err(rollback_error) = tx.rollback().await {
+                    tracing::warn!(
+                        "failed to roll back generated certificate issuance: {rollback_error}"
+                    );
+                }
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
+        if let Err(error) = commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -214,7 +287,17 @@ impl CertificateMutation {
             },
         )
         .await
-        .map_err(gql_error)?;
+        {
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
         Ok(issued.into())
     }
 
@@ -240,7 +323,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -274,12 +357,34 @@ impl CertificateMutation {
         let state = ctx.data::<AppState>()?;
         let entity_id = parse_id(input.entity_id, "entityId")?;
         let tenant_id = require_credential_management(state, &auth, entity_id).await?;
-        let mut tx = state
-            .pool
-            .begin()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
-        let issued = service::issue_certificate_from_csr_v2_in_tx(
+        let error_meta = audit::AuditMeta {
+            actor_entity_id: Some(auth.entity_id),
+            tenant_id,
+            target_kind: "entity",
+            target_id: Some(entity_id),
+            event: "certificate.issue",
+        };
+        let error_details = serde_json::json!({
+            "csr": true,
+            "managed": true,
+            "transport": "graphql",
+        });
+        let mut tx = match state.pool.begin().await {
+            Ok(tx) => tx,
+            Err(error) => {
+                let error = db_err(error);
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
+        let issued = match service::issue_certificate_from_csr_v2_in_tx(
             &mut tx,
             &state.config,
             tenant_id,
@@ -291,7 +396,25 @@ impl CertificateMutation {
             },
         )
         .await
-        .map_err(gql_error)?;
+        {
+            Ok(issued) => issued,
+            Err(error) => {
+                if let Err(rollback_error) = tx.rollback().await {
+                    tracing::warn!(
+                        "failed to roll back CSR certificate issuance: {rollback_error}"
+                    );
+                }
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
+        };
         let details = serde_json::json!({
             "credential_id": issued.certificate.credential_id,
             "serial_number": issued.certificate.serial_number,
@@ -302,9 +425,17 @@ impl CertificateMutation {
             "replay": issued.idempotent_replay,
         });
         if issued.idempotent_replay {
-            tx.commit()
-                .await
-                .map_err(|error| gql_error(db_err(error)))?;
+            if let Err(error) = commit_lifecycle_replay(tx, "issuance").await {
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
             audit::write(
                 &state.pool,
                 false,
@@ -320,7 +451,7 @@ impl CertificateMutation {
             )
             .await;
         } else {
-            audit::commit_with_audit(
+            if let Err(error) = commit_with_lifecycle_audit(
                 &state.pool,
                 tx,
                 state.config.events.enabled(),
@@ -335,7 +466,17 @@ impl CertificateMutation {
                 },
             )
             .await
-            .map_err(gql_error)?;
+            {
+                audit::observe_error(
+                    &state.pool,
+                    state.config.events.enabled(),
+                    &error_meta,
+                    &error_details,
+                    &error,
+                )
+                .await;
+                return Err(gql_error(error));
+            }
         }
         Ok(issued.into())
     }
@@ -364,7 +505,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -500,7 +641,7 @@ impl CertificateMutation {
         )
         .await
         .map_err(gql_error)?;
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -558,12 +699,18 @@ impl CertificateMutation {
             .after_credential_id
             .map(|id| parse_id(id, "afterCredentialId"))
             .transpose()?;
+        let snapshot_at = input
+            .snapshot_at
+            .as_deref()
+            .map(|value| parse_timestamp(value, "snapshotAt"))
+            .transpose()?;
         lifecycle::bulk_revoke(
             state,
             selector,
             auth.entity_id,
             input.reason,
             after,
+            snapshot_at,
             input.limit.unwrap_or(100),
         )
         .await
@@ -609,9 +756,9 @@ async fn revoke_certificate_exact(
         "idempotent_replay": revoked.idempotent_replay,
     });
     if revoked.idempotent_replay {
-        tx.commit()
+        commit_lifecycle_replay(tx, "revocation")
             .await
-            .map_err(|error| gql_error(db_err(error)))?;
+            .map_err(gql_error)?;
         audit::write(
             &state.pool,
             false,
@@ -627,7 +774,7 @@ async fn revoke_certificate_exact(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -662,12 +809,35 @@ async fn renew_certificate_v2(
         .map_err(gql_error)?;
     require_certificate_rotate(state, &auth, &old).await?;
     let key_mode = key_source.mode();
-    let mut tx = state
-        .pool
-        .begin()
-        .await
-        .map_err(|error| gql_error(db_err(error)))?;
-    let issued = service::renew_certificate_v2_in_tx(
+    let error_meta = audit::AuditMeta {
+        actor_entity_id: Some(auth.entity_id),
+        tenant_id: old.tenant_id,
+        target_kind: "credential",
+        target_id: Some(old.credential_id),
+        event: "certificate.renew",
+    };
+    let error_details = serde_json::json!({
+        "key_mode": key_mode,
+        "revoke_old": revoke_old,
+        "managed": true,
+        "transport": "graphql",
+    });
+    let mut tx = match state.pool.begin().await {
+        Ok(tx) => tx,
+        Err(error) => {
+            let error = db_err(error);
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
+    };
+    let issued = match service::renew_certificate_v2_in_tx(
         &mut tx,
         &state.config,
         service::CertificateRenewalAuthorization::Operator {
@@ -684,7 +854,23 @@ async fn renew_certificate_v2(
         },
     )
     .await
-    .map_err(gql_error)?;
+    {
+        Ok(issued) => issued,
+        Err(error) => {
+            if let Err(rollback_error) = tx.rollback().await {
+                tracing::warn!("failed to roll back certificate renewal: {rollback_error}");
+            }
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
+    };
     let details = serde_json::json!({
         "old_credential_id": old.credential_id,
         "new_credential_id": issued.certificate.credential_id,
@@ -699,9 +885,17 @@ async fn renew_certificate_v2(
         "managed": true,
     });
     if issued.idempotent_replay {
-        tx.commit()
-            .await
-            .map_err(|error| gql_error(db_err(error)))?;
+        if let Err(error) = commit_lifecycle_replay(tx, "renewal").await {
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
         audit::write(
             &state.pool,
             false,
@@ -717,7 +911,7 @@ async fn renew_certificate_v2(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        if let Err(error) = commit_with_lifecycle_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -732,7 +926,17 @@ async fn renew_certificate_v2(
             },
         )
         .await
-        .map_err(gql_error)?;
+        {
+            audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &error_meta,
+                &error_details,
+                &error,
+            )
+            .await;
+            return Err(gql_error(error));
+        }
     }
     Ok(issued.into())
 }
@@ -813,6 +1017,7 @@ pub struct BulkRevokeCertificatesInput {
     pub principal_group_id: Option<ID>,
     pub reason: Option<String>,
     pub after_credential_id: Option<ID>,
+    pub snapshot_at: Option<String>,
     pub limit: Option<i64>,
 }
 
@@ -829,6 +1034,7 @@ pub struct BulkRevokeCertificateItem {
 #[derive(async_graphql::SimpleObject)]
 pub struct BulkRevokeCertificatesPayload {
     pub items: Vec<BulkRevokeCertificateItem>,
+    pub snapshot_at: String,
     pub next_cursor: Option<ID>,
     pub complete: bool,
 }
@@ -836,6 +1042,7 @@ pub struct BulkRevokeCertificatesPayload {
 impl From<lifecycle::BulkRevocationBatch> for BulkRevokeCertificatesPayload {
     fn from(value: lifecycle::BulkRevocationBatch) -> Self {
         Self {
+            snapshot_at: value.snapshot_at.to_rfc3339(),
             items: value
                 .items
                 .into_iter()

--- a/src/certs/http.rs
+++ b/src/certs/http.rs
@@ -9,6 +9,8 @@ use uuid::Uuid;
 
 use crate::{certs::service, error::AppError, state::AppState};
 
+use super::authority::http::etag_matches;
+
 pub async fn ca_chain(State(state): State<AppState>) -> Result<Response, AppError> {
     let pem = service::ca_chain(&state.config, state.certificate_issuer.as_deref())?;
     let mut headers = HeaderMap::new();
@@ -64,9 +66,7 @@ pub async fn issuer_crl(
     let not_modified = request_headers
         .get(header::IF_NONE_MATCH)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| {
-            value == "*" || value.split(',').any(|candidate| candidate.trim() == etag)
-        });
+        .is_some_and(|value| etag_matches(value, &etag));
     if not_modified {
         return Ok((StatusCode::NOT_MODIFIED, headers).into_response());
     }

--- a/src/certs/lifecycle/mod.rs
+++ b/src/certs/lifecycle/mod.rs
@@ -55,6 +55,10 @@ pub struct BulkRevocationItem {
 #[derive(Debug, Clone, Serialize)]
 pub struct BulkRevocationBatch {
     pub items: Vec<BulkRevocationItem>,
+    /// Freeze point for the operation. Pass it unchanged on every resumed
+    /// page so certificates issued while a batch is running are handled by a
+    /// later operation instead of being silently skipped by UUID pagination.
+    pub snapshot_at: DateTime<Utc>,
     /// Pass this value as `after_credential_id` to resume. On a failure it is
     /// the last contiguous success, so the failed item is selected again.
     pub next_cursor: Option<Uuid>,
@@ -243,6 +247,7 @@ pub async fn bulk_revoke(
     actor_entity_id: Uuid,
     reason: Option<String>,
     after_credential_id: Option<Uuid>,
+    snapshot_at: Option<DateTime<Utc>>,
     limit: i64,
 ) -> Result<BulkRevocationBatch, AppError> {
     if !(1..=MAX_BULK_BATCH_SIZE).contains(&limit) {
@@ -250,11 +255,29 @@ pub async fn bulk_revoke(
             "bulk revocation limit must be between 1 and {MAX_BULK_BATCH_SIZE}"
         )));
     }
+    if after_credential_id.is_some() && snapshot_at.is_none() {
+        return Err(AppError::bad_request(
+            "snapshotAt is required when afterCredentialId is provided",
+        ));
+    }
+    let database_now = repo::bulk_snapshot_at(&state.pool).await?;
+    if snapshot_at
+        .as_ref()
+        .is_some_and(|snapshot| snapshot > &database_now)
+    {
+        return Err(AppError::bad_request(
+            "snapshotAt cannot be later than the database clock",
+        ));
+    }
+    let snapshot_at = snapshot_at.unwrap_or(database_now);
+
     // One look-ahead row determines whether a successful page has more work.
+    // The creation-time cutoff freezes membership across all UUID pages.
     let candidates = repo::bulk_candidates(
         &state.pool,
         selector,
         after_credential_id,
+        &snapshot_at,
         limit.saturating_add(1),
     )
     .await?;
@@ -270,26 +293,26 @@ pub async fn bulk_revoke(
             }
             Err(error) => {
                 let error_code = public_error_code(&error);
-                audit::write(
+                audit::observe_error(
                     &state.pool,
                     state.config.events.enabled(),
-                    audit::AuditEvent {
+                    &audit::AuditMeta {
                         actor_entity_id: Some(actor_entity_id),
                         tenant_id: candidate.tenant_id,
-                        target_kind: Some("credential"),
+                        target_kind: "credential",
                         target_id: Some(candidate.credential_id),
                         event: "certificate.bulk_revoke",
-                        outcome: error.audit_outcome(),
-                        details: serde_json::json!({
-                            "selector_kind": selector.kind(),
-                            "selector_id": selector.id(),
-                            "issuer_id": candidate.issuer_id,
-                            "credential_id": candidate.credential_id,
-                            "entity_id": candidate.entity_id,
-                            "tenant_id": candidate.tenant_id,
-                            "error_code": error_code,
-                        }),
                     },
+                    &serde_json::json!({
+                        "selector_kind": selector.kind(),
+                        "selector_id": selector.id(),
+                        "issuer_id": candidate.issuer_id,
+                        "credential_id": candidate.credential_id,
+                        "entity_id": candidate.entity_id,
+                        "tenant_id": candidate.tenant_id,
+                        "error_code": error_code,
+                    }),
+                    &error,
                 )
                 .await;
                 items.push(BulkRevocationItem {
@@ -302,6 +325,7 @@ pub async fn bulk_revoke(
                 });
                 return Ok(BulkRevocationBatch {
                     items,
+                    snapshot_at,
                     next_cursor: last_success,
                     complete: false,
                 });
@@ -311,6 +335,7 @@ pub async fn bulk_revoke(
 
     Ok(BulkRevocationBatch {
         items,
+        snapshot_at,
         next_cursor: if has_more { last_success } else { None },
         complete: !has_more,
     })
@@ -351,7 +376,9 @@ async fn revoke_candidate(
         "idempotent_replay": revoked.idempotent_replay,
     });
     if revoked.idempotent_replay {
-        tx.commit().await.map_err(AppError::Database)?;
+        let commit = tx.commit().await.map_err(AppError::Database);
+        certificates::record_lifecycle_commit("revocation", &commit);
+        commit?;
         audit::write(
             &state.pool,
             false,
@@ -367,7 +394,7 @@ async fn revoke_candidate(
         )
         .await;
     } else {
-        audit::commit_with_audit(
+        let commit = audit::commit_with_audit(
             &state.pool,
             tx,
             state.config.events.enabled(),
@@ -381,7 +408,9 @@ async fn revoke_candidate(
                 details,
             },
         )
-        .await?;
+        .await;
+        certificates::record_lifecycle_commit("revocation", &commit);
+        commit?;
     }
 
     Ok(BulkRevocationItem {

--- a/src/certs/lifecycle/repo.rs
+++ b/src/certs/lifecycle/repo.rs
@@ -97,7 +97,6 @@ pub async fn due_certificate_windows(
             WHERE c.kind = 'certificate'
               AND c.status = 'active'
               AND c.expires_at IS NOT NULL
-              AND c.expires_at > $1
         ), due AS (
             SELECT credential_id, issuer_id, entity_id, tenant_id, expires_at,
                    'renewal'::text AS window_kind, renewal_at AS window_at
@@ -155,7 +154,6 @@ pub async fn due_authority_windows(
                a.not_after - ($2 * interval '1 second') AS window_at
         FROM pki_authorities a
         WHERE a.status IN ('active', 'retiring')
-          AND a.not_after > $1
           AND a.not_after - ($2 * interval '1 second') <= $1
           AND NOT EXISTS (
               SELECT 1 FROM pki_lifecycle_notifications n
@@ -276,10 +274,21 @@ pub async fn selector_tenant_id(
     }
 }
 
+/// Database-clock cutoff used to freeze the membership of a paginated bulk
+/// operation. Credential creation also uses the database clock, avoiding
+/// process/DB clock skew at the page boundary.
+pub async fn bulk_snapshot_at(pool: &PgPool) -> Result<DateTime<Utc>, AppError> {
+    sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(pool)
+        .await
+        .map_err(AppError::Database)
+}
+
 pub async fn bulk_candidates(
     pool: &PgPool,
     selector: BulkRevocationSelector,
     after: Option<Uuid>,
+    snapshot_at: &DateTime<Utc>,
     limit: i64,
 ) -> Result<Vec<BulkCandidate>, AppError> {
     match selector {
@@ -308,15 +317,17 @@ pub async fn bulk_candidates(
                 CROSS JOIN root_group root
                 WHERE c.kind = 'certificate'
                   AND c.status = 'active'
+                  AND c.created_at <= $3
                   AND e.tenant_id IS NOT DISTINCT FROM root.tenant_id
                   AND ($2::uuid IS NULL OR c.id > $2)
                 GROUP BY c.id, c.issuer_id, c.entity_id, e.tenant_id
                 ORDER BY c.id ASC
-                LIMIT $3
+                LIMIT $4
                 "#,
         )
         .bind(group_id)
         .bind(after)
+        .bind(snapshot_at)
         .bind(limit)
         .fetch_all(pool)
         .await
@@ -331,6 +342,8 @@ pub async fn bulk_candidates(
                   AND c.status = 'active'
                 "#,
             );
+            query.push(" AND c.created_at <= ");
+            query.push_bind(snapshot_at);
             match selector {
                 BulkRevocationSelector::Tenant(tenant_id) => {
                     query.push(" AND e.tenant_id = ");

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -300,6 +300,24 @@ impl PkiArtifactSigner {
         &self,
         response_data_der: &[u8],
     ) -> Result<PkiArtifactSignature, AppError> {
+        let certificate_der =
+            one_certificate_der(&self.certificate_pem, "OCSP signer certificate")?;
+        let (_, certificate) =
+            x509_parser::parse_x509_certificate(&certificate_der).map_err(|_| {
+                AppError::Internal(anyhow::anyhow!("stored invalid OCSP signer certificate"))
+            })?;
+        let usage = certificate
+            .tbs_certificate
+            .key_usage()
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid OCSP signer key usage")))?
+            .ok_or_else(|| {
+                AppError::Internal(anyhow::anyhow!("OCSP signer is missing key usage"))
+            })?;
+        if !usage.value.digital_signature() {
+            return Err(AppError::bad_request(
+                "authority certificate is not authorized for OCSP response signing",
+            ));
+        }
         let algorithm = pki_signature_algorithm(self.signing_key.algorithm())?;
         let bytes = self
             .signing_key
@@ -1033,13 +1051,40 @@ fn validate_chain(issuer_der: &[u8], chain_pem: &str) -> Result<(), AppError> {
             "issuer chain must begin with the issuing certificate",
         ));
     }
-    for pair in chain.windows(2) {
-        let (_, child) = x509_parser::parse_x509_certificate(&pair[0])
-            .map_err(|_| AppError::bad_request("invalid issuer chain certificate"))?;
-        let (_, parent) = x509_parser::parse_x509_certificate(&pair[1])
-            .map_err(|_| AppError::bad_request("invalid issuer chain certificate"))?;
-        validate_issuer_certificate(&child)?;
-        validate_issuer_certificate(&parent)?;
+    let parsed_chain = chain
+        .iter()
+        .map(|certificate| {
+            x509_parser::parse_x509_certificate(certificate)
+                .map(|(_, certificate)| certificate)
+                .map_err(|_| AppError::bad_request("invalid issuer chain certificate"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for (index, certificate) in parsed_chain.iter().enumerate() {
+        validate_issuer_certificate(certificate)?;
+        let constraints = certificate
+            .tbs_certificate
+            .basic_constraints()
+            .map_err(|_| AppError::bad_request("invalid issuer basic constraints"))?
+            .ok_or_else(|| AppError::bad_request("issuer is missing basic constraints"))?;
+        let subordinate_ca_count = parsed_chain[..index]
+            .iter()
+            .filter(|subordinate| subordinate.issuer() != subordinate.subject())
+            .count();
+        if constraints
+            .value
+            .path_len_constraint
+            .is_some_and(|limit| subordinate_ca_count > limit as usize)
+        {
+            return Err(AppError::bad_request(
+                "issuer chain exceeds a parent path-length constraint",
+            ));
+        }
+    }
+
+    for pair in parsed_chain.windows(2) {
+        let child = &pair[0];
+        let parent = &pair[1];
         if child.issuer() != parent.subject() {
             return Err(AppError::bad_request("issuer chain names do not link"));
         }
@@ -1054,18 +1099,15 @@ fn validate_chain(issuer_der: &[u8], chain_pem: &str) -> Result<(), AppError> {
             ));
         }
     }
-    let (_, root) = x509_parser::parse_x509_certificate(
-        chain
-            .last()
-            .ok_or_else(|| AppError::bad_request("issuer chain is empty"))?,
-    )
-    .map_err(|_| AppError::bad_request("invalid issuer root certificate"))?;
+    let root = parsed_chain
+        .last()
+        .ok_or_else(|| AppError::bad_request("issuer chain is empty"))?;
     if root.issuer() != root.subject() {
         return Err(AppError::bad_request(
             "issuer chain is not anchored by a root",
         ));
     }
-    validate_issuer_certificate(&root)?;
+    validate_issuer_certificate(root)?;
     root.verify_signature(None)
         .map_err(|_| AppError::bad_request("issuer chain root is not self-signed"))?;
     Ok(())
@@ -1235,6 +1277,42 @@ mod tests {
         let mut requested = CertificateParams::default();
         requested.key_usages = vec![KeyUsagePurpose::KeyCertSign];
         assert!(validate_requested_extensions(&profile, &requested).is_err());
+    }
+
+    #[test]
+    fn issuer_chain_rejects_parent_path_len_violation() {
+        let root_key = KeyPair::generate().unwrap();
+        let mut root_params = CertificateParams::default();
+        root_params
+            .distinguished_name
+            .push(DnType::CommonName, "Constrained Test Root");
+        root_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Constrained(0));
+        root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        let root = root_params.self_signed(&root_key).unwrap();
+
+        let issuer_key = KeyPair::generate().unwrap();
+        let mut issuer_params = CertificateParams::default();
+        issuer_params
+            .distinguished_name
+            .push(DnType::CommonName, "Subordinate Test Issuer");
+        issuer_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Constrained(0));
+        issuer_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+        let issuer = issuer_params
+            .signed_by(&issuer_key, &Issuer::from_params(&root_params, &root_key))
+            .unwrap();
+        let issuer_pem = issuer.pem();
+        let chain_pem = format!("{issuer_pem}{}", root.pem());
+
+        let error = PkiIssuer::from_pem(
+            &issuer_pem,
+            &issuer_key.serialize_pem(),
+            &chain_pem,
+            "https://pki.example.test/ocsp",
+            "https://pki.example.test/ca.der",
+            "https://pki.example.test/crl.der",
+        )
+        .expect_err("a pathLen=0 root cannot have a subordinate CA");
+        assert!(error.to_string().contains("path-length constraint"));
     }
 
     #[test]

--- a/src/certs/profile.rs
+++ b/src/certs/profile.rs
@@ -313,6 +313,9 @@ impl TryFrom<ProfileRow> for CertificateProfile {
             .iter()
             .map(|usage| KeyUsage::parse(usage))
             .collect::<Result<Vec<_>, _>>()?;
+        if key_usages.is_empty() {
+            return Err(invalid_profile("key usages cannot be empty"));
+        }
         require_unique(&key_usages, "duplicate key usage")?;
 
         let extended_key_usages = row
@@ -320,6 +323,9 @@ impl TryFrom<ProfileRow> for CertificateProfile {
             .iter()
             .map(|usage| ExtendedKeyUsage::parse(usage))
             .collect::<Result<Vec<_>, _>>()?;
+        if extended_key_usages.is_empty() {
+            return Err(invalid_profile("extended key usages cannot be empty"));
+        }
         require_unique(&extended_key_usages, "duplicate extended key usage")?;
 
         let san_policy: SanPolicy = serde_json::from_value(row.san_policy)
@@ -513,6 +519,31 @@ fn invalid_profile(message: impl Into<String>) -> AppError {
 mod tests {
     use super::*;
 
+    fn valid_profile_row() -> ProfileRow {
+        ProfileRow {
+            id: Uuid::new_v4(),
+            tenant_id: None,
+            base_profile_id: None,
+            name: "test".to_string(),
+            permitted_key_algorithms: serde_json::json!([
+                {"algorithm": "ecdsa", "sizes": [256]}
+            ]),
+            default_ttl_seconds: 3_600,
+            maximum_ttl_seconds: 7_200,
+            renewal_threshold_seconds: 600,
+            key_usages: vec!["digital_signature".to_string()],
+            extended_key_usages: vec!["client_auth".to_string()],
+            san_policy: serde_json::json!({
+                "dns": {"mode": "deny", "values": []},
+                "ip": {"mode": "deny", "values": []},
+                "email": {"mode": "deny", "values": []},
+                "uri": {"mode": "identity", "values": []}
+            }),
+            identity_uri_template: "urn:atom:{scope}entity:{entity_id}".to_string(),
+            basic_constraints: serde_json::json!({"ca": false, "path_len": null}),
+        }
+    }
+
     fn rule(mode: SanRuleMode, values: &[&str]) -> SanRule {
         SanRule {
             mode,
@@ -550,5 +581,28 @@ mod tests {
             &[SanRuleMode::EntityTemplate]
         )
         .is_err());
+    }
+
+    #[test]
+    fn empty_usage_sets_fail_closed_in_typed_profile_loading() {
+        let mut row = valid_profile_row();
+        row.key_usages.clear();
+        let AppError::Internal(error) =
+            CertificateProfile::try_from(row).expect_err("empty key usages")
+        else {
+            panic!("empty stored key usages must be an internal integrity error");
+        };
+        assert!(error.to_string().contains("key usages cannot be empty"));
+
+        let mut row = valid_profile_row();
+        row.extended_key_usages.clear();
+        let AppError::Internal(error) =
+            CertificateProfile::try_from(row).expect_err("empty extended key usages")
+        else {
+            panic!("empty stored extended key usages must be an internal integrity error");
+        };
+        assert!(error
+            .to_string()
+            .contains("extended key usages cannot be empty"));
     }
 }

--- a/src/certs/repo.rs
+++ b/src/certs/repo.rs
@@ -785,6 +785,29 @@ where
     .map_err(db_err)
 }
 
+pub async fn certificate_revocation_by_issuer_serial<'e, E>(
+    executor: E,
+    issuer_id: Uuid,
+    serial_number: &str,
+) -> Result<Option<CertificateRevocationRecord>, AppError>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, CertificateRevocationRecord>(
+        r#"
+        SELECT credential_id, issuer_id, issuer_fingerprint_sha256,
+               serial_number, reason, actor_entity_id, revoked_at
+        FROM certificate_revocations
+        WHERE issuer_id = $1 AND serial_number = $2
+        "#,
+    )
+    .bind(issuer_id)
+    .bind(serial_number)
+    .fetch_optional(executor)
+    .await
+    .map_err(AppError::Database)
+}
+
 pub async fn active_entity_certificates<'e, E>(
     executor: E,
     entity_id: Uuid,
@@ -808,28 +831,24 @@ where
     .map_err(AppError::Database)
 }
 
-/// Revoked certificates issued by one issuer, for that issuer's CRL. A CRL is
-/// signed by its issuer and covers only certificates the issuer signed, so the
-/// filter is a correctness requirement, not an optimisation — and it also keeps
-/// certificate rows created outside the issuance path (no full metadata, e.g.
-/// externally provisioned or test fixtures) from breaking CRL generation.
-pub async fn revoked_certificates(
-    pool: &PgPool,
+/// Unexpired durable revocations for a legacy file issuer. The caller's
+/// transaction already owns the legacy CRL state lock; querying through it
+/// avoids a nested pool acquire and keeps the published snapshot consistent.
+pub async fn revocations_by_fingerprint_tx(
+    tx: &mut Transaction<'_, Postgres>,
     issuer_fingerprint_sha256: &str,
-) -> Result<Vec<CertificateCredential>, AppError> {
-    sqlx::query_as::<_, CertificateCredential>(
+) -> Result<Vec<IssuerRevocationEntry>, AppError> {
+    sqlx::query_as::<_, IssuerRevocationEntry>(
         r#"
-        SELECT c.id, c.issuer_id, c.entity_id, e.tenant_id, c.identifier, c.status, c.metadata,
-               c.expires_at, c.created_at
-        FROM credentials c
-        JOIN entities e ON e.id = c.entity_id
-        WHERE c.kind = 'certificate' AND c.status = 'revoked'
-          AND c.metadata->>'issuer_fingerprint_sha256' = $1
-        ORDER BY c.created_at ASC
+        SELECT credential_id, serial_number, reason, revoked_at
+        FROM certificate_revocations
+        WHERE issuer_fingerprint_sha256 = $1
+          AND expires_at > now()
+        ORDER BY revoked_at, credential_id
         "#,
     )
     .bind(issuer_fingerprint_sha256)
-    .fetch_all(pool)
+    .fetch_all(&mut **tx)
     .await
     .map_err(AppError::Database)
 }
@@ -970,6 +989,7 @@ pub async fn issuer_revocations_tx(
         SELECT credential_id, serial_number, reason, revoked_at
         FROM certificate_revocations
         WHERE issuer_id = $1
+          AND expires_at > now()
         ORDER BY revoked_at, credential_id
         "#,
     )

--- a/src/certs/service.rs
+++ b/src/certs/service.rs
@@ -506,10 +506,9 @@ pub async fn issue_certificate(
     issuer: Option<&CertificateIssuer>,
     input: IssueCertificate,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "issuance").await?;
     let issued = issue_certificate_in_tx(&mut tx, config, issuer, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "issuance").await
 }
 
 /// The caller owns the commit, so an audited caller can bind issuance and its
@@ -522,7 +521,7 @@ pub async fn issue_certificate_in_tx(
     input: IssueCertificate,
 ) -> Result<IssuedCertificate, AppError> {
     let result = issue_certificate_in_tx_inner(tx, config, issuer, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -629,10 +628,9 @@ pub async fn issue_certificate_from_csr(
     issuer: Option<&CertificateIssuer>,
     input: IssueCertificateFromCsr,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "issuance").await?;
     let issued = issue_certificate_from_csr_in_tx(&mut tx, config, issuer, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "issuance").await
 }
 
 /// See [`issue_certificate_in_tx`] — the caller owns the commit.
@@ -643,7 +641,7 @@ pub async fn issue_certificate_from_csr_in_tx(
     input: IssueCertificateFromCsr,
 ) -> Result<IssuedCertificate, AppError> {
     let result = issue_certificate_from_csr_in_tx_inner(tx, config, issuer, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -728,11 +726,10 @@ pub async fn issue_certificate_from_csr_v2(
     authorized_tenant_id: Option<Uuid>,
     input: IssueCertificateFromCsrV2,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "issuance").await?;
     let issued =
         issue_certificate_from_csr_v2_in_tx(&mut tx, config, authorized_tenant_id, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "issuance").await
 }
 
 /// Managed CSR issuance using only the caller's existing transaction and
@@ -745,7 +742,7 @@ pub async fn issue_certificate_from_csr_v2_in_tx(
 ) -> Result<IssuedCertificate, AppError> {
     let result =
         issue_certificate_from_csr_v2_in_tx_inner(tx, config, authorized_tenant_id, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -865,7 +862,7 @@ pub async fn issue_generated_certificate_v2_in_tx(
 ) -> Result<IssuedCertificate, AppError> {
     let result =
         issue_generated_certificate_v2_in_tx_inner(tx, config, authorized_tenant_id, input).await;
-    record_lifecycle_operation("issuance", &result);
+    record_lifecycle_precommit_failure("issuance", &result);
     result
 }
 
@@ -972,10 +969,9 @@ pub async fn renew_certificate(
     issuer: Option<&CertificateIssuer>,
     input: RenewCertificate,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "renewal").await?;
     let issued = renew_certificate_in_tx(&mut tx, config, issuer, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "renewal").await
 }
 
 /// See [`issue_certificate_in_tx`] — the caller owns the commit. Renewal issues
@@ -988,7 +984,7 @@ pub async fn renew_certificate_in_tx(
     input: RenewCertificate,
 ) -> Result<IssuedCertificate, AppError> {
     let result = renew_certificate_in_tx_inner(tx, config, issuer, input).await;
-    record_lifecycle_operation("renewal", &result);
+    record_lifecycle_precommit_failure("renewal", &result);
     result
 }
 
@@ -1032,10 +1028,9 @@ pub async fn renew_certificate_v2(
     authorization: CertificateRenewalAuthorization,
     input: RenewCertificateV2,
 ) -> Result<IssuedCertificate, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "renewal").await?;
     let issued = renew_certificate_v2_in_tx(&mut tx, config, authorization, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(issued)
+    commit_lifecycle_transaction(tx, issued, "renewal").await
 }
 
 /// Exact-credential, issuer-aware renewal. Operator authorization is bound to
@@ -1049,7 +1044,7 @@ pub async fn renew_certificate_v2_in_tx(
     input: RenewCertificateV2,
 ) -> Result<IssuedCertificate, AppError> {
     let result = renew_certificate_v2_in_tx_inner(tx, config, authorization, input).await;
-    record_lifecycle_operation("renewal", &result);
+    record_lifecycle_precommit_failure("renewal", &result);
     result
 }
 
@@ -1265,10 +1260,9 @@ pub async fn revoke_certificate(
     serial_number: &str,
     reason: Option<String>,
 ) -> Result<CertificateRecord, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "revocation").await?;
     let record = revoke_certificate_in_tx(&mut tx, serial_number, reason).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(record)
+    commit_lifecycle_transaction(tx, record, "revocation").await
 }
 
 /// See [`issue_certificate_in_tx`] — the caller owns the commit. The revocation
@@ -1281,7 +1275,7 @@ pub async fn revoke_certificate_in_tx(
     reason: Option<String>,
 ) -> Result<CertificateRecord, AppError> {
     let result = revoke_certificate_in_tx_inner(tx, serial_number, reason).await;
-    record_lifecycle_operation("revocation", &result);
+    record_lifecycle_precommit_failure("revocation", &result);
     result
 }
 
@@ -1338,10 +1332,9 @@ pub async fn revoke_certificate_v2(
     pool: &sqlx::PgPool,
     input: RevokeCertificateV2,
 ) -> Result<CertificateRevocationResult, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "revocation").await?;
     let result = revoke_certificate_v2_in_tx(&mut tx, input).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(result)
+    commit_lifecycle_transaction(tx, result, "revocation").await
 }
 
 /// Revoke one exact certificate. The row lock makes first-write semantics and
@@ -1353,7 +1346,7 @@ pub async fn revoke_certificate_v2_in_tx(
     input: RevokeCertificateV2,
 ) -> Result<CertificateRevocationResult, AppError> {
     let result = revoke_certificate_v2_in_tx_inner(tx, input).await;
-    record_lifecycle_operation("revocation", &result);
+    record_lifecycle_precommit_failure("revocation", &result);
     result
 }
 
@@ -1428,10 +1421,9 @@ pub async fn revoke_entity_certificates(
     entity_id: Uuid,
     reason: Option<String>,
 ) -> Result<usize, AppError> {
-    let mut tx = pool.begin().await.map_err(AppError::Database)?;
+    let mut tx = begin_lifecycle_transaction(pool, "revocation").await?;
     let count = revoke_entity_certificates_in_tx(&mut tx, entity_id, reason).await?;
-    tx.commit().await.map_err(AppError::Database)?;
-    Ok(count)
+    commit_lifecycle_transaction(tx, count, "revocation").await
 }
 
 /// See [`revoke_certificate_in_tx`] — the caller owns the commit. Revoking an
@@ -1458,7 +1450,7 @@ pub async fn revoke_entity_certificates_v2_in_tx(
 ) -> Result<BulkCertificateRevocationResult, AppError> {
     let result =
         revoke_entity_certificates_v2_in_tx_inner(tx, entity_id, reason, actor_entity_id).await;
-    record_lifecycle_operation("revocation", &result);
+    record_lifecycle_precommit_failure("revocation", &result);
     result
 }
 
@@ -1596,19 +1588,19 @@ pub async fn generate_crl(
     }
 
     let generation_started = Instant::now();
-    let revoked = repo::revoked_certificates(pool, &loaded.issuer_fingerprint_sha256).await?;
-    let revoked_certs = revoked
-        .into_iter()
-        .map(|cert| {
-            let metadata = metadata_from_value(&cert.metadata)?;
-            Ok(RevokedCertParams {
-                serial_number: SerialNumber::from(serial_bytes(&cert.identifier)?),
-                revocation_time: to_offset(metadata.revoked_at.unwrap_or_else(Utc::now))?,
-                reason_code: Some(RevocationReason::Unspecified),
-                invalidity_date: None,
+    let revoked_certs =
+        repo::revocations_by_fingerprint_tx(&mut tx, &loaded.issuer_fingerprint_sha256)
+            .await?
+            .into_iter()
+            .map(|entry| {
+                Ok(RevokedCertParams {
+                    serial_number: SerialNumber::from(serial_bytes(&entry.serial_number)?),
+                    revocation_time: to_offset(entry.revoked_at)?,
+                    reason_code: Some(crl_revocation_reason(&entry.reason)),
+                    invalidity_date: None,
+                })
             })
-        })
-        .collect::<Result<Vec<_>, AppError>>()?;
+            .collect::<Result<Vec<_>, AppError>>()?;
     let now = OffsetDateTime::now_utc();
     let next_update = now + Duration::hours(CRL_TTL_HOURS);
     let crl_number = state.crl_number + 1;
@@ -2836,6 +2828,14 @@ async fn managed_ocsp_status(
     issuer_id: Uuid,
     serial_number: &str,
 ) -> Result<CertStatus, AppError> {
+    if let Some(revocation) =
+        repo::certificate_revocation_by_issuer_serial(pool, issuer_id, serial_number).await?
+    {
+        return Ok(CertStatus::revoked(RevokedInfo {
+            revocation_time: ocsp_time(revocation.revoked_at)?,
+            revocation_reason: Some(ocsp_revocation_reason(&revocation.reason)),
+        }));
+    }
     let certificate = match repo::certificate_by_issuer_serial(pool, issuer_id, serial_number).await
     {
         Ok(certificate) => certificate,
@@ -2844,25 +2844,9 @@ async fn managed_ocsp_status(
     };
     match certificate.status.as_str() {
         "active" => Ok(CertStatus::good()),
-        "revoked" => {
-            let revocation = repo::certificate_revocation_by_id(pool, certificate.id)
-                .await
-                .map_err(|error| {
-                    AppError::Internal(anyhow::anyhow!(
-                        "revoked certificate has no immutable revocation record: {error}"
-                    ))
-                })?;
-            if revocation.issuer_id != Some(issuer_id) || revocation.serial_number != serial_number
-            {
-                return Err(AppError::Internal(anyhow::anyhow!(
-                    "certificate revocation record does not match its issuer identity"
-                )));
-            }
-            Ok(CertStatus::revoked(RevokedInfo {
-                revocation_time: ocsp_time(revocation.revoked_at)?,
-                revocation_reason: Some(ocsp_revocation_reason(&revocation.reason)),
-            }))
-        }
+        "revoked" => Err(AppError::Internal(anyhow::anyhow!(
+            "revoked certificate has no immutable revocation record"
+        ))),
         _ => Ok(CertStatus::unknown()),
     }
 }
@@ -2995,7 +2979,39 @@ fn is_unique_violation(err: &AppError) -> bool {
     )
 }
 
-fn record_lifecycle_operation<T>(operation: &'static str, result: &Result<T, AppError>) {
+async fn begin_lifecycle_transaction<'a>(
+    pool: &'a sqlx::PgPool,
+    operation: &'static str,
+) -> Result<sqlx::Transaction<'a, sqlx::Postgres>, AppError> {
+    match pool.begin().await {
+        Ok(tx) => Ok(tx),
+        Err(error) => {
+            crate::metrics::record_pki_lifecycle_operation(operation, "failure");
+            Err(AppError::Database(error))
+        }
+    }
+}
+
+async fn commit_lifecycle_transaction<T>(
+    tx: sqlx::Transaction<'_, sqlx::Postgres>,
+    value: T,
+    operation: &'static str,
+) -> Result<T, AppError> {
+    let result = tx.commit().await;
+    record_lifecycle_commit(operation, &result);
+    result.map(|_| value).map_err(AppError::Database)
+}
+
+fn record_lifecycle_precommit_failure<T>(operation: &'static str, result: &Result<T, AppError>) {
+    if result.is_err() {
+        crate::metrics::record_pki_lifecycle_operation(operation, "failure");
+    }
+}
+
+/// Record an operation only after the owner of a transaction has observed its
+/// final commit result. Transactional transports use this after their audit +
+/// mutation commit; `_in_tx` helpers record only pre-commit failures.
+pub(crate) fn record_lifecycle_commit<T, E>(operation: &'static str, result: &Result<T, E>) {
     crate::metrics::record_pki_lifecycle_operation(
         operation,
         if result.is_ok() { "success" } else { "failure" },

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,6 +334,9 @@ pub struct EnrollmentConfig {
     pub max_csr_bytes: usize,
     pub max_connections: usize,
     pub trust_bundle_refresh_secs: u64,
+    pub tls_handshake_timeout_secs: u64,
+    pub connection_timeout_secs: u64,
+    pub shutdown_drain_timeout_secs: u64,
 }
 
 impl Default for EnrollmentConfig {
@@ -353,6 +356,9 @@ impl Default for EnrollmentConfig {
             max_csr_bytes: 64 * 1024,
             max_connections: 256,
             trust_bundle_refresh_secs: 60,
+            tls_handshake_timeout_secs: 10,
+            connection_timeout_secs: 300,
+            shutdown_drain_timeout_secs: 30,
         }
     }
 }
@@ -1295,6 +1301,18 @@ fn enrollment_from_env() -> Result<EnrollmentConfig> {
             "ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS",
             default.trust_bundle_refresh_secs,
         )?,
+        tls_handshake_timeout_secs: env_parse(
+            "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS",
+            default.tls_handshake_timeout_secs,
+        )?,
+        connection_timeout_secs: env_parse(
+            "ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS",
+            default.connection_timeout_secs,
+        )?,
+        shutdown_drain_timeout_secs: env_parse(
+            "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS",
+            default.shutdown_drain_timeout_secs,
+        )?,
     };
     if cfg.max_csr_bytes == 0 {
         anyhow::bail!("ATOM_PKI_ENROLLMENT_MAX_CSR_BYTES must be greater than zero");
@@ -1304,6 +1322,15 @@ fn enrollment_from_env() -> Result<EnrollmentConfig> {
     }
     if cfg.trust_bundle_refresh_secs == 0 {
         anyhow::bail!("ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS must be greater than zero");
+    }
+    if cfg.tls_handshake_timeout_secs == 0 {
+        anyhow::bail!("ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS must be greater than zero");
+    }
+    if cfg.connection_timeout_secs == 0 {
+        anyhow::bail!("ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS must be greater than zero");
+    }
+    if cfg.shutdown_drain_timeout_secs == 0 {
+        anyhow::bail!("ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS must be greater than zero");
     }
     Ok(cfg)
 }
@@ -1729,6 +1756,9 @@ mod tests {
         assert!(!cfg.enrollment.enabled);
         assert!(cfg.enrollment.tls.is_none());
         assert_eq!(cfg.enrollment.max_csr_bytes, 64 * 1024);
+        assert_eq!(cfg.enrollment.tls_handshake_timeout_secs, 10);
+        assert_eq!(cfg.enrollment.connection_timeout_secs, 300);
+        assert_eq!(cfg.enrollment.shutdown_drain_timeout_secs, 30);
 
         std::env::set_var("ATOM_PKI_ENROLLMENT_ENABLED", "true");
         let err = Config::from_env().expect_err("enabled listener without TLS");
@@ -1741,10 +1771,16 @@ mod tests {
         std::env::set_var("ATOM_PKI_ENROLLMENT_TLS_KEY_PATH", "/tls/server-key.pem");
         std::env::set_var("ATOM_PKI_ENROLLMENT_ENTITY_RATE_LIMIT", "7");
         std::env::set_var("ATOM_PKI_ENROLLMENT_TENANT_RATE_LIMIT", "70");
+        std::env::set_var("ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS", "11");
+        std::env::set_var("ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS", "301");
+        std::env::set_var("ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS", "31");
         let cfg = Config::from_env().expect("enrollment config");
         assert!(cfg.enrollment.enabled);
         assert_eq!(cfg.enrollment.entity_rate_limit.max_requests, 7);
         assert_eq!(cfg.enrollment.tenant_rate_limit.max_requests, 70);
+        assert_eq!(cfg.enrollment.tls_handshake_timeout_secs, 11);
+        assert_eq!(cfg.enrollment.connection_timeout_secs, 301);
+        assert_eq!(cfg.enrollment.shutdown_drain_timeout_secs, 31);
         assert_eq!(
             cfg.enrollment
                 .tls
@@ -1880,6 +1916,9 @@ mod tests {
             "ATOM_PKI_ENROLLMENT_MAX_CSR_BYTES",
             "ATOM_PKI_ENROLLMENT_MAX_CONNECTIONS",
             "ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS",
+            "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS",
+            "ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS",
+            "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS",
             "ATOM_PKI_LIFECYCLE_ENABLED",
             "ATOM_PKI_LIFECYCLE_INTERVAL_SECS",
             "ATOM_PKI_LIFECYCLE_BATCH_SIZE",

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -426,7 +426,7 @@ impl CertificateService for AtomCertificates {
         )
         .await
         .map_err(Status::from)?;
-        audit::commit_with_audit(
+        let commit = audit::commit_with_audit(
             &self.state.pool,
             tx,
             self.state.config.events.enabled(),
@@ -446,8 +446,9 @@ impl CertificateService for AtomCertificates {
                 }),
             },
         )
-        .await
-        .map_err(Status::from)?;
+        .await;
+        certs::service::record_lifecycle_commit("revocation", &commit);
+        commit.map_err(Status::from)?;
 
         Ok(Response::new(RevokeEntityCertificatesResponse {
             revoked: revoked.count as u64,

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -897,6 +897,18 @@ pub async fn purge_entity_with_audit(
             .await
             .map_err(db_err)?;
 
+    // Enrollment counters intentionally have no FK because a scope may be
+    // admitted before all subject reads finish. Purge them explicitly so a
+    // one-time subject cannot leave durable abuse-control state behind.
+    sqlx::query(
+        "DELETE FROM pki_enrollment_rate_windows
+         WHERE scope_kind = 'entity' AND scope_id = $1",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await
+    .map_err(db_err)?;
+
     let purged_tenant_id: Option<Option<Uuid>> = sqlx::query_scalar(
         "DELETE FROM entities WHERE id = $1 AND deleted_at IS NOT NULL RETURNING tenant_id",
     )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -197,8 +197,12 @@ mod backend {
             "platform_leaf_issuer",
             "tenant_intermediate",
         ];
+        // Prometheus recorders cannot unregister one labeled gauge through
+        // the facade. NaN explicitly represents an absent authority kind and
+        // prevents a missing fleet from looking like a real zero-second CA,
+        // which would otherwise trigger false expiry alerts.
         for kind in AUTHORITY_KINDS {
-            metrics::gauge!(PKI_AUTHORITY_TIME_TO_EXPIRY, "kind" => kind).set(0.0);
+            metrics::gauge!(PKI_AUTHORITY_TIME_TO_EXPIRY, "kind" => kind).set(f64::NAN);
         }
         for row in authority_rows {
             let Some(kind) = AUTHORITY_KINDS

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -110,6 +110,13 @@ pub async fn purge_expired(pool: &PgPool, cfg: PurgeConfig) -> Result<PurgeSumma
     // Entities: capture cascaded credential ids before the delete removes them.
     let entity_ids = select_doomed(&mut tx, "entities", cutoff, cfg.batch_size).await?;
     if !entity_ids.is_empty() {
+        sqlx::query(
+            "DELETE FROM pki_enrollment_rate_windows
+             WHERE scope_kind = 'entity' AND scope_id = ANY($1)",
+        )
+        .bind(&entity_ids)
+        .execute(&mut *tx)
+        .await?;
         let credential_ids: Vec<Uuid> =
             sqlx::query_scalar("SELECT id FROM credentials WHERE entity_id = ANY($1)")
                 .bind(&entity_ids)

--- a/src/tenants/repo.rs
+++ b/src/tenants/repo.rs
@@ -736,6 +736,21 @@ pub(crate) async fn purge_tenant_pki_in_tx(
         return Ok(());
     }
 
+    // Rate-limit rows are deliberately independent of subject FKs. Remove
+    // both tenant and child-entity scopes while those entities are still
+    // available to identify, before the tenant cascade runs.
+    sqlx::query(
+        r#"DELETE FROM pki_enrollment_rate_windows
+           WHERE (scope_kind = 'tenant' AND scope_id = ANY($1))
+              OR (scope_kind = 'entity' AND scope_id IN (
+                    SELECT id FROM entities WHERE tenant_id = ANY($1)
+                 ))"#,
+    )
+    .bind(tenant_ids)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+
     // Credentials restrict authority deletion, and authorities belong to the
     // tenant being purged. Remove them in dependency order before the tenant.
     sqlx::query(

--- a/tests/common/pki.rs
+++ b/tests/common/pki.rs
@@ -81,10 +81,11 @@ pub async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, &config.pki_ca_keys)
+    let mut pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, &config.pki_ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported = provisioning::import_signed_authority_in_tx(
@@ -99,7 +100,7 @@ pub async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let provisioned =
+    let mut provisioned =
         provisioning::provision_tenant_automatically_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
             .await
             .unwrap();
@@ -109,6 +110,7 @@ pub async fn provision_tenant_issuer(
         provisioned.validation_error
     );
     tx.commit().await.unwrap();
+    provisioned.commit_generated_key();
     sqlx::query(
         r#"UPDATE pki_authorities
            SET ocsp_url = $2, ca_issuers_url = $3,
@@ -139,10 +141,11 @@ pub async fn provision_platform_leaf_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let pending = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &config.pki_ca_keys)
+    let mut pending = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &config.pki_ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported = provisioning::import_signed_authority_in_tx(
@@ -180,11 +183,12 @@ pub async fn rotate_tenant_issuer(
     tenant_id: Uuid,
 ) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let pending =
+    let mut pending =
         provisioning::begin_tenant_authority_in_tx(&mut tx, &config.pki_ca_keys, tenant_id)
             .await
             .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported = provisioning::import_signed_authority_in_tx(

--- a/tests/m17_certificates.rs
+++ b/tests/m17_certificates.rs
@@ -17,8 +17,8 @@ use der::{
 use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose};
 use ring::digest;
 use spki::AlgorithmIdentifierOwned;
-use sqlx::PgPool;
-use std::{fs, path::PathBuf};
+use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::{fs, path::PathBuf, time::Duration as StdDuration};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 use x509_ocsp::{CertId, OcspRequest, Request as OcspSingleRequest, TbsRequest};
@@ -260,9 +260,18 @@ async fn certificate_lifecycle_with_database() {
             .unwrap();
     assert!(revoked_count >= 2);
 
-    let crl = service::generate_crl(&pool, &cfg, Some(&issuer))
+    let single_connection_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&std::env::var("DATABASE_URL").unwrap())
         .await
         .unwrap();
+    let crl = tokio::time::timeout(
+        StdDuration::from_secs(5),
+        service::generate_crl(&single_connection_pool, &cfg, Some(&issuer)),
+    )
+    .await
+    .expect("legacy CRL generation must not perform a nested pool acquire")
+    .unwrap();
     let (_, parsed_crl) = x509_parser::parse_x509_crl(&crl).unwrap();
     let serial = hex::decode(&issued.certificate.serial_number).unwrap();
     assert!(parsed_crl

--- a/tests/m21_soft_delete.rs
+++ b/tests/m21_soft_delete.rs
@@ -1799,6 +1799,22 @@ async fn tombstoned_tenant_cannot_be_reactivated_or_authorized() {
 async fn purge_tenant_removes_owned_objects_instead_of_orphaning_them() {
     let pool = common::pool().await;
     let tenant_id = make_tenant(&pool, &format!("sd-purge-ten-{}", Uuid::new_v4())).await;
+    let entity_id = make_entity(
+        &pool,
+        &format!("sd-purge-rate-{}", Uuid::new_v4()),
+        Some(tenant_id),
+    )
+    .await;
+    sqlx::query(
+        "INSERT INTO pki_enrollment_rate_windows
+         (scope_kind, scope_id, window_start, request_count)
+         VALUES ('tenant', $1, now(), 1), ('entity', $2, now(), 1)",
+    )
+    .bind(tenant_id)
+    .bind(entity_id)
+    .execute(&pool)
+    .await
+    .expect("enrollment rate windows");
     let role_id = Uuid::new_v4();
     sqlx::query("INSERT INTO roles (id, name, tenant_id) VALUES ($1, $2, $3)")
         .bind(role_id)
@@ -1849,4 +1865,18 @@ async fn purge_tenant_removes_owned_objects_instead_of_orphaning_them() {
             "{table} row must be purged with the tenant, not orphaned"
         );
     }
+    let abandoned_rate_windows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pki_enrollment_rate_windows
+         WHERE (scope_kind = 'tenant' AND scope_id = $1)
+            OR (scope_kind = 'entity' AND scope_id = $2)",
+    )
+    .bind(tenant_id)
+    .bind(entity_id)
+    .fetch_one(&pool)
+    .await
+    .expect("rate window count");
+    assert_eq!(
+        abandoned_rate_windows, 0,
+        "tenant purge must drop tenant and child enrollment counters"
+    );
 }

--- a/tests/m22_restore.rs
+++ b/tests/m22_restore.rs
@@ -47,7 +47,6 @@ async fn restore_entity_reverses_soft_delete_but_keeps_credentials_revoked() {
         .execute(&pool)
         .await
         .expect("insert credential");
-
     atom::identity::repo::delete_entity(&pool, id, None)
         .await
         .expect("soft delete entity");
@@ -353,6 +352,15 @@ async fn purge_entity_physically_removes_a_tombstoned_row_and_cascades() {
         .execute(&pool)
         .await
         .expect("insert credential");
+    sqlx::query(
+        "INSERT INTO pki_enrollment_rate_windows
+         (scope_kind, scope_id, window_start, request_count)
+         VALUES ('entity', $1, now(), 1)",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .expect("insert enrollment rate window");
 
     atom::identity::repo::delete_entity(&pool, id, None)
         .await
@@ -374,6 +382,20 @@ async fn purge_entity_physically_removes_a_tombstoned_row_and_cascades() {
         .await
         .expect("credential lookup");
     assert!(cred_exists.is_none(), "FK cascade must drop credentials");
+    let rate_window_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM pki_enrollment_rate_windows
+            WHERE scope_kind = 'entity' AND scope_id = $1
+         )",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .expect("rate window lookup");
+    assert!(
+        !rate_window_exists,
+        "purge must drop the entity's durable enrollment counter"
+    );
 }
 
 #[tokio::test]

--- a/tests/m30_pki_ca_provisioning.rs
+++ b/tests/m30_pki_ca_provisioning.rs
@@ -447,6 +447,12 @@ fn assert_generated_ca_csr(authority: &AuthorityRecord, expected: BasicConstrain
         .key_usages
         .contains(&KeyUsagePurpose::KeyCertSign));
     assert!(parsed.params.key_usages.contains(&KeyUsagePurpose::CrlSign));
+    if expected == BasicConstraints::Constrained(0) {
+        assert!(parsed
+            .params
+            .key_usages
+            .contains(&KeyUsagePurpose::DigitalSignature));
+    }
 }
 
 fn assert_failed(outcome: provisioning::AuthorityImportOutcome) {
@@ -465,11 +471,12 @@ async fn import_root(pool: &PgPool, pem: &str) -> AuthorityRecord {
 
 async fn begin_tenant(pool: &PgPool, ca_keys: &PkiCaKeyConfig, tenant_id: Uuid) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let authority = provisioning::begin_tenant_authority_in_tx(&mut tx, ca_keys, tenant_id)
+    let mut authority = provisioning::begin_tenant_authority_in_tx(&mut tx, ca_keys, tenant_id)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    authority
+    authority.commit_generated_key();
+    authority.value
 }
 
 async fn begin_tenant_owned(
@@ -482,20 +489,22 @@ async fn begin_tenant_owned(
 
 async fn begin_platform_leaf(pool: &PgPool, ca_keys: &PkiCaKeyConfig) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let authority = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, ca_keys)
+    let mut authority = provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    authority
+    authority.commit_generated_key();
+    authority.value
 }
 
 async fn begin_platform_intermediate(pool: &PgPool, ca_keys: &PkiCaKeyConfig) -> AuthorityRecord {
     let mut tx = pool.begin().await.unwrap();
-    let authority = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
+    let mut authority = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
-    authority
+    authority.commit_generated_key();
+    authority.value
 }
 
 async fn provision_automatically(
@@ -504,11 +513,13 @@ async fn provision_automatically(
     tenant_id: Uuid,
 ) -> provisioning::AuthorityImportOutcome {
     let mut tx = pool.begin().await.unwrap();
-    let outcome = provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
-        .await
-        .unwrap();
+    let mut outcome =
+        provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
+            .await
+            .unwrap();
     tx.commit().await.unwrap();
-    outcome
+    outcome.commit_generated_key();
+    outcome.value
 }
 
 async fn import_signed(

--- a/tests/m31_pki_certificate_profiles.rs
+++ b/tests/m31_pki_certificate_profiles.rs
@@ -53,6 +53,22 @@ async fn stored_profiles_and_pki_core_enforce_the_pr004_contract() {
     assert_eq!(client.extended_key_usages().len(), 1);
     assert_eq!(server.extended_key_usages().len(), 1);
 
+    let empty_key_usages =
+        sqlx::query("UPDATE certificate_profiles SET key_usages = '{}'::text[] WHERE id = $1")
+            .bind(client.id())
+            .execute(&pool)
+            .await
+            .map(|_| ());
+    assert_check_violation(empty_key_usages);
+    let empty_extended_key_usages = sqlx::query(
+        "UPDATE certificate_profiles SET extended_key_usages = '{}'::text[] WHERE id = $1",
+    )
+    .bind(client.id())
+    .execute(&pool)
+    .await
+    .map(|_| ());
+    assert_check_violation(empty_extended_key_usages);
+
     let combined_id = insert_platform_profile(
         &pool,
         "combined",

--- a/tests/m32_pki_csr_issuance.rs
+++ b/tests/m32_pki_csr_issuance.rs
@@ -180,6 +180,11 @@ async fn managed_csr_issuance_enforces_the_pr005_contract() {
         .await;
     assert!(errors_contain(&mismatched_retry.errors, "idempotency key"));
     assert_eq!(certificate_count(&pool, entity_a).await, 1);
+    assert_eq!(
+        error_event_count(&pool, "certificate.issue", entity_a).await,
+        1,
+        "failed managed CSR issuance must publish one error observation"
+    );
 
     let ledger: (String, String, Option<Uuid>) = sqlx::query_as(
         r#"SELECT request_key_hash, request_fingerprint_sha256, credential_id
@@ -540,10 +545,11 @@ async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
+    let mut pending = provisioning::begin_platform_intermediate_in_tx(&mut tx, ca_keys)
         .await
         .unwrap();
     tx.commit().await.unwrap();
+    pending.commit_generated_key();
     let signed = sign_authority_csr(&pending, root);
     let mut tx = pool.begin().await.unwrap();
     let imported =
@@ -554,7 +560,7 @@ async fn provision_tenant_issuer(
     tx.commit().await.unwrap();
 
     let mut tx = pool.begin().await.unwrap();
-    let provisioned =
+    let mut provisioned =
         provisioning::provision_tenant_automatically_in_tx(&mut tx, ca_keys, tenant_id)
             .await
             .unwrap();
@@ -564,6 +570,7 @@ async fn provision_tenant_issuer(
         provisioned.validation_error
     );
     tx.commit().await.unwrap();
+    provisioned.commit_generated_key();
     sqlx::query(
         r#"UPDATE pki_authorities
            SET ocsp_url = $2, ca_issuers_url = $3,
@@ -640,7 +647,7 @@ async fn event_count(pool: &PgPool, table: &str, event: &str, target_id: Uuid) -
     let query = match table {
         "audit_logs" => "SELECT COUNT(*) FROM audit_logs WHERE event = $1 AND target_id = $2",
         "event_outbox" => {
-            "SELECT COUNT(*) FROM event_outbox WHERE event = $1 AND (payload->>'target_id')::uuid = $2"
+            "SELECT COUNT(*) FROM event_outbox WHERE event = $1 AND (payload->>'target_id')::uuid = $2 AND payload->>'outcome' = 'allow'"
         }
         _ => panic!("unsupported event table"),
     };
@@ -650,6 +657,21 @@ async fn event_count(pool: &PgPool, table: &str, event: &str, target_id: Uuid) -
         .fetch_one(pool)
         .await
         .unwrap()
+}
+
+async fn error_event_count(pool: &PgPool, event: &str, target_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM event_outbox
+           WHERE event = $1
+             AND (payload->>'target_id')::uuid = $2
+             AND payload->>'outcome' = 'error'
+             AND payload->'details'->>'transport' = 'graphql'"#,
+    )
+    .bind(event)
+    .bind(target_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }
 
 async fn install_serial_collision_trigger(pool: &PgPool, entity_id: Uuid) {

--- a/tests/m33_pki_generated_issuance.rs
+++ b/tests/m33_pki_generated_issuance.rs
@@ -132,6 +132,11 @@ async fn managed_generated_key_issuance_enforces_the_pr006_contract() {
         "no active issuing authority"
     ));
     assert_eq!(certificate_count(&pool, entity_without_issuer).await, 0);
+    assert_eq!(
+        error_event_count(&pool, "certificate.issue", entity_without_issuer).await,
+        1,
+        "failed generated issuance must publish one error observation"
+    );
 
     let issued = schema
         .execute(issue_request(
@@ -237,9 +242,9 @@ async fn managed_generated_key_issuance_enforces_the_pr006_contract() {
         credential_id.to_string()
     );
 
-    // A failure after signing but before persistence commits nothing and emits
-    // no operational record. The generated secret is dropped/zeroized by the
-    // service response wrapper and never appears in the returned error/logs.
+    // A failure after signing but before persistence commits no credential or
+    // success audit, but it does emit one error observation. The generated
+    // secret is dropped/zeroized and never appears in the returned error/logs.
     install_persistence_failure_trigger(&pool, entity_a).await;
     let before_credentials = certificate_count(&pool, entity_a).await;
     let before_audits = event_count(&pool, "audit_logs", entity_a).await;
@@ -262,8 +267,22 @@ async fn managed_generated_key_issuance_enforces_the_pr006_contract() {
     );
     assert_eq!(
         event_count(&pool, "event_outbox", entity_a).await,
-        before_events
+        before_events + 1
     );
+    let failure: (String, String) = sqlx::query_as(
+        r#"SELECT payload->>'outcome', payload->'details'->>'transport'
+           FROM event_outbox
+           WHERE event = 'certificate.issue'
+             AND actor_entity_id = $1
+             AND payload->>'outcome' = 'error'
+           ORDER BY created_at DESC
+           LIMIT 1"#,
+    )
+    .bind(entity_a)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(failure, ("error".into(), "graphql".into()));
 
     private_key_pem.zeroize();
 }
@@ -342,6 +361,21 @@ async fn certificate_count(pool: &PgPool, entity_id: Uuid) -> i64 {
         "SELECT COUNT(*) FROM credentials WHERE entity_id = $1 AND kind = 'certificate'",
     )
     .bind(entity_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn error_event_count(pool: &PgPool, event: &str, target_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM event_outbox
+           WHERE event = $1
+             AND (payload->>'target_id')::uuid = $2
+             AND payload->>'outcome' = 'error'
+             AND payload->'details'->>'transport' = 'graphql'"#,
+    )
+    .bind(event)
+    .bind(target_id)
     .fetch_one(pool)
     .await
     .unwrap()

--- a/tests/m34_pki_renewal.rs
+++ b/tests/m34_pki_renewal.rs
@@ -257,6 +257,11 @@ async fn issuer_aware_renewal_enforces_the_pr007_contract() {
         ))
         .await;
     assert!(errors_contain(&revoked_operator.errors, "revoked"));
+    assert_eq!(
+        error_event_count(&pool, "certificate.renew", old_revoked.credential_id).await,
+        1,
+        "failed renewal must publish one error observation"
+    );
 
     // The certificate-authenticated service seam accepts an exact, valid
     // certificate in its profile window and rejects credential substitution.
@@ -597,7 +602,9 @@ async fn assert_audit_and_outbox_linkage(pool: &PgPool, old_id: Uuid, new_id: Uu
     assert_eq!(details["revoke_old"], false);
     let payload: Value = sqlx::query_scalar(
         r#"SELECT payload FROM event_outbox
-           WHERE event = 'certificate.renew' AND (payload->>'target_id')::uuid = $1"#,
+           WHERE event = 'certificate.renew'
+             AND payload->>'outcome' = 'allow'
+             AND (payload->>'target_id')::uuid = $1"#,
     )
     .bind(old_id)
     .fetch_one(pool)
@@ -605,7 +612,10 @@ async fn assert_audit_and_outbox_linkage(pool: &PgPool, old_id: Uuid, new_id: Uu
     .unwrap();
     assert_eq!(payload["details"]["new_credential_id"], new_id.to_string());
     let event_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM event_outbox WHERE event = 'certificate.renew' AND (payload->>'target_id')::uuid = $1",
+        "SELECT COUNT(*) FROM event_outbox
+         WHERE event = 'certificate.renew'
+           AND payload->>'outcome' = 'allow'
+           AND (payload->>'target_id')::uuid = $1",
     )
     .bind(old_id)
     .fetch_one(pool)
@@ -628,6 +638,21 @@ async fn audit_details(pool: &PgPool, event: &str, old_id: Uuid) -> Value {
     )
     .bind(event)
     .bind(old_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn error_event_count(pool: &PgPool, event: &str, target_id: Uuid) -> i64 {
+    sqlx::query_scalar(
+        r#"SELECT COUNT(*) FROM event_outbox
+           WHERE event = $1
+             AND (payload->>'target_id')::uuid = $2
+             AND payload->>'outcome' = 'error'
+             AND payload->'details'->>'transport' = 'graphql'"#,
+    )
+    .bind(event)
+    .bind(target_id)
     .fetch_one(pool)
     .await
     .unwrap()

--- a/tests/m36_pki_issuer_crls.rs
+++ b/tests/m36_pki_issuer_crls.rs
@@ -148,10 +148,11 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         empty_a.der
     );
     let not_modified = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
-                .header(header::IF_NONE_MATCH, etag)
+                .header(header::IF_NONE_MATCH, &etag)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -162,6 +163,18 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         .await
         .unwrap()
         .is_empty());
+    let weak_not_modified = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/certs/issuers/{}/crl", issuer_a.id))
+                .header(header::IF_NONE_MATCH, format!("W/{etag}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(weak_not_modified.status(), StatusCode::NOT_MODIFIED);
 
     let key_compromise = issue_managed(&pool, &config, tenant_a, entity_a, "key-compromise").await;
     revoke(
@@ -270,6 +283,9 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
         .unwrap();
     assert!(after_restart.cache_hit);
     assert_eq!(after_restart.der, repaired.der);
+
+    let purge_entity = common::pki::create_entity(&pool, tenant_a, "pki-crl-purge").await;
+    let purge_leaf = issue_managed(&pool, &config, tenant_a, purge_entity, "purge").await;
 
     // Rotation retains old-authority publication. One old leaf is revoked
     // while the issuer is retiring and another after it is retired; neither
@@ -415,6 +431,38 @@ async fn per_issuer_crls_enforce_the_pr009_contract() {
             .der,
         retired_crl.der
     );
+
+    // Revocation publication evidence is independent of credential/entity
+    // retention. Purging the owning entity before regeneration cannot remove
+    // a still-valid serial from the issuer's next CRL.
+    revoke(
+        &pool,
+        purge_leaf.credential_id,
+        purge_entity,
+        tenant_a,
+        "key_compromise",
+    )
+    .await;
+    sqlx::query("DELETE FROM entities WHERE id = $1")
+        .bind(purge_entity)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM certificate_revocations WHERE credential_id = $1",
+        )
+        .bind(purge_leaf.credential_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap(),
+        1
+    );
+    let after_purge = service::issuer_crl(&pool, &config, issuer_a.id)
+        .await
+        .unwrap();
+    assert_eq!(after_purge.crl_number, 8);
+    assert!(crl_contains(&after_purge.der, &purge_leaf.serial_number));
 }
 
 async fn issue_managed(

--- a/tests/m37_pki_issuer_ocsp.rs
+++ b/tests/m37_pki_issuer_ocsp.rs
@@ -74,6 +74,14 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
     let leaf_b = issue_managed(&pool, &config, tenant_b, entity_b, "leaf-b").await;
     let issuer_a_pem = issuer_a.certificate_pem.as_deref().unwrap();
     let issuer_b_pem = issuer_b.certificate_pem.as_deref().unwrap();
+    let issuer_a_der = parse_x509_pem(issuer_a_pem.as_bytes()).unwrap().1.contents;
+    let (_, parsed_issuer_a) = x509_parser::parse_x509_certificate(&issuer_a_der).unwrap();
+    assert!(parsed_issuer_a
+        .key_usage()
+        .unwrap()
+        .unwrap()
+        .value
+        .digital_signature());
 
     // Both RFC-required SHA-1 CertIDs and reviewed SHA-256 CertIDs resolve to
     // good. The managed issuer currently supports ECDSA P-256, and the
@@ -323,6 +331,19 @@ async fn per_issuer_ocsp_enforces_the_pr010_contract() {
             .await
             .unwrap();
     assert_status(&duplicate_b_after_revoke, CertStatus::good());
+
+    // A physical credential purge must not turn a revoked issuer/serial into
+    // unknown while the certificate is still valid.
+    sqlx::query("DELETE FROM credentials WHERE id = $1")
+        .bind(leaf_a.credential_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let revoked_after_purge =
+        service::issuer_ocsp_response(&pool, &config, issuer_a.id, &request_a_sha1)
+            .await
+            .unwrap();
+    assert_status(&revoked_after_purge, CertStatus::revoked(revoked));
 
     // Rotation retains responder availability while the old authority is
     // retiring and after it is retired. No delegated responder is used: the

--- a/tests/m39_pki_enrollment.rs
+++ b/tests/m39_pki_enrollment.rs
@@ -912,8 +912,8 @@ async fn outbox_count(pool: &sqlx::PgPool, event: &str) -> i64 {
         "SELECT COUNT(*) FROM event_outbox
          WHERE event = $1 AND payload->>'outcome' = 'allow'",
     )
-        .bind(event)
-        .fetch_one(pool)
-        .await
-        .unwrap()
+    .bind(event)
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }

--- a/tests/m39_pki_enrollment.rs
+++ b/tests/m39_pki_enrollment.rs
@@ -908,7 +908,10 @@ async fn audit_count(pool: &sqlx::PgPool, event: &str) -> i64 {
 }
 
 async fn outbox_count(pool: &sqlx::PgPool, event: &str) -> i64 {
-    sqlx::query_scalar("SELECT COUNT(*) FROM event_outbox WHERE event = $1")
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM event_outbox
+         WHERE event = $1 AND payload->>'outcome' = 'allow'",
+    )
         .bind(event)
         .fetch_one(pool)
         .await

--- a/tests/m39_pki_enrollment.rs
+++ b/tests/m39_pki_enrollment.rs
@@ -282,6 +282,20 @@ async fn native_enrollment_enforces_the_pr014_contract() {
     .await
     .unwrap();
     assert_eq!(injected.status, 401, "{}", injected.body);
+    let native_denial: (String, String) = sqlx::query_as(
+        r#"SELECT payload->>'outcome', payload->'details'->>'transport'
+           FROM event_outbox
+           WHERE event = 'certificate.reenroll'
+             AND payload->>'outcome' = 'deny'
+             AND payload->'details'->>'transport' = 'native'
+           ORDER BY created_at DESC
+           LIMIT 1"#,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(native_denial.0, "deny");
+    assert_eq!(native_denial.1, "native");
 
     // A certificate asserted in the TLS handshake but signed outside Atom's
     // trust bundle is rejected during the in-process handshake.

--- a/tests/m40_pki_lifecycle_automation.rs
+++ b/tests/m40_pki_lifecycle_automation.rs
@@ -22,7 +22,7 @@ use atom::{
 use chrono::{DateTime, Duration, Utc};
 use rcgen::{CertificateParams, KeyPair};
 use serde_json::{json, Value};
-use sqlx::PgPool;
+use sqlx::{Acquire, PgPool};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -154,6 +154,41 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     assert_eq!(
         marker_count(&pool, future.credential_id, "renewal").await,
         0
+    );
+
+    // A delayed or failed sweep still claims windows after the subject has
+    // crossed its expiry timestamp; those events must not disappear merely
+    // because the next successful retry is late.
+    let overdue = issue(&pool, &config, tenant_b, entity_b, "overdue").await;
+    set_expiry_and_renewal(
+        &pool,
+        overdue.credential_id,
+        now - Duration::minutes(1),
+        now - Duration::hours(2),
+    )
+    .await;
+    let overdue_authority_tenant =
+        common::pki::create_tenant(&pool, "pki-life-overdue-authority").await;
+    let overdue_authority =
+        common::pki::provision_tenant_issuer(&pool, &config, &root, overdue_authority_tenant).await;
+    sqlx::query("UPDATE pki_authorities SET not_after = $2 WHERE id = $1")
+        .bind(overdue_authority.id)
+        .bind(now - Duration::minutes(1))
+        .execute(&pool)
+        .await
+        .unwrap();
+    let overdue_sweep = lifecycle::sweep_once(&pool, config.pki_lifecycle, true, now)
+        .await
+        .unwrap();
+    assert_eq!(overdue_sweep.certificate_events, 2);
+    assert_eq!(overdue_sweep.authority_events, 1);
+    assert_eq!(
+        marker_count(&pool, overdue.credential_id, "expiry").await,
+        1
+    );
+    assert_eq!(
+        marker_count(&pool, overdue_authority.id, "authority_expiry").await,
+        1
     );
 
     // The marker and outbox insert are one transaction: a forced outbox error
@@ -358,21 +393,22 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     assert_eq!(partial["items"][1]["outcome"], "failed");
     assert_eq!(partial["items"][1]["errorCode"], "internal");
     assert_eq!(partial["nextCursor"], ordered[0].to_string());
-    let failed_audit: (String, String) = sqlx::query_as(
+    let partial_snapshot = partial["snapshotAt"].as_str().unwrap().to_string();
+    let failed_observation: (String, String) = sqlx::query_as(
         r#"
-        SELECT outcome, details->>'error_code'
-        FROM audit_logs
-        WHERE event = 'certificate.bulk_revoke' AND target_id = $1
+        SELECT payload->>'outcome', payload->'details'->>'error_code'
+        FROM event_outbox
+        WHERE event = 'certificate.bulk_revoke' AND payload->>'target_id' = $1
         ORDER BY created_at DESC
         LIMIT 1
         "#,
     )
-    .bind(ordered[1])
+    .bind(ordered[1].to_string())
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(failed_audit.0, "error");
-    assert_eq!(failed_audit.1, "internal");
+    assert_eq!(failed_observation.0, "error");
+    assert_eq!(failed_observation.1, "internal");
     sqlx::query("UPDATE credentials SET metadata = $2 WHERE id = $1")
         .bind(ordered[1])
         .bind(original_metadata)
@@ -387,6 +423,7 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
             "tenantId": tenant_c,
             "reason": "key_compromise",
             "afterCredentialId": ordered[0],
+            "snapshotAt": partial_snapshot,
             "limit": 10
         }),
     )
@@ -395,6 +432,72 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     assert_eq!(resumed["items"].as_array().unwrap().len(), 1);
     assert_eq!(resumed["items"][0]["credentialId"], ordered[1].to_string());
     assert_eq!(resumed["items"][0]["outcome"], "revoked");
+
+    // A bulk operation freezes its membership at page one. Certificates
+    // issued between pages are deliberately excluded even when their random
+    // UUID sorts after the cursor; a later operation then picks them up.
+    let tenant_d = common::pki::create_tenant(&pool, "pki-life-d").await;
+    common::pki::provision_tenant_issuer(&pool, &config, &root, tenant_d).await;
+    let entity_d = common::pki::create_entity(&pool, tenant_d, "pki-life-d").await;
+    issue(&pool, &config, tenant_d, entity_d, "snapshot-one").await;
+    issue(&pool, &config, tenant_d, entity_d, "snapshot-two").await;
+    let snapshot_first = execute_bulk(
+        &schema,
+        common::admin_id(),
+        None,
+        json!({"tenantId": tenant_d, "reason": "superseded", "limit": 1}),
+    )
+    .await;
+    assert!(!snapshot_first["complete"].as_bool().unwrap());
+    let snapshot_cursor = Uuid::parse_str(snapshot_first["nextCursor"].as_str().unwrap()).unwrap();
+    let snapshot_at = snapshot_first["snapshotAt"].as_str().unwrap().to_string();
+    let mut issued_during_scan = None;
+    for index in 0..32 {
+        let issued = issue(
+            &pool,
+            &config,
+            tenant_d,
+            entity_d,
+            &format!("snapshot-late-{index}"),
+        )
+        .await;
+        if issued.credential_id > snapshot_cursor {
+            issued_during_scan = Some(issued);
+            break;
+        }
+    }
+    let issued_during_scan = issued_during_scan.expect("random UUID after first-page cursor");
+    let snapshot_resumed = execute_bulk(
+        &schema,
+        common::admin_id(),
+        None,
+        json!({
+            "tenantId": tenant_d,
+            "reason": "superseded",
+            "afterCredentialId": snapshot_cursor,
+            "snapshotAt": snapshot_at,
+            "limit": 100
+        }),
+    )
+    .await;
+    assert!(snapshot_resumed["complete"].as_bool().unwrap());
+    assert_eq!(
+        certificate_status(&pool, issued_during_scan.credential_id).await,
+        "active",
+        "the frozen operation must not absorb certificates issued between pages"
+    );
+    let catch_up = execute_bulk(
+        &schema,
+        common::admin_id(),
+        None,
+        json!({"tenantId": tenant_d, "reason": "superseded", "limit": 100}),
+    )
+    .await;
+    assert!(catch_up["complete"].as_bool().unwrap());
+    assert_eq!(
+        certificate_status(&pool, issued_during_scan.credential_id).await,
+        "revoked"
+    );
 
     // First enrollment is included in the unified lifecycle operation metric;
     // a deliberately invalid issuance and unknown revocation prove failures.
@@ -441,6 +544,28 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
         .await
         .unwrap();
     assert!(!crl.der.is_empty());
+
+    // `_in_tx` success is provisional. Rolling the caller-owned transaction
+    // back must not publish a successful issuance sample.
+    let before_rollback = lifecycle_metric_value(&metrics::render(&pool), "issuance", "success");
+    let mut rollback_tx = pool.begin().await.unwrap();
+    service::issue_certificate_from_csr_v2_in_tx(
+        &mut rollback_tx,
+        &config,
+        Some(tenant_b),
+        service::IssueCertificateFromCsrV2 {
+            entity_id: entity_b,
+            ttl_secs: None,
+            csr_pem: csr(),
+            idempotency_key: "m40-rolled-back-issuance".into(),
+        },
+    )
+    .await
+    .unwrap();
+    rollback_tx.rollback().await.unwrap();
+    let after_rollback = lifecycle_metric_value(&metrics::render(&pool), "issuance", "success");
+    assert_eq!(before_rollback, after_rollback);
+
     let rendered = metrics::render(&pool);
     for metric in [
         metrics::PKI_LIFECYCLE_OPERATIONS,
@@ -467,6 +592,29 @@ async fn lifecycle_automation_enforces_the_pr015_contract() {
     ] {
         assert!(!rendered.contains(&secret_or_identifier));
     }
+    metrics::record_pki_fleet_snapshot(&[], &[]);
+    let absent_snapshot = metrics::render(&pool);
+    assert!(
+        absent_snapshot.lines().any(|line| {
+            line.starts_with(metrics::PKI_AUTHORITY_TIME_TO_EXPIRY)
+                && line.contains("kind=\"root\"")
+                && line.ends_with(" NaN")
+        }),
+        "an absent authority kind must be explicit rather than a false zero: {absent_snapshot}"
+    );
+}
+
+fn lifecycle_metric_value(rendered: &str, operation: &str, outcome: &str) -> f64 {
+    rendered
+        .lines()
+        .find(|line| {
+            line.starts_with(metrics::PKI_LIFECYCLE_OPERATIONS)
+                && line.contains(&format!("operation=\"{operation}\""))
+                && line.contains(&format!("outcome=\"{outcome}\""))
+        })
+        .and_then(|line| line.rsplit_once(' '))
+        .and_then(|(_, value)| value.parse().ok())
+        .unwrap_or(0.0)
 }
 
 async fn issue(
@@ -738,6 +886,7 @@ async fn execute_bulk(
                 r#"mutation Bulk($input: BulkRevokeCertificatesInput!) {
                     bulkRevokeCertificates(input: $input) {
                         complete
+                        snapshotAt
                         nextCursor
                         items { credentialId issuerId entityId tenantId outcome errorCode }
                     }

--- a/tests/m41_pki_est.rs
+++ b/tests/m41_pki_est.rs
@@ -104,7 +104,7 @@ async fn est_adapter_interoperates_and_enforces_the_pr014b_contract() {
         .execute(&pool)
         .await
         .unwrap();
-        provisioned.authority
+        provisioned.value.authority
     };
 
     keys::bootstrap_if_needed(&pool, &config.signing_keys)

--- a/tests/m41_pki_est.rs
+++ b/tests/m41_pki_est.rs
@@ -77,7 +77,7 @@ async fn est_adapter_interoperates_and_enforces_the_pr014b_contract() {
     let issuer = common::pki::provision_tenant_issuer(&pool, &config, &root, tenant).await;
     let other_issuer = {
         let mut tx = pool.begin().await.unwrap();
-        let provisioned = provisioning::provision_tenant_automatically_in_tx(
+        let mut provisioned = provisioning::provision_tenant_automatically_in_tx(
             &mut tx,
             &config.pki_ca_keys,
             other_tenant,
@@ -90,6 +90,7 @@ async fn est_adapter_interoperates_and_enforces_the_pr014b_contract() {
             provisioned.validation_error
         );
         tx.commit().await.unwrap();
+        provisioned.commit_generated_key();
         sqlx::query(
             r#"UPDATE pki_authorities
                SET ocsp_url = $2, ca_issuers_url = $3,

--- a/tests/m42_pki_pkcs11.rs
+++ b/tests/m42_pki_pkcs11.rs
@@ -11,7 +11,8 @@ use atom::{
             key_provider::{
                 validate_startup, AuthorityKeyAlgorithm, AuthorityKeyContext, AuthorityKeyProvider,
                 AuthorityKeyProviderError, AuthorityKeyProviderStatus,
-                EncryptedDatabaseKeyProvider, ManagedAuthorityKeyProvider, Pkcs11KeyProvider,
+                EncryptedDatabaseKeyProvider, ManagedAuthorityKeyProvider, Pkcs11AuthorityKey,
+                Pkcs11KeyProvider,
             },
             provisioning, repo as authority_repo, AuthorityKeyBackend,
         },
@@ -258,16 +259,41 @@ async fn softhsm_enforces_the_pr013_provider_contract() {
         "provider outage cannot corrupt authority lifecycle state"
     );
 
+    // The key is generated before the caller-owned SQL transaction commits.
+    // Rolling that outer transaction back must also remove the token objects;
+    // otherwise retries would accumulate usable keys with no authority row.
+    let mut tx = pool.begin().await.expect("rollback transaction");
+    let rolled_back =
+        provisioning::begin_platform_leaf_issuer_in_tx(&mut tx, &app_config.pki_ca_keys)
+            .await
+            .expect("generate rollback candidate");
+    let rolled_back_context = AuthorityKeyContext {
+        authority_id: rolled_back.id,
+        tenant_id: rolled_back.tenant_id,
+        version: rolled_back.version,
+    };
+    let rolled_back_key =
+        Pkcs11AuthorityKey::from_authority(&rolled_back.value).expect("rollback key reference");
+    tx.rollback().await.expect("rollback generated authority");
+    drop(rolled_back);
+    assert_eq!(
+        provider
+            .public_key(rolled_back_context, &rolled_back_key)
+            .expect_err("rolled-back token key must be destroyed"),
+        AuthorityKeyProviderError::KeyNotFound
+    );
+
     let rotated_tenant = common::pki::create_tenant(&pool, "encrypted-rotation").await;
     let mut rotated_keys = app_config.pki_ca_keys.clone();
     rotated_keys.provisioning_backend = PkiCaProvisioningBackend::EncryptedDatabase;
     let mut tx = pool.begin().await.expect("rotation transaction");
-    let rotated =
+    let mut rotated =
         provisioning::provision_tenant_automatically_in_tx(&mut tx, &rotated_keys, rotated_tenant)
             .await
             .expect("cross-provider rotation");
     assert!(rotated.succeeded(), "{:?}", rotated.validation_error);
     tx.commit().await.expect("commit rotated authority");
+    rotated.commit_generated_key();
     assert_eq!(
         rotated.authority.key_backend,
         AuthorityKeyBackend::EncryptedDatabase


### PR DESCRIPTION
## Objective

Validate and land the remaining post-merge corrections for the PKI delivery as one exact, dependency-ordered `certificates` tree.

## Included focused follow-ups

- #71 — PR-004 profile usage invariants and CA path-length validation.
- #72 — PR-005/006/007 transactional failure observation and rollback coverage.
- #73 — PR-009/010 durable revocation evidence, CRL/OCSP behavior, KU, and ETag coverage.
- #74 — PR-014/015 enrollment resource bounds, durable cleanup, snapshot-safe bulk lifecycle work, overdue claims, and post-commit metrics.
- #75 — PR-013 PKCS#11 non-starving waits, late-mutation serialization, and generated-key rollback ownership.

The branches are applied in that order. Database migrations remain ordered as 015 then 016. The only overlapping code path preserves both error observation and lifecycle metrics recorded from the final commit result.

## Validation

`git diff --check` passes on the combined tree. The hosted workflows run API-doc validation, rustfmt, locked Clippy, compilation, every test binary against a fresh PostgreSQL database, the ignored SoftHSM contract suite, and the PKCS#11 backup recovery runbook.

## Scope

This PR targets `certificates`. It contains corrective work only for the already-merged PR-003 through PR-015 PKI delivery and supersedes the focused draft merge operations after preserving them as review records.