### PR TITLE
Fix blank externalId filter and no-op object-group removal events

### DIFF
--- a/src/authz/repo.rs
+++ b/src/authz/repo.rs
@@ -683,8 +683,12 @@ pub async fn remove_resource_from_object_group_with_audit(
     group_id: Uuid,
 ) -> Result<Resource, AppError> {
     let mut tx = pool.begin().await.map_err(db_err)?;
-    delete_resource_object_groups_in_tx(&mut tx, resource_id, Some(group_id)).await?;
+    let deleted = delete_resource_object_groups_in_tx(&mut tx, resource_id, Some(group_id)).await?;
     let resource = fetch_resource(&mut *tx, resource_id).await?;
+    if deleted == 0 {
+        tx.commit().await.map_err(db_err)?;
+        return Ok(resource);
+    }
     let meta = crate::audit::AuditMeta {
         actor_entity_id: actor_id,
         tenant_id: resource.tenant_id,
@@ -715,8 +719,12 @@ pub async fn clear_resource_object_groups_with_audit(
     resource_id: Uuid,
 ) -> Result<Resource, AppError> {
     let mut tx = pool.begin().await.map_err(db_err)?;
-    delete_resource_object_groups_in_tx(&mut tx, resource_id, None).await?;
+    let deleted = delete_resource_object_groups_in_tx(&mut tx, resource_id, None).await?;
     let resource = fetch_resource(&mut *tx, resource_id).await?;
+    if deleted == 0 {
+        tx.commit().await.map_err(db_err)?;
+        return Ok(resource);
+    }
     let meta = crate::audit::AuditMeta {
         actor_entity_id: actor_id,
         tenant_id: resource.tenant_id,
@@ -799,7 +807,7 @@ async fn delete_resource_object_groups_in_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     resource_id: Uuid,
     group_id: Option<Uuid>,
-) -> Result<(), AppError> {
+) -> Result<u64, AppError> {
     let tenant_id: Option<Option<Uuid>> =
         sqlx::query_scalar("SELECT tenant_id FROM resources WHERE id = $1 AND deleted_at IS NULL")
             .bind(resource_id)
@@ -829,7 +837,7 @@ async fn delete_resource_object_groups_in_tx(
             "resource {resource_id} not found"
         )));
     }
-    sqlx::query(
+    let deleted = sqlx::query(
         r#"DELETE FROM object_group_resources
            WHERE resource_id = $1 AND ($2::uuid IS NULL OR group_id = $2)"#,
     )
@@ -837,8 +845,9 @@ async fn delete_resource_object_groups_in_tx(
     .bind(group_id)
     .execute(&mut **tx)
     .await
-    .map_err(db_err)?;
-    Ok(())
+    .map_err(db_err)?
+    .rows_affected();
+    Ok(deleted)
 }
 
 /// Object group membership is a set, and a scalar attribute cannot express one.

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -493,8 +493,12 @@ pub async fn remove_entity_from_object_group_with_audit(
     group_id: Uuid,
 ) -> Result<Entity, AppError> {
     let mut tx = pool.begin().await.map_err(db_err)?;
-    delete_entity_object_groups_in_tx(&mut tx, entity_id, Some(group_id)).await?;
+    let deleted = delete_entity_object_groups_in_tx(&mut tx, entity_id, Some(group_id)).await?;
     let entity = fetch_entity(&mut *tx, entity_id).await?;
+    if deleted == 0 {
+        tx.commit().await.map_err(db_err)?;
+        return Ok(entity);
+    }
     let meta = crate::audit::AuditMeta {
         actor_entity_id: actor_id,
         tenant_id: entity.tenant_id,
@@ -524,8 +528,12 @@ pub async fn clear_entity_object_groups_with_audit(
     entity_id: Uuid,
 ) -> Result<Entity, AppError> {
     let mut tx = pool.begin().await.map_err(db_err)?;
-    delete_entity_object_groups_in_tx(&mut tx, entity_id, None).await?;
+    let deleted = delete_entity_object_groups_in_tx(&mut tx, entity_id, None).await?;
     let entity = fetch_entity(&mut *tx, entity_id).await?;
+    if deleted == 0 {
+        tx.commit().await.map_err(db_err)?;
+        return Ok(entity);
+    }
     let meta = crate::audit::AuditMeta {
         actor_entity_id: actor_id,
         tenant_id: entity.tenant_id,
@@ -609,7 +617,7 @@ async fn delete_entity_object_groups_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     entity_id: Uuid,
     group_id: Option<Uuid>,
-) -> Result<(), AppError> {
+) -> Result<u64, AppError> {
     let tenant_id: Option<Option<Uuid>> =
         sqlx::query_scalar("SELECT tenant_id FROM entities WHERE id = $1 AND deleted_at IS NULL")
             .bind(entity_id)
@@ -635,7 +643,7 @@ async fn delete_entity_object_groups_in_tx(
     if locked.is_none() {
         return Err(AppError::not_found(format!("entity {entity_id} not found")));
     }
-    sqlx::query(
+    let deleted = sqlx::query(
         r#"DELETE FROM object_group_entities
            WHERE entity_id = $1 AND ($2::uuid IS NULL OR group_id = $2)"#,
     )
@@ -643,8 +651,9 @@ async fn delete_entity_object_groups_in_tx(
     .bind(group_id)
     .execute(&mut **tx)
     .await
-    .map_err(db_err)?;
-    Ok(())
+    .map_err(db_err)?
+    .rows_affected();
+    Ok(deleted)
 }
 
 /// Object group membership is a set, and a scalar attribute cannot express one.

--- a/src/models/external_id.rs
+++ b/src/models/external_id.rs
@@ -23,19 +23,17 @@ fn trim_external_id(external_id: Option<String>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-/// Trim an external identifier for storage or lookup. Whitespace-only (and
-/// empty) input is absent, not a value. Case is preserved.
-///
-/// This is the lookup-side normalization: it never fails, so an invalid filter
-/// value simply matches nothing instead of erroring.
+/// Normalize an external identifier for a lookup filter. `None` means
+/// omitted (no filter). Blank/NUL/over-cap `Some(_)` normalizes to a value
+/// over `MAX_EXTERNAL_ID_LEN`, unmatchable per `chk_entities_external_id_length`,
+/// so it never degrades into "no filter" the way collapsing to `None` would.
 pub fn normalize_external_id(external_id: Option<String>) -> Option<String> {
-    trim_external_id(external_id).map(|value| {
-        if value.contains('\0') {
-            "x".repeat(MAX_EXTERNAL_ID_LEN + 1)
-        } else {
-            value
-        }
-    })
+    let value = external_id?.trim().to_string();
+    if value.is_empty() || value.contains('\0') {
+        Some("x".repeat(MAX_EXTERNAL_ID_LEN + 1))
+    } else {
+        Some(value)
+    }
 }
 
 /// Normalize an optional external identifier for a write, enforcing the length
@@ -198,7 +196,21 @@ mod tests {
             Some("x".repeat(MAX_EXTERNAL_ID_LEN + 1)),
             "a NUL-bearing filter must match nothing without binding a NUL to Postgres"
         );
-        assert_eq!(normalize_external_id(Some("  ".into())), None);
+    }
+
+    #[test]
+    fn normalize_keeps_omitted_and_blank_distinct() {
+        // Omitted (`None`): callers bind this as SQL NULL, and the query reads
+        // "IS NULL OR col = $n", so `None` means "no filter applied".
+        assert_eq!(normalize_external_id(None), None);
+
+        // Explicitly blank stays `Some(_)`: the sentinel is over
+        // `MAX_EXTERNAL_ID_LEN`, which no stored row can equal.
+        for blank in ["", "   ", "\t\n"] {
+            let normalized =
+                normalize_external_id(Some(blank.to_string())).expect("blank filter stays Some");
+            assert!(normalized.chars().count() > MAX_EXTERNAL_ID_LEN);
+        }
     }
 
     #[test]

--- a/tests/m30_group_membership_many_to_many.rs
+++ b/tests/m30_group_membership_many_to_many.rs
@@ -655,6 +655,117 @@ async fn removing_one_group_leaves_the_other_membership_and_its_grants() {
     assert!(!pdp_allows(&pool, via_b, "entity", device).await);
 }
 
+// ─── No-op removals do not publish membership-change events ───────────────────
+
+async fn outbox_row_exists(pool: &sqlx::PgPool, event: &str, target_id: Uuid) -> bool {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (SELECT 1 FROM event_outbox
+                         WHERE event = $1 AND (payload->>'target_id')::uuid = $2)",
+    )
+    .bind(event)
+    .bind(target_id)
+    .fetch_one(pool)
+    .await
+    .expect("query event_outbox")
+}
+
+#[tokio::test]
+#[ignore]
+async fn removing_a_membership_that_never_existed_publishes_no_event() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "noop-entity-remove").await;
+    let device = make_entity(&pool, tenant_id, EntityKind::Device, "device").await;
+    let group = make_object_group(&pool, tenant_id, "g").await;
+
+    atom::identity::repo::remove_entity_from_object_group_with_audit(
+        &pool, true, None, device, group,
+    )
+    .await
+    .expect("no-op remove must still succeed");
+
+    assert!(
+        !outbox_row_exists(&pool, "entity.object_group.remove", device).await,
+        "removing a membership that never existed must not publish an event"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn removing_an_existing_membership_still_publishes_its_event() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "real-entity-remove").await;
+    let device = make_entity(&pool, tenant_id, EntityKind::Device, "device").await;
+    let group = make_object_group(&pool, tenant_id, "g").await;
+    atom::identity::repo::add_entity_to_object_group(&pool, device, group)
+        .await
+        .expect("add membership");
+
+    atom::identity::repo::remove_entity_from_object_group_with_audit(
+        &pool, true, None, device, group,
+    )
+    .await
+    .expect("remove");
+
+    assert!(
+        outbox_row_exists(&pool, "entity.object_group.remove", device).await,
+        "an actual removal must still publish its event"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn clearing_an_already_empty_entity_membership_set_publishes_no_event() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "noop-entity-clear").await;
+    let device = make_entity(&pool, tenant_id, EntityKind::Device, "device").await;
+
+    atom::identity::repo::clear_entity_object_groups_with_audit(&pool, true, None, device)
+        .await
+        .expect("no-op clear must still succeed");
+
+    assert!(
+        !outbox_row_exists(&pool, "entity.object_groups.clear", device).await,
+        "clearing an already-empty membership set must not publish an event"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn removing_a_resource_membership_that_never_existed_publishes_no_event() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "noop-resource-remove").await;
+    let resource = make_resource(&pool, tenant_id, "channel").await;
+    let group = make_object_group(&pool, tenant_id, "g").await;
+
+    atom::authz::repo::remove_resource_from_object_group_with_audit(
+        &pool, true, None, resource, group,
+    )
+    .await
+    .expect("no-op remove must still succeed");
+
+    assert!(
+        !outbox_row_exists(&pool, "resource.object_group.remove", resource).await,
+        "removing a membership that never existed must not publish an event"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn clearing_an_already_empty_resource_membership_set_publishes_no_event() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "noop-resource-clear").await;
+    let resource = make_resource(&pool, tenant_id, "channel").await;
+
+    atom::authz::repo::clear_resource_object_groups_with_audit(&pool, true, None, resource)
+        .await
+        .expect("no-op clear must still succeed");
+
+    assert!(
+        !outbox_row_exists(&pool, "resource.object_groups.clear", resource).await,
+        "clearing an already-empty membership set must not publish an event"
+    );
+}
+
 // ─── Descendant traversal across two subtrees ──────────────────────────────
 
 #[tokio::test]

--- a/tests/m31_entity_external_id.rs
+++ b/tests/m31_entity_external_id.rs
@@ -665,6 +665,19 @@ async fn the_external_id_filter_matches_exactly_and_scopes_to_tenant() {
     assert!(list_by_external_id(&p, &slug("SN-absent")).await.is_empty());
 }
 
+/// A blank filter is a caller mistake, not "no filter": it must match zero
+/// rows, not silently fall back to the unfiltered authorized set.
+#[tokio::test]
+#[ignore]
+async fn a_blank_external_id_filter_matches_nothing_via_authorized_listing() {
+    let p = pool().await;
+    let tenant_id = make_tenant(&p).await;
+    create(&p, device(Some(tenant_id), Some(&slug("SN")))).await;
+    create(&p, device(Some(tenant_id), None)).await;
+
+    assert!(list_by_external_id(&p, "   ").await.is_empty());
+}
+
 #[tokio::test]
 #[ignore]
 async fn the_admin_deleted_listing_filters_by_external_id_too() {
@@ -698,6 +711,43 @@ async fn the_admin_deleted_listing_filters_by_external_id_too() {
 
     assert_eq!(list.total, 1);
     assert_eq!(list.items[0].id, entity.id);
+}
+
+/// Same caller-mistake guarantee as `authorized_object_ids`, on the other
+/// `external_id` call site (`identity::repo::list_entities`).
+#[tokio::test]
+#[ignore]
+async fn a_blank_external_id_filter_matches_nothing_via_list_entities() {
+    let p = pool().await;
+    let tenant_id = make_tenant(&p).await;
+    create(&p, device(Some(tenant_id), Some(&slug("SN")))).await;
+    create(&p, device(Some(tenant_id), None)).await;
+
+    let list = identity_repo::list_entities(
+        &p,
+        ListEntities {
+            q: None,
+            kind: None,
+            external_id: Some("   ".to_string()),
+            profile_id: None,
+            tenant_id: Some(tenant_id),
+            attributes_contains: None,
+            status: None,
+            deleted: DeletedFilter::Live,
+            parent_group_id: None,
+            include_descendants: false,
+            limit: 20,
+            offset: 0,
+        },
+    )
+    .await
+    .expect("blank external_id listing");
+
+    assert_eq!(
+        list.total, 0,
+        "a blank external_id filter must match nothing"
+    );
+    assert!(list.items.is_empty());
 }
 
 #[tokio::test]

--- a/tests/m32_authorized_object_ids_filters.rs
+++ b/tests/m32_authorized_object_ids_filters.rs
@@ -467,3 +467,35 @@ async fn external_id_and_entity_status_also_narrow() {
     assert_eq!(total, 1);
     assert_eq!(ids, vec![matching.to_string()]);
 }
+
+/// A blank `externalId` is a caller mistake, not "no filter": it must match
+/// zero rows, not the unfiltered authorized set.
+#[tokio::test]
+#[ignore]
+async fn blank_external_id_matches_nothing_not_everything() {
+    let pool = common::pool().await;
+    let tenant_id = make_tenant(&pool, "m32-blank-external-id").await;
+    let subject_id = make_entity(&pool, tenant_id, json!({})).await;
+    let a = make_entity(&pool, tenant_id, json!({})).await;
+    let b = make_entity(&pool, tenant_id, json!({})).await;
+    grant_read(&pool, tenant_id, subject_id, a).await;
+    grant_read(&pool, tenant_id, subject_id, b).await;
+
+    let schema = build_schema(state(pool).await);
+    let response = schema
+        .execute(authed_as(
+            subject_id,
+            format!(
+                r#"{{ authorizedObjectIds(input: {{
+                      subjectId: "{subject_id}", action: "read",
+                      objectKind: "entity", objectType: "entity:device",
+                      externalId: "   "
+                    }}) {{ ids total }} }}"#
+            ),
+        ))
+        .await;
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let (ids, total) = listing(&response.data.into_json().expect("json data"));
+    assert_eq!(total, 0, "a blank externalId filter must match nothing");
+    assert!(ids.is_empty());
+}


### PR DESCRIPTION
## Summary

Two P2 findings from review of #69, both confirmed real and fixed.

**1. A blank `externalId` filter matched the unfiltered set, not nothing.**

`normalize_external_id` collapsed both "filter omitted" (`None`) and
"filter explicitly blank/whitespace" (`Some("   ")`) down to `None`.
The SQL callers (`authorized_object_ids`'s entity path, and
`identity::repo::list_entities`) bind that as `col IS NULL OR col =
$n`, so a caller who passed a blank `externalId` — a mistake, or an
attempt to match nothing — got back the full unfiltered
authorized/listed set instead of zero rows.

Fix: every `Some(_)` input now stays `Some(_)`. Blank, NUL-bearing,
and over-cap values normalize to a sentinel longer than
`MAX_EXTERNAL_ID_LEN`, which `chk_entities_external_id_length`
guarantees no stored row can equal — the same "unmatchable value"
approach the function already used for NUL bytes. Only a genuinely
omitted `None` still means "no filter".

**2. No-op object-group removals published membership-change events anyway.**

`remove_entity_from_object_group`, `clear_entity_object_groups`, and
their resource counterparts (`authz::repo`) discarded the DELETE's
affected-row count and unconditionally published
`entity.object_group.remove` / `entity.object_groups.clear` (and the
resource equivalents), even when zero rows were deleted — e.g.
removing a membership that never existed, or clearing an
already-empty set. Event consumers were told a change happened when
nothing changed.

Fix: `delete_entity_object_groups_in_tx` /
`delete_resource_object_groups_in_tx` now return the deleted row
count, and the four `*_with_audit` callers skip the event publish
(but still commit) when it's zero — the same shape already used by
`add_entity_to_object_group_with_audit` /
`add_resource_to_object_group_with_audit` on the additive side, and
by `remove_group_member_with_audit` for principal-group membership.

## Test plan

- [x] `cargo build`
- [x] `cargo test --lib` (unit tests, no DB)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Full DB-gated suite run the way CI runs it — each test binary
      against its own freshly migrated database, single-threaded
      (`.github/workflows/rust.yml`'s `run_one` loop) — all green,
      including the new tests:
      - `models::external_id::tests::normalize_keeps_omitted_and_blank_distinct`
      - `m31_entity_external_id::a_blank_external_id_filter_matches_nothing_via_authorized_listing`
      - `m31_entity_external_id::a_blank_external_id_filter_matches_nothing_via_list_entities`
      - `m32_authorized_object_ids_filters::blank_external_id_matches_nothing_not_everything`
      - `m30_group_membership_many_to_many::removing_a_membership_that_never_existed_publishes_no_event`
      - `m30_group_membership_many_to_many::removing_an_existing_membership_still_publishes_its_event`
      - `m30_group_membership_many_to_many::clearing_an_already_empty_entity_membership_set_publishes_no_event`
      - `m30_group_membership_many_to_many::removing_a_resource_membership_that_never_existed_publishes_no_event`
      - `m30_group_membership_many_to_many::clearing_an_already_empty_resource_membership_set_publishes_no_event`