### PR TITLE
Surface object-group membership and reverse policy lookup in the UI

### DIFF
--- a/app/components/crud/table/inspect-sheet.tsx
+++ b/app/components/crud/table/inspect-sheet.tsx
@@ -11,6 +11,8 @@ import { EntityCredentials } from "@/components/entities/entity-credentials";
 import { EntityInspectDetails } from "@/components/entities/entity-inspect-details";
 import { GroupInspectDetails } from "@/components/groups/group-inspect-details";
 import { GroupMembersPanel } from "@/components/groups/group-members-panel";
+import { ObjectGroupMembersPanel } from "@/components/groups/object-group-members-panel";
+import { ObjectAccessPanel } from "@/components/policy/object-access-panel";
 import { PolicyInspectDetails } from "@/components/policy/policy-inspect-details";
 import { ProfileInspectDetails } from "@/components/profiles/profile-inspect-details";
 import { ResourceInspectDetails } from "@/components/resources/resource-inspect-details";
@@ -110,6 +112,7 @@ function InspectBody({
       <Tabs defaultValue="details">
         <TabsList className="mb-4">
           <TabsTrigger value="details">Details</TabsTrigger>
+          <TabsTrigger value="access">Access</TabsTrigger>
           <TabsTrigger value="audit">Audit Logs</TabsTrigger>
         </TabsList>
         <TabsContent value="details" className="grid gap-3">
@@ -121,6 +124,14 @@ function InspectBody({
               entityKind={
                 typeof inspected.kind === "string" ? inspected.kind : undefined
               }
+            />
+          ) : null}
+        </TabsContent>
+        <TabsContent value="access">
+          {inspected?.id ? (
+            <ObjectAccessPanel
+              objectId={String(inspected.id)}
+              objectKind="entity"
             />
           ) : null}
         </TabsContent>
@@ -140,6 +151,12 @@ function InspectBody({
         {inspected?.id && groupType === "principal" ? (
           <GroupMembersPanel groupId={String(inspected.id)} />
         ) : null}
+        {inspected?.id && groupType === "object" ? (
+          <ObjectGroupMembersPanel
+            groupId={String(inspected.id)}
+            tenantId={inspected.tenantId ? String(inspected.tenantId) : null}
+          />
+        ) : null}
       </>
     );
   }
@@ -148,11 +165,20 @@ function InspectBody({
       <Tabs defaultValue="details">
         <TabsList className="mb-4">
           <TabsTrigger value="details">Details</TabsTrigger>
+          <TabsTrigger value="access">Access</TabsTrigger>
           <TabsTrigger value="audit">Audit Logs</TabsTrigger>
         </TabsList>
         <TabsContent value="details" className="grid gap-3">
           <ResourceInspectDetails row={inspected} />
           <InspectAuthzAction resourceKey={resourceKey} row={inspected} />
+        </TabsContent>
+        <TabsContent value="access">
+          {inspected?.id ? (
+            <ObjectAccessPanel
+              objectId={String(inspected.id)}
+              objectKind="resource"
+            />
+          ) : null}
         </TabsContent>
         <TabsContent value="audit">
           {inspected?.id ? (

--- a/app/components/entities/entity-inspect-details.tsx
+++ b/app/components/entities/entity-inspect-details.tsx
@@ -5,9 +5,11 @@ import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 import * as React from "react";
 import { StatusBadge } from "@/components/crud/status-badge";
 import { DisplayTimeCell } from "@/components/display-time";
+import { ObjectGroupMembershipField } from "@/components/groups/object-group-membership-field";
 import { Button } from "@/components/ui/button";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { graphqlClient } from "@/lib/graphql/client";
+import { objectGroupIdsFromRow } from "@/lib/object-groups/membership";
 import { Action } from "@/lib/utils";
 
 const TENANT_QUERY = `
@@ -136,6 +138,15 @@ export function EntityInspectDetails({ row }: { row: Row | null }) {
         <Field label="Tenant">
           <span className="text-sm">{tenantName}</span>
         </Field>
+      ) : null}
+
+      {id ? (
+        <ObjectGroupMembershipField
+          initialObjectGroupIds={objectGroupIdsFromRow(row)}
+          kind="entity"
+          memberId={id}
+          tenantId={tenantId}
+        />
       ) : null}
 
       {profileId ? (

--- a/app/components/groups/object-group-members-panel.test.tsx
+++ b/app/components/groups/object-group-members-panel.test.tsx
@@ -31,7 +31,7 @@ vi.stubGlobal(
   },
 );
 
-function renderPanel() {
+function renderPanel(tenantId: string | null = "tenant-1") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -41,7 +41,7 @@ function renderPanel() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <ObjectGroupMembersPanel groupId="group-1" tenantId="tenant-1" />
+      <ObjectGroupMembersPanel groupId="group-1" tenantId={tenantId} />
     </QueryClientProvider>,
   );
 }
@@ -151,5 +151,21 @@ describe("ObjectGroupMembersPanel", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "sensor-01 removed from this group",
     );
+  });
+
+  it("does not query or render add controls for a platform-scoped group", async () => {
+    renderPanel(null);
+
+    await screen.findByText("sensor-01");
+
+    expect(screen.queryByText("Add entity")).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search entities…"),
+    ).not.toBeInTheDocument();
+    expect(
+      mocks.graphqlClient.mock.calls.some(([call]) =>
+        call.query.includes("ObjectGroupEntityCandidates"),
+      ),
+    ).toBe(false);
   });
 });

--- a/app/components/groups/object-group-members-panel.test.tsx
+++ b/app/components/groups/object-group-members-panel.test.tsx
@@ -1,0 +1,155 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ObjectGroupMembersPanel } from "@/components/groups/object-group-members-panel";
+
+const mocks = vi.hoisted(() => ({
+  graphqlClient: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/lib/graphql/client", () => ({
+  graphqlClient: mocks.graphqlClient,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+// jsdom has no ResizeObserver, which the scroll area measures itself with.
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+function renderPanel() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ObjectGroupMembersPanel groupId="group-1" tenantId="tenant-1" />
+    </QueryClientProvider>,
+  );
+}
+
+type GraphqlCall = { query: string; variables?: Record<string, unknown> };
+
+function respond({ query, variables }: GraphqlCall) {
+  if (query.includes("ObjectGroupEntityMembers")) {
+    expect(variables).toMatchObject({ groupId: "group-1" });
+    return Promise.resolve({
+      list: {
+        total: 1,
+        items: [
+          {
+            id: "entity-1",
+            name: "sensor-01",
+            kind: "device",
+            status: "active",
+          },
+        ],
+      },
+    });
+  }
+
+  if (query.includes("ObjectGroupEntityCandidates")) {
+    expect(variables).toMatchObject({ tenantId: "tenant-1" });
+    return Promise.resolve({
+      list: {
+        total: 1,
+        items: [
+          {
+            id: "entity-2",
+            name: "gateway-02",
+            kind: "device",
+            status: "active",
+          },
+        ],
+      },
+    });
+  }
+
+  if (query.includes("AddEntityToObjectGroup")) {
+    return Promise.resolve({
+      result: { id: "entity-2", objectGroupIds: ["group-1"] },
+    });
+  }
+
+  if (query.includes("RemoveEntityFromObjectGroup")) {
+    return Promise.resolve({
+      result: { id: "entity-1", objectGroupIds: [] },
+    });
+  }
+
+  throw new Error(`Unexpected query: ${query}`);
+}
+
+describe("ObjectGroupMembersPanel", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.graphqlClient.mockReset();
+    mocks.toastSuccess.mockReset();
+    mocks.graphqlClient.mockImplementation(respond);
+  });
+
+  it("lists the entities in the object group", async () => {
+    renderPanel();
+
+    expect(await screen.findByText("sensor-01")).toBeInTheDocument();
+    expect(screen.getByText("1 entity")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("adds a searched entity to the group", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await screen.findByText("gateway-02");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(mocks.graphqlClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: { entityId: "entity-2", objectGroupId: "group-1" },
+        }),
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "gateway-02 added to this group",
+    );
+  });
+
+  it("removes a member from the group", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await screen.findByText("sensor-01");
+    await user.click(screen.getByRole("button", { name: "Remove from group" }));
+
+    await waitFor(() => {
+      expect(mocks.graphqlClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: { entityId: "entity-1", objectGroupId: "group-1" },
+        }),
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "sensor-01 removed from this group",
+    );
+  });
+});

--- a/app/components/groups/object-group-members-panel.tsx
+++ b/app/components/groups/object-group-members-panel.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import * as React from "react";
+import { StatusBadge } from "@/components/crud/status-badge";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  memberDisplayName,
+  memberKindLabel,
+  memberKindTitle,
+  type ObjectMemberKind,
+} from "@/lib/object-groups/membership";
+import {
+  useObjectGroupMemberCandidates,
+  useObjectGroupMembers,
+  useObjectGroupMembershipActions,
+} from "@/lib/object-groups/use-object-group-membership";
+
+const PAGE_SIZE = 10;
+
+export function ObjectGroupMembersPanel({
+  groupId,
+  tenantId,
+}: {
+  groupId: string;
+  tenantId?: string | null;
+}) {
+  return (
+    <div className="grid gap-3 rounded-lg border bg-background p-3">
+      <div className="text-sm font-medium">Members</div>
+      <p className="text-xs text-muted-foreground">
+        Entities and resources in this object group. Membership is many-to-many,
+        so an object can belong to several object groups at once.
+      </p>
+
+      <Tabs defaultValue="entity">
+        <TabsList className="mb-3">
+          <TabsTrigger value="entity">Entities</TabsTrigger>
+          <TabsTrigger value="resource">Resources</TabsTrigger>
+        </TabsList>
+        <TabsContent value="entity">
+          <ObjectGroupMemberList
+            groupId={groupId}
+            kind="entity"
+            tenantId={tenantId}
+          />
+        </TabsContent>
+        <TabsContent value="resource">
+          <ObjectGroupMemberList
+            groupId={groupId}
+            kind="resource"
+            tenantId={tenantId}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function ObjectGroupMemberList({
+  groupId,
+  kind,
+  tenantId,
+}: {
+  groupId: string;
+  kind: ObjectMemberKind;
+  tenantId?: string | null;
+}) {
+  const [page, setPage] = React.useState(1);
+  const [search, setSearch] = React.useState("");
+
+  const membersQuery = useObjectGroupMembers({
+    groupId,
+    kind,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+  const candidatesQuery = useObjectGroupMemberCandidates({
+    kind,
+    tenantId,
+    search,
+  });
+  const { addToGroup, removeFromGroup } = useObjectGroupMembershipActions(kind);
+
+  const members = membersQuery.data?.items ?? [];
+  const total = membersQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const candidates = candidatesQuery.data ?? [];
+
+  return (
+    <div className="grid gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium">{memberKindTitle(kind)}</span>
+        <Badge variant="outline">{memberKindLabel(kind, total)}</Badge>
+      </div>
+
+      {membersQuery.isError ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {membersQuery.error.message}
+        </div>
+      ) : membersQuery.isFetching && members.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : members.length === 0 ? (
+        <div className="rounded-lg border bg-background p-3 text-sm text-muted-foreground">
+          No {kind === "entity" ? "entities" : "resources"} in this group yet.
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          {members.map((member) => (
+            <div
+              className="flex items-center justify-between gap-2 rounded-lg border bg-background px-3 py-2"
+              key={member.id}
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <span className="truncate text-sm font-medium">
+                  {memberDisplayName(member)}
+                </span>
+                <span className="truncate font-mono text-xs text-muted-foreground">
+                  {member.kind}
+                </span>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {member.status ? <StatusBadge value={member.status} /> : null}
+                <Button
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                  disabled={removeFromGroup.isPending}
+                  onClick={() =>
+                    removeFromGroup.mutate({
+                      memberId: member.id,
+                      objectGroupId: groupId,
+                      message: `${memberDisplayName(member)} removed from this group`,
+                    })
+                  }
+                  size="sm"
+                  variant="ghost"
+                >
+                  <Trash2 className="size-3.5" />
+                  <span className="sr-only">Remove from group</span>
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 ? (
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            Page {page} of {totalPages} · {total} total
+          </span>
+          <div className="flex gap-2">
+            <Button
+              disabled={page <= 1 || membersQuery.isFetching}
+              onClick={() => setPage((current) => current - 1)}
+              size="sm"
+              variant="outline"
+            >
+              Previous
+            </Button>
+            <Button
+              disabled={page >= totalPages || membersQuery.isFetching}
+              onClick={() => setPage((current) => current + 1)}
+              size="sm"
+              variant="outline"
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 rounded-lg border bg-muted/30 p-3">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Plus className="size-4 text-muted-foreground" />
+          Add {kind}
+        </div>
+        <Input
+          className="h-8 text-sm"
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={`Search ${kind === "entity" ? "entities" : "resources"}…`}
+          value={search}
+        />
+        {candidatesQuery.isError ? (
+          <div className="text-sm text-destructive">
+            {candidatesQuery.error.message}
+          </div>
+        ) : candidates.length === 0 ? (
+          <div className="text-xs text-muted-foreground">
+            {search
+              ? `No matching ${kind === "entity" ? "entities" : "resources"}.`
+              : `No ${kind === "entity" ? "entities" : "resources"} available.`}
+          </div>
+        ) : (
+          <ScrollArea className="max-h-48">
+            <div className="grid gap-1">
+              {candidates.map((candidate) => (
+                <div
+                  className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+                  key={candidate.id}
+                >
+                  <div className="flex min-w-0 flex-col gap-0">
+                    <span className="truncate text-xs font-medium">
+                      {memberDisplayName(candidate)}
+                    </span>
+                    <span className="truncate font-mono text-xs text-muted-foreground">
+                      {candidate.kind}
+                    </span>
+                  </div>
+                  <Button
+                    className="h-7 shrink-0 text-xs"
+                    disabled={addToGroup.isPending}
+                    onClick={() =>
+                      addToGroup.mutate({
+                        memberId: candidate.id,
+                        objectGroupId: groupId,
+                        message: `${memberDisplayName(candidate)} added to this group`,
+                      })
+                    }
+                    size="sm"
+                    variant="outline"
+                  >
+                    Add
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/groups/object-group-members-panel.tsx
+++ b/app/components/groups/object-group-members-panel.tsx
@@ -173,64 +173,66 @@ function ObjectGroupMemberList({
         </div>
       ) : null}
 
-      <div className="grid gap-3 rounded-lg border bg-muted/30 p-3">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <Plus className="size-4 text-muted-foreground" />
-          Add {kind}
-        </div>
-        <Input
-          className="h-8 text-sm"
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder={`Search ${kind === "entity" ? "entities" : "resources"}…`}
-          value={search}
-        />
-        {candidatesQuery.isError ? (
-          <div className="text-sm text-destructive">
-            {candidatesQuery.error.message}
+      {tenantId ? (
+        <div className="grid gap-3 rounded-lg border bg-muted/30 p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Plus className="size-4 text-muted-foreground" />
+            Add {kind}
           </div>
-        ) : candidates.length === 0 ? (
-          <div className="text-xs text-muted-foreground">
-            {search
-              ? `No matching ${kind === "entity" ? "entities" : "resources"}.`
-              : `No ${kind === "entity" ? "entities" : "resources"} available.`}
-          </div>
-        ) : (
-          <ScrollArea className="max-h-48">
-            <div className="grid gap-1">
-              {candidates.map((candidate) => (
-                <div
-                  className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
-                  key={candidate.id}
-                >
-                  <div className="flex min-w-0 flex-col gap-0">
-                    <span className="truncate text-xs font-medium">
-                      {memberDisplayName(candidate)}
-                    </span>
-                    <span className="truncate font-mono text-xs text-muted-foreground">
-                      {candidate.kind}
-                    </span>
-                  </div>
-                  <Button
-                    className="h-7 shrink-0 text-xs"
-                    disabled={addToGroup.isPending}
-                    onClick={() =>
-                      addToGroup.mutate({
-                        memberId: candidate.id,
-                        objectGroupId: groupId,
-                        message: `${memberDisplayName(candidate)} added to this group`,
-                      })
-                    }
-                    size="sm"
-                    variant="outline"
-                  >
-                    Add
-                  </Button>
-                </div>
-              ))}
+          <Input
+            className="h-8 text-sm"
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={`Search ${kind === "entity" ? "entities" : "resources"}…`}
+            value={search}
+          />
+          {candidatesQuery.isError ? (
+            <div className="text-sm text-destructive">
+              {candidatesQuery.error.message}
             </div>
-          </ScrollArea>
-        )}
-      </div>
+          ) : candidates.length === 0 ? (
+            <div className="text-xs text-muted-foreground">
+              {search
+                ? `No matching ${kind === "entity" ? "entities" : "resources"}.`
+                : `No ${kind === "entity" ? "entities" : "resources"} available.`}
+            </div>
+          ) : (
+            <ScrollArea className="max-h-48">
+              <div className="grid gap-1">
+                {candidates.map((candidate) => (
+                  <div
+                    className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+                    key={candidate.id}
+                  >
+                    <div className="flex min-w-0 flex-col gap-0">
+                      <span className="truncate text-xs font-medium">
+                        {memberDisplayName(candidate)}
+                      </span>
+                      <span className="truncate font-mono text-xs text-muted-foreground">
+                        {candidate.kind}
+                      </span>
+                    </div>
+                    <Button
+                      className="h-7 shrink-0 text-xs"
+                      disabled={addToGroup.isPending}
+                      onClick={() =>
+                        addToGroup.mutate({
+                          memberId: candidate.id,
+                          objectGroupId: groupId,
+                          message: `${memberDisplayName(candidate)} added to this group`,
+                        })
+                      }
+                      size="sm"
+                      variant="outline"
+                    >
+                      Add
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/components/groups/object-group-membership-field.test.tsx
+++ b/app/components/groups/object-group-membership-field.test.tsx
@@ -1,0 +1,176 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ObjectGroupMembershipField } from "@/components/groups/object-group-membership-field";
+
+const mocks = vi.hoisted(() => ({
+  graphqlClient: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/lib/graphql/client", () => ({
+  graphqlClient: mocks.graphqlClient,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+// jsdom has no ResizeObserver, which the scroll area measures itself with.
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+function renderField(tenantId: string | null = "tenant-1") {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ObjectGroupMembershipField
+        initialObjectGroupIds={["group-1"]}
+        kind="entity"
+        memberId="entity-1"
+        tenantId={tenantId}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+type GraphqlCall = { query: string; variables?: Record<string, unknown> };
+
+function respond({ query }: GraphqlCall) {
+  if (query.includes("ResolveGroup")) {
+    return Promise.resolve({ group: { name: "Floor sensors" } });
+  }
+
+  if (query.includes("ObjectGroupPicker")) {
+    return Promise.resolve({
+      objectGroups: {
+        total: 1,
+        items: [{ id: "group-2", name: "Gateways" }],
+      },
+    });
+  }
+
+  if (query.includes("RemoveEntityFromObjectGroup")) {
+    return Promise.resolve({ result: { id: "entity-1", objectGroupIds: [] } });
+  }
+
+  if (query.includes("AddEntityToObjectGroup")) {
+    return Promise.resolve({
+      result: { id: "entity-1", objectGroupIds: ["group-1", "group-2"] },
+    });
+  }
+
+  if (query.includes("ClearEntityObjectGroups")) {
+    return Promise.resolve({ result: { id: "entity-1", objectGroupIds: [] } });
+  }
+
+  throw new Error(`Unexpected query: ${query}`);
+}
+
+describe("ObjectGroupMembershipField", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.graphqlClient.mockReset();
+    mocks.toastSuccess.mockReset();
+    mocks.graphqlClient.mockImplementation(respond);
+  });
+
+  it("shows the groups the row already carries, resolved to names", async () => {
+    renderField();
+
+    expect(await screen.findByText("Floor sensors")).toBeInTheDocument();
+    expect(screen.getByText("1 joined")).toBeInTheDocument();
+    expect(mocks.graphqlClient).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining("EntityObjectGroups"),
+      }),
+    );
+  });
+
+  it("adds the entity to a picked object group", async () => {
+    const user = userEvent.setup();
+    renderField();
+
+    await screen.findByText("Gateways");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(mocks.graphqlClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: { entityId: "entity-1", objectGroupId: "group-2" },
+        }),
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Added to Gateways");
+  });
+
+  it("removes the entity from one group", async () => {
+    const user = userEvent.setup();
+    renderField();
+
+    await screen.findByText("Floor sensors");
+    await user.click(
+      screen.getByRole("button", { name: "Remove from Floor sensors" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.graphqlClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: { entityId: "entity-1", objectGroupId: "group-1" },
+        }),
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Removed from Floor sensors",
+    );
+  });
+
+  it("clears every membership behind a confirmation", async () => {
+    const user = userEvent.setup();
+    renderField();
+
+    await screen.findByText("Floor sensors");
+    await user.click(
+      screen.getByRole("button", { name: "Remove from all object groups" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Remove from all" }));
+
+    await waitFor(() => {
+      expect(mocks.graphqlClient).toHaveBeenCalledWith(
+        expect.objectContaining({ variables: { entityId: "entity-1" } }),
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Removed from all object groups",
+    );
+  });
+
+  it("explains why a platform-scoped entity cannot join a group", async () => {
+    renderField(null);
+
+    expect(
+      await screen.findByText(/Platform-scoped entities cannot join/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search object groups…"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/groups/object-group-membership-field.tsx
+++ b/app/components/groups/object-group-membership-field.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { Plus, X } from "lucide-react";
+import * as React from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { ObjectMemberKind } from "@/lib/object-groups/membership";
+import {
+  useObjectGroupIds,
+  useObjectGroupMembershipActions,
+  useObjectGroupOptions,
+} from "@/lib/object-groups/use-object-group-membership";
+import { useNameMap } from "@/lib/reconcile/use-name-map";
+
+/**
+ * Object-group membership seen from the entity/resource side. The same
+ * mutations back the group-side panel, so both views stay in step.
+ */
+export function ObjectGroupMembershipField({
+  initialObjectGroupIds,
+  kind,
+  memberId,
+  tenantId,
+}: {
+  initialObjectGroupIds: string[];
+  kind: ObjectMemberKind;
+  memberId: string;
+  tenantId?: string | null;
+}) {
+  const [search, setSearch] = React.useState("");
+
+  const { data: objectGroupIds = [] } = useObjectGroupIds({
+    kind,
+    memberId,
+    initialObjectGroupIds,
+  });
+  const optionsQuery = useObjectGroupOptions({ tenantId, search });
+  const { addToGroup, removeFromGroup, clearGroups } =
+    useObjectGroupMembershipActions(kind);
+
+  const names = useNameMap({ groupIds: objectGroupIds });
+  const options = optionsQuery.data ?? [];
+  const isPlatformScoped = !tenantId;
+
+  return (
+    <div className="grid gap-3 rounded-lg border bg-background p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs font-medium uppercase text-muted-foreground">
+          Object groups
+        </div>
+        {objectGroupIds.length > 0 ? (
+          <Badge variant="outline">{objectGroupIds.length} joined</Badge>
+        ) : null}
+      </div>
+
+      {objectGroupIds.length === 0 ? (
+        <span className="text-sm text-muted-foreground">
+          Not a member of any object group.
+        </span>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {objectGroupIds.map((groupId) => {
+            const name = names.get(groupId) ?? groupId;
+            return (
+              <span
+                className="flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs"
+                key={groupId}
+              >
+                <span className="max-w-40 truncate">{name}</span>
+                <Button
+                  className="size-4 p-0 text-muted-foreground hover:text-destructive"
+                  disabled={removeFromGroup.isPending}
+                  onClick={() =>
+                    removeFromGroup.mutate({
+                      memberId,
+                      objectGroupId: groupId,
+                      message: `Removed from ${name}`,
+                    })
+                  }
+                  size="icon"
+                  variant="ghost"
+                >
+                  <X className="size-3" />
+                  <span className="sr-only">Remove from {name}</span>
+                </Button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {isPlatformScoped ? (
+        <p className="text-xs text-muted-foreground">
+          Platform-scoped {kind === "entity" ? "entities" : "resources"} cannot
+          join an object group. Assign a tenant first.
+        </p>
+      ) : (
+        <div className="grid gap-2 rounded-lg border bg-muted/30 p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Plus className="size-4 text-muted-foreground" />
+            Add to object group
+          </div>
+          <Input
+            className="h-8 text-sm"
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search object groups…"
+            value={search}
+          />
+          {optionsQuery.isError ? (
+            <div className="text-sm text-destructive">
+              {optionsQuery.error.message}
+            </div>
+          ) : options.length === 0 ? (
+            <div className="text-xs text-muted-foreground">
+              {search
+                ? "No matching object groups."
+                : "No object groups in this tenant."}
+            </div>
+          ) : (
+            <ScrollArea className="max-h-40">
+              <div className="grid gap-1">
+                {options.map((option) => (
+                  <div
+                    className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+                    key={option.id}
+                  >
+                    <span className="truncate text-xs font-medium">
+                      {option.name}
+                    </span>
+                    <Button
+                      className="h-7 shrink-0 text-xs"
+                      disabled={addToGroup.isPending}
+                      onClick={() =>
+                        addToGroup.mutate({
+                          memberId,
+                          objectGroupId: option.id,
+                          message: `Added to ${option.name}`,
+                        })
+                      }
+                      size="sm"
+                      variant="outline"
+                    >
+                      Add
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+      )}
+
+      {objectGroupIds.length > 0 ? (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              className="justify-self-start"
+              disabled={clearGroups.isPending}
+              size="sm"
+              variant="outline"
+            >
+              Remove from all object groups
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Remove from all object groups?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                This drops every one of the {objectGroupIds.length} object group
+                memberships at once. Access granted through those groups stops
+                applying to this {kind}.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => clearGroups.mutate({ memberId })}
+              >
+                Remove from all
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/policy/object-access-panel.tsx
+++ b/app/components/policy/object-access-panel.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { UserRound, UsersRound } from "lucide-react";
+import * as React from "react";
+import { DisplayTimeCell } from "@/components/display-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  type AccessObjectKind,
+  DIRECT_POLICIES_FOR_OBJECT_QUERY,
+  type DirectPolicyPage,
+  type DirectPolicyRow,
+  directPolicyReachLabel,
+  directPolicyScopeGroupIds,
+  directPolicySubjectIds,
+  isGroupSubject,
+} from "@/lib/access/object-access";
+import { graphqlClient } from "@/lib/graphql/client";
+import { useNameMap } from "@/lib/reconcile/use-name-map";
+import { Action } from "@/lib/utils";
+
+const PAGE_SIZE = 10;
+
+/**
+ * Read-only reverse policy lookup. Grants are created from the Policies page;
+ * this only answers who the object is currently shared with.
+ */
+export function ObjectAccessPanel({
+  objectId,
+  objectKind,
+}: {
+  objectId: string;
+  objectKind: AccessObjectKind;
+}) {
+  const [page, setPage] = React.useState(1);
+
+  const { data, error, isFetching } = useQuery({
+    enabled: Boolean(objectId),
+    queryKey: ["object-direct-policies", objectKind, objectId, page],
+    queryFn: ({ signal }) =>
+      graphqlClient<{ directPolicies: DirectPolicyPage }>({
+        query: DIRECT_POLICIES_FOR_OBJECT_QUERY,
+        variables: {
+          objectId,
+          objectKind,
+          limit: PAGE_SIZE,
+          offset: (page - 1) * PAGE_SIZE,
+        },
+        signal,
+      }),
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+
+  const items = data?.directPolicies.items ?? [];
+  const total = data?.directPolicies.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const { entityIds, groupIds } = directPolicySubjectIds(items);
+  const names = useNameMap({
+    entityIds,
+    groupIds: [...groupIds, ...directPolicyScopeGroupIds(items)],
+  });
+
+  return (
+    <div className="grid gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-sm font-medium">Shared with</div>
+        <Badge variant="outline">{total} direct policies</Badge>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Subjects granted access by a policy that names this {objectKind} —
+        directly, or through an object group it belongs to. Access inherited
+        from roles, and broad platform, tenant, or kind-wide grants, are not
+        listed here.
+      </p>
+
+      {error ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {error.message}
+        </div>
+      ) : isFetching && items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border bg-muted/30 p-4 text-center text-sm text-muted-foreground">
+          This {objectKind} is not shared with anyone directly.
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          {items.map((policy) => (
+            <AccessRow key={policy.id} names={names} policy={policy} />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 ? (
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            Page {page} of {totalPages} · {total} total
+          </span>
+          <div className="flex gap-2">
+            <Button
+              disabled={page <= 1 || isFetching}
+              onClick={() => setPage((current) => current - 1)}
+              size="sm"
+              variant="outline"
+            >
+              Previous
+            </Button>
+            <Button
+              disabled={page >= totalPages || isFetching}
+              onClick={() => setPage((current) => current + 1)}
+              size="sm"
+              variant="outline"
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AccessRow({
+  names,
+  policy,
+}: {
+  names: Map<string, string>;
+  policy: DirectPolicyRow;
+}) {
+  const isGroup = isGroupSubject(policy.subjectKind);
+  const Icon = isGroup ? UsersRound : UserRound;
+  const subjectName = names.get(policy.subjectId) ?? policy.subjectId;
+  const block = policy.permissionBlock;
+  const scopeGroupName = block.groupId ? names.get(block.groupId) : undefined;
+
+  return (
+    <div className="grid gap-2 rounded-md border p-2">
+      <div className="flex min-w-0 items-start gap-2">
+        <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted text-muted-foreground">
+          <Icon className="size-4" />
+        </span>
+        <div className="grid min-w-0 flex-1 gap-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <span className="min-w-0 truncate text-sm font-medium">
+              {subjectName}
+            </span>
+            <Badge variant="secondary">
+              {isGroup ? "Principal group" : "Entity"}
+            </Badge>
+            <Badge
+              variant={block.effect === "deny" ? "destructive" : "outline"}
+            >
+              {block.effect}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {block.actions.length === 0 ? (
+              <span className="text-xs text-muted-foreground">No actions</span>
+            ) : (
+              block.actions.map((action) => (
+                <Badge key={action.name} variant="outline">
+                  {action.name}
+                </Badge>
+              ))
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span>{directPolicyReachLabel(block, scopeGroupName)}</span>
+            <span>
+              Granted{" "}
+              <DisplayTimeCell
+                action={Action.Created}
+                time={policy.createdAt}
+              />
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="break-all font-mono text-xs text-muted-foreground">
+        {policy.subjectId}
+      </div>
+    </div>
+  );
+}

--- a/app/components/resources/resource-inspect-details.tsx
+++ b/app/components/resources/resource-inspect-details.tsx
@@ -4,9 +4,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Check, Copy } from "lucide-react";
 import * as React from "react";
 import { DisplayTimeCell } from "@/components/display-time";
+import { ObjectGroupMembershipField } from "@/components/groups/object-group-membership-field";
 import { Button } from "@/components/ui/button";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { graphqlClient } from "@/lib/graphql/client";
+import { objectGroupIdsFromRow } from "@/lib/object-groups/membership";
 import { Action } from "@/lib/utils";
 
 const TENANT_QUERY = `
@@ -118,6 +120,15 @@ export function ResourceInspectDetails({ row }: { row: Row | null }) {
         <Field label="Owner">
           <span className="text-sm">{ownerName}</span>
         </Field>
+      ) : null}
+
+      {id ? (
+        <ObjectGroupMembershipField
+          initialObjectGroupIds={objectGroupIdsFromRow(row)}
+          kind="resource"
+          memberId={id}
+          tenantId={tenantId}
+        />
       ) : null}
 
       <div className="grid gap-3 sm:grid-cols-2">

--- a/app/lib/access/object-access.test.ts
+++ b/app/lib/access/object-access.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  DIRECT_POLICIES_FOR_OBJECT_QUERY,
+  type DirectPolicyRow,
+  directPolicyActionNames,
+  directPolicyReachLabel,
+  directPolicyScopeGroupIds,
+  directPolicySubjectIds,
+  isGroupSubject,
+  objectKindForResourceKey,
+} from "@/lib/access/object-access";
+
+function policy(overrides: Partial<DirectPolicyRow> = {}): DirectPolicyRow {
+  return {
+    id: "policy-1",
+    subjectKind: "entity",
+    subjectId: "entity-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    permissionBlock: {
+      id: "block-1",
+      scopeMode: "object",
+      groupId: null,
+      effect: "allow",
+      actions: [{ name: "read" }],
+    },
+    ...overrides,
+  };
+}
+
+describe("object kind for the inspect sheet", () => {
+  it("maps the two CRUD keys to the kinds the server parses", () => {
+    expect(objectKindForResourceKey("entities")).toBe("entity");
+    expect(objectKindForResourceKey("resources")).toBe("resource");
+  });
+
+  it("has no object kind for other resources", () => {
+    expect(objectKindForResourceKey("groups")).toBeNull();
+    expect(objectKindForResourceKey("policies")).toBeNull();
+  });
+});
+
+describe("direct policy subjects", () => {
+  it("recognises group subjects regardless of casing", () => {
+    expect(isGroupSubject("group")).toBe(true);
+    expect(isGroupSubject("GROUP")).toBe(true);
+    expect(isGroupSubject("entity")).toBe(false);
+  });
+
+  it("splits subject ids by kind for name resolution", () => {
+    expect(
+      directPolicySubjectIds([
+        policy(),
+        policy({ id: "policy-2", subjectKind: "group", subjectId: "group-1" }),
+        policy({ id: "policy-3", subjectId: "entity-2" }),
+      ]),
+    ).toEqual({
+      entityIds: ["entity-1", "entity-2"],
+      groupIds: ["group-1"],
+    });
+  });
+
+  it("skips policies without a subject id", () => {
+    expect(directPolicySubjectIds([policy({ subjectId: "" })])).toEqual({
+      entityIds: [],
+      groupIds: [],
+    });
+  });
+
+  it("collects the object groups the blocks name, without duplicates", () => {
+    expect(
+      directPolicyScopeGroupIds([
+        policy(),
+        policy({
+          id: "policy-2",
+          permissionBlock: {
+            id: "block-2",
+            scopeMode: "group_direct_objects",
+            groupId: "group-1",
+            effect: "allow",
+            actions: [],
+          },
+        }),
+        policy({
+          id: "policy-3",
+          permissionBlock: {
+            id: "block-3",
+            scopeMode: "group_descendant_objects",
+            groupId: "group-1",
+            effect: "allow",
+            actions: [],
+          },
+        }),
+      ]),
+    ).toEqual(["group-1"]);
+  });
+});
+
+describe("why a policy reaches this object", () => {
+  function block(scopeMode: string, groupId: string | null = "group-1") {
+    return {
+      id: "block-1",
+      scopeMode,
+      groupId,
+      effect: "allow",
+      actions: [],
+    };
+  }
+
+  it("describes an object-scoped grant", () => {
+    expect(directPolicyReachLabel(block("object", null))).toBe(
+      "This object directly",
+    );
+  });
+
+  it("describes a grant on the group itself", () => {
+    expect(directPolicyReachLabel(block("group"))).toBe("This object group");
+  });
+
+  it("names the group a membership scope came through", () => {
+    expect(
+      directPolicyReachLabel(block("group_direct_objects"), "Floor sensors"),
+    ).toBe("Direct members of Floor sensors");
+    expect(
+      directPolicyReachLabel(
+        block("group_descendant_objects"),
+        "Floor sensors",
+      ),
+    ).toBe("Members of Floor sensors and its descendants");
+    expect(
+      directPolicyReachLabel(block("group_child_groups"), "Floor sensors"),
+    ).toBe("Child groups of Floor sensors");
+    expect(
+      directPolicyReachLabel(block("group_descendant_groups"), "Floor sensors"),
+    ).toBe("Descendant groups of Floor sensors");
+  });
+
+  it("falls back to the group id, then to a generic phrase", () => {
+    expect(directPolicyReachLabel(block("group_direct_objects"))).toBe(
+      "Direct members of group-1",
+    );
+    expect(directPolicyReachLabel(block("group_direct_objects", null))).toBe(
+      "Direct members of its object group",
+    );
+  });
+
+  it("shows an unknown scope mode as-is", () => {
+    expect(directPolicyReachLabel(block("something_new"))).toBe(
+      "something_new",
+    );
+  });
+});
+
+describe("direct policy actions", () => {
+  it("lists the granted action names", () => {
+    expect(
+      directPolicyActionNames({
+        id: "block-1",
+        scopeMode: "object",
+        groupId: null,
+        effect: "allow",
+        actions: [{ name: "read" }, { name: "write" }],
+      }),
+    ).toEqual(["read", "write"]);
+  });
+});
+
+describe("the reverse lookup query", () => {
+  it("filters by object id and kind", () => {
+    expect(DIRECT_POLICIES_FOR_OBJECT_QUERY).toContain(
+      "directPolicies(objectId: $objectId, objectKind: $objectKind",
+    );
+    expect(DIRECT_POLICIES_FOR_OBJECT_QUERY).toContain("$objectKind: String!");
+  });
+
+  it("selects the subject and its permission block", () => {
+    expect(DIRECT_POLICIES_FOR_OBJECT_QUERY).toContain("subjectKind");
+    expect(DIRECT_POLICIES_FOR_OBJECT_QUERY).toContain("subjectId");
+    expect(DIRECT_POLICIES_FOR_OBJECT_QUERY).toContain("permissionBlock");
+    expect(DIRECT_POLICIES_FOR_OBJECT_QUERY).toContain("actions { name }");
+  });
+});

--- a/app/lib/access/object-access.ts
+++ b/app/lib/access/object-access.ts
@@ -1,0 +1,128 @@
+/**
+ * Reverse policy lookup: "who is this object shared with".
+ *
+ * `directPolicies(objectId:)` returns only the direct policies whose permission
+ * block *names* the object — by id, by object group, or through a group
+ * hierarchy scope. Blocks that reach the object without naming it (platform,
+ * tenant, objectKind, objectType) and any role-derived access are excluded by
+ * the server, so this is a sharing list, not effective access.
+ */
+
+/** The object kinds the inspect sheets ask about. */
+export type AccessObjectKind = "entity" | "resource";
+
+export type DirectPolicyAction = {
+  name: string;
+};
+
+export type DirectPolicyPermissionBlock = {
+  id: string;
+  scopeMode?: string | null;
+  groupId?: string | null;
+  effect: string;
+  actions: DirectPolicyAction[];
+};
+
+export type DirectPolicyRow = {
+  id: string;
+  subjectKind: string;
+  subjectId: string;
+  createdAt: string;
+  permissionBlock: DirectPolicyPermissionBlock;
+};
+
+export type DirectPolicyPage = {
+  total: number;
+  items: DirectPolicyRow[];
+};
+
+export const DIRECT_POLICIES_FOR_OBJECT_QUERY = `
+  query DirectPoliciesForObject($objectId: ID!, $objectKind: String!, $limit: Int!, $offset: Int!) {
+    directPolicies(objectId: $objectId, objectKind: $objectKind, limit: $limit, offset: $offset) {
+      total
+      items {
+        id
+        subjectKind
+        subjectId
+        createdAt
+        permissionBlock {
+          id
+          scopeMode
+          groupId
+          effect
+          actions { name }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * CRUD resource key to the `objectKind` string the server parses. The accepted
+ * values are lowercase (`parse_object_kind`), so "Entity" would be rejected.
+ */
+export function objectKindForResourceKey(
+  resourceKey: string,
+): AccessObjectKind | null {
+  if (resourceKey === "entities") return "entity";
+  if (resourceKey === "resources") return "resource";
+  return null;
+}
+
+export function isGroupSubject(subjectKind: string) {
+  return subjectKind.toLowerCase() === "group";
+}
+
+/** Subject ids split by kind, ready for `useNameMap`. */
+export function directPolicySubjectIds(policies: DirectPolicyRow[]) {
+  const entityIds: string[] = [];
+  const groupIds: string[] = [];
+
+  for (const policy of policies) {
+    if (!policy.subjectId) continue;
+    if (isGroupSubject(policy.subjectKind)) groupIds.push(policy.subjectId);
+    else entityIds.push(policy.subjectId);
+  }
+
+  return { entityIds, groupIds };
+}
+
+/** Object groups named by the returned blocks, so their names resolve too. */
+export function directPolicyScopeGroupIds(policies: DirectPolicyRow[]) {
+  const groupIds = policies
+    .map((policy) => policy.permissionBlock.groupId)
+    .filter((id): id is string => Boolean(id));
+  return [...new Set(groupIds)];
+}
+
+/**
+ * Why this policy shows up for this object — the block's scope mode read from
+ * the object's side rather than the grant's side.
+ */
+export function directPolicyReachLabel(
+  block: DirectPolicyPermissionBlock,
+  groupName?: string,
+) {
+  const group = groupName || block.groupId || "its object group";
+
+  switch (block.scopeMode) {
+    case "object":
+      return "This object directly";
+    case "group":
+      return "This object group";
+    case "group_direct_objects":
+      return `Direct members of ${group}`;
+    case "group_descendant_objects":
+      return `Members of ${group} and its descendants`;
+    case "group_child_groups":
+      return `Child groups of ${group}`;
+    case "group_descendant_groups":
+      return `Descendant groups of ${group}`;
+    default:
+      return block.scopeMode ?? "Named by this permission block";
+  }
+}
+
+export function directPolicyActionNames(block: DirectPolicyPermissionBlock) {
+  return block.actions.map((action) => action.name);
+}

--- a/app/lib/object-groups/membership.test.ts
+++ b/app/lib/object-groups/membership.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  candidatesQuery,
+  memberDisplayName,
+  memberIdVariableName,
+  memberKindLabel,
+  memberKindTitle,
+  membershipMutation,
+  membershipQuery,
+  membershipVariables,
+  membersQuery,
+  OBJECT_GROUPS_QUERY,
+  objectGroupIdsFromRow,
+} from "@/lib/object-groups/membership";
+
+describe("object group ids from a row", () => {
+  it("reads the ids the list query already selected", () => {
+    expect(
+      objectGroupIdsFromRow({
+        id: "entity-1",
+        objectGroupIds: ["group-1", "group-2"],
+      }),
+    ).toEqual(["group-1", "group-2"]);
+  });
+
+  it("drops duplicates, blanks, and non-string ids", () => {
+    expect(
+      objectGroupIdsFromRow({
+        objectGroupIds: ["group-1", "group-1", "", null, 7, "group-2"],
+      }),
+    ).toEqual(["group-1", "group-2"]);
+  });
+
+  it("returns nothing when the row has no membership", () => {
+    expect(objectGroupIdsFromRow(null)).toEqual([]);
+    expect(objectGroupIdsFromRow(undefined)).toEqual([]);
+    expect(objectGroupIdsFromRow({ id: "entity-1" })).toEqual([]);
+    expect(objectGroupIdsFromRow({ objectGroupIds: "group-1" })).toEqual([]);
+  });
+});
+
+describe("membership mutation variables", () => {
+  it("names the member argument per kind", () => {
+    expect(memberIdVariableName("entity")).toBe("entityId");
+    expect(memberIdVariableName("resource")).toBe("resourceId");
+  });
+
+  it("carries the group id for add and remove", () => {
+    expect(membershipVariables("entity", "entity-1", "group-1")).toEqual({
+      entityId: "entity-1",
+      objectGroupId: "group-1",
+    });
+    expect(membershipVariables("resource", "resource-1", "group-1")).toEqual({
+      resourceId: "resource-1",
+      objectGroupId: "group-1",
+    });
+  });
+
+  it("omits the group id when clearing every membership", () => {
+    expect(membershipVariables("entity", "entity-1")).toEqual({
+      entityId: "entity-1",
+    });
+  });
+});
+
+describe("membership documents", () => {
+  it("picks the entity mutations", () => {
+    expect(membershipMutation("entity", "add")).toContain(
+      "addEntityToObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId)",
+    );
+    expect(membershipMutation("entity", "remove")).toContain(
+      "removeEntityFromObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId)",
+    );
+    expect(membershipMutation("entity", "clear")).toContain(
+      "clearEntityObjectGroups(entityId: $entityId)",
+    );
+  });
+
+  it("picks the resource mutations", () => {
+    expect(membershipMutation("resource", "add")).toContain(
+      "addResourceToObjectGroup(resourceId: $resourceId, objectGroupId: $objectGroupId)",
+    );
+    expect(membershipMutation("resource", "remove")).toContain(
+      "removeResourceFromObjectGroup(resourceId: $resourceId, objectGroupId: $objectGroupId)",
+    );
+    expect(membershipMutation("resource", "clear")).toContain(
+      "clearResourceObjectGroups(resourceId: $resourceId)",
+    );
+  });
+
+  it("returns the updated membership so no refetch is needed", () => {
+    for (const kind of ["entity", "resource"] as const) {
+      for (const operation of ["add", "remove", "clear"] as const) {
+        const document = membershipMutation(kind, operation);
+        expect(document).toContain("result:");
+        expect(document).toContain("objectGroupIds");
+      }
+    }
+  });
+
+  it("lists members through the parentGroupId list filter", () => {
+    expect(membersQuery("entity")).toContain(
+      "list: entities(parentGroupId: $groupId",
+    );
+    expect(membersQuery("resource")).toContain(
+      "list: resources(parentGroupId: $groupId",
+    );
+  });
+
+  it("reads status only for entities, which alone have one", () => {
+    expect(membersQuery("entity")).toContain("status");
+    expect(membersQuery("resource")).not.toContain("status");
+    expect(candidatesQuery("resource")).not.toContain("status");
+  });
+
+  it("scopes add pickers by tenant and search term", () => {
+    expect(candidatesQuery("entity")).toContain(
+      "list: entities(tenantId: $tenantId, q: $q",
+    );
+    expect(candidatesQuery("resource")).toContain(
+      "list: resources(tenantId: $tenantId, q: $q",
+    );
+  });
+
+  it("reads a single member's membership set", () => {
+    expect(membershipQuery("entity")).toContain(
+      "member: entity(id: $id) { id objectGroupIds }",
+    );
+    expect(membershipQuery("resource")).toContain(
+      "member: resource(id: $id) { id objectGroupIds }",
+    );
+  });
+
+  it("picks groups through objectGroups so principal groups never appear", () => {
+    expect(OBJECT_GROUPS_QUERY).toContain("objectGroups(tenantId: $tenantId");
+    expect(OBJECT_GROUPS_QUERY).not.toMatch(/\bgroups\(/);
+  });
+});
+
+describe("member labels", () => {
+  it("falls back to the id when a resource has no name", () => {
+    expect(memberDisplayName({ id: "resource-1", name: null })).toBe(
+      "resource-1",
+    );
+    expect(memberDisplayName({ id: "resource-1", name: "   " })).toBe(
+      "resource-1",
+    );
+    expect(memberDisplayName({ id: "resource-1", name: "Telemetry" })).toBe(
+      "Telemetry",
+    );
+  });
+
+  it("counts members in the right plural", () => {
+    expect(memberKindLabel("entity", 0)).toBe("0 entities");
+    expect(memberKindLabel("entity", 1)).toBe("1 entity");
+    expect(memberKindLabel("entity", 4)).toBe("4 entities");
+    expect(memberKindLabel("resource", 1)).toBe("1 resource");
+    expect(memberKindLabel("resource", 2)).toBe("2 resources");
+  });
+
+  it("titles each members section", () => {
+    expect(memberKindTitle("entity")).toBe("Entities");
+    expect(memberKindTitle("resource")).toBe("Resources");
+  });
+});

--- a/app/lib/object-groups/membership.ts
+++ b/app/lib/object-groups/membership.ts
@@ -1,0 +1,238 @@
+/**
+ * Object-group membership is many-to-many: an entity or resource belongs to a
+ * set of object groups, and a group holds a set of both kinds. Every document
+ * and helper here is shared by the group-side panel and the entity/resource
+ * side field so the two directions can never drift apart.
+ */
+
+export type ObjectMemberKind = "entity" | "resource";
+
+export const OBJECT_MEMBER_KINDS: ObjectMemberKind[] = ["entity", "resource"];
+
+export type ObjectGroupMember = {
+  id: string;
+  /** `Resource.name` is nullable in the schema, `Entity.name` is not. */
+  name?: string | null;
+  kind: string;
+  /** Entities carry a lifecycle status; resources have no status field. */
+  status?: string | null;
+};
+
+export type ObjectGroupMemberPage = {
+  total: number;
+  items: ObjectGroupMember[];
+};
+
+export type ObjectGroupOption = {
+  id: string;
+  name: string;
+};
+
+export type ObjectGroupMembership = {
+  id: string;
+  objectGroupIds: string[];
+};
+
+/**
+ * Members of one object group, read through the list filters rather than a
+ * dedicated query — `parentGroupId` is the supported way to ask this.
+ */
+const MEMBERS_QUERIES: Record<ObjectMemberKind, string> = {
+  entity: `
+    query ObjectGroupEntityMembers($groupId: ID!, $limit: Int!, $offset: Int!) {
+      list: entities(parentGroupId: $groupId, limit: $limit, offset: $offset) {
+        total
+        items { id name kind status }
+      }
+    }
+  `,
+  resource: `
+    query ObjectGroupResourceMembers($groupId: ID!, $limit: Int!, $offset: Int!) {
+      list: resources(parentGroupId: $groupId, limit: $limit, offset: $offset) {
+        total
+        items { id name kind }
+      }
+    }
+  `,
+};
+
+/** Search-to-add pickers, scoped to the group's tenant. */
+const CANDIDATES_QUERIES: Record<ObjectMemberKind, string> = {
+  entity: `
+    query ObjectGroupEntityCandidates($tenantId: ID, $q: String, $limit: Int!) {
+      list: entities(tenantId: $tenantId, q: $q, limit: $limit, offset: 0) {
+        total
+        items { id name kind status }
+      }
+    }
+  `,
+  resource: `
+    query ObjectGroupResourceCandidates($tenantId: ID, $q: String, $limit: Int!) {
+      list: resources(tenantId: $tenantId, q: $q, limit: $limit, offset: 0) {
+        total
+        items { id name kind }
+      }
+    }
+  `,
+};
+
+const MEMBERSHIP_QUERIES: Record<ObjectMemberKind, string> = {
+  entity: `
+    query EntityObjectGroups($id: ID!) {
+      member: entity(id: $id) { id objectGroupIds }
+    }
+  `,
+  resource: `
+    query ResourceObjectGroups($id: ID!) {
+      member: resource(id: $id) { id objectGroupIds }
+    }
+  `,
+};
+
+/**
+ * The type-filtered convenience query, so principal groups can never show up
+ * in an object-group picker.
+ */
+export const OBJECT_GROUPS_QUERY = `
+  query ObjectGroupPicker($tenantId: ID, $q: String, $limit: Int!, $offset: Int!) {
+    objectGroups(tenantId: $tenantId, q: $q, limit: $limit, offset: $offset) {
+      total
+      items { id name }
+    }
+  }
+`;
+
+export type MembershipOperation = "add" | "remove" | "clear";
+
+/**
+ * Each mutation returns the mutated Entity/Resource, so the response carries
+ * the authoritative membership set and no refetch is needed. Results are
+ * aliased to `result` so callers read one shape for all six mutations.
+ */
+const MEMBERSHIP_MUTATIONS: Record<
+  ObjectMemberKind,
+  Record<MembershipOperation, string>
+> = {
+  entity: {
+    add: `
+      mutation AddEntityToObjectGroup($entityId: ID!, $objectGroupId: ID!) {
+        result: addEntityToObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId) {
+          id
+          objectGroupIds
+        }
+      }
+    `,
+    remove: `
+      mutation RemoveEntityFromObjectGroup($entityId: ID!, $objectGroupId: ID!) {
+        result: removeEntityFromObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId) {
+          id
+          objectGroupIds
+        }
+      }
+    `,
+    clear: `
+      mutation ClearEntityObjectGroups($entityId: ID!) {
+        result: clearEntityObjectGroups(entityId: $entityId) {
+          id
+          objectGroupIds
+        }
+      }
+    `,
+  },
+  resource: {
+    add: `
+      mutation AddResourceToObjectGroup($resourceId: ID!, $objectGroupId: ID!) {
+        result: addResourceToObjectGroup(resourceId: $resourceId, objectGroupId: $objectGroupId) {
+          id
+          objectGroupIds
+        }
+      }
+    `,
+    remove: `
+      mutation RemoveResourceFromObjectGroup($resourceId: ID!, $objectGroupId: ID!) {
+        result: removeResourceFromObjectGroup(resourceId: $resourceId, objectGroupId: $objectGroupId) {
+          id
+          objectGroupIds
+        }
+      }
+    `,
+    clear: `
+      mutation ClearResourceObjectGroups($resourceId: ID!) {
+        result: clearResourceObjectGroups(resourceId: $resourceId) {
+          id
+          objectGroupIds
+        }
+      }
+    `,
+  },
+};
+
+export function membersQuery(kind: ObjectMemberKind) {
+  return MEMBERS_QUERIES[kind];
+}
+
+export function candidatesQuery(kind: ObjectMemberKind) {
+  return CANDIDATES_QUERIES[kind];
+}
+
+export function membershipQuery(kind: ObjectMemberKind) {
+  return MEMBERSHIP_QUERIES[kind];
+}
+
+export function membershipMutation(
+  kind: ObjectMemberKind,
+  operation: MembershipOperation,
+) {
+  return MEMBERSHIP_MUTATIONS[kind][operation];
+}
+
+/** `entityId` / `resourceId` — the mutations do not share an argument name. */
+export function memberIdVariableName(kind: ObjectMemberKind) {
+  return kind === "entity" ? "entityId" : "resourceId";
+}
+
+export function membershipVariables(
+  kind: ObjectMemberKind,
+  memberId: string,
+  objectGroupId?: string,
+): Record<string, string> {
+  const variables: Record<string, string> = {
+    [memberIdVariableName(kind)]: memberId,
+  };
+  if (objectGroupId !== undefined) {
+    variables.objectGroupId = objectGroupId;
+  }
+  return variables;
+}
+
+/**
+ * Entity and resource rows already select `objectGroupIds`, so the inspect
+ * sheet can seed membership without a round trip.
+ */
+export function objectGroupIdsFromRow(
+  row: Record<string, unknown> | null | undefined,
+): string[] {
+  if (!row || !Array.isArray(row.objectGroupIds)) return [];
+  const ids = row.objectGroupIds.filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
+  );
+  return [...new Set(ids)];
+}
+
+/** Resource names are nullable; never render an empty label. */
+export function memberDisplayName(member: {
+  id: string;
+  name?: string | null;
+}) {
+  const name = member.name?.trim();
+  return name ? name : member.id;
+}
+
+export function memberKindLabel(kind: ObjectMemberKind, count: number) {
+  if (count === 1) return `1 ${kind}`;
+  return `${count} ${kind === "entity" ? "entities" : "resources"}`;
+}
+
+export function memberKindTitle(kind: ObjectMemberKind) {
+  return kind === "entity" ? "Entities" : "Resources";
+}

--- a/app/lib/object-groups/use-object-group-membership.ts
+++ b/app/lib/object-groups/use-object-group-membership.ts
@@ -82,6 +82,7 @@ export function useObjectGroupMemberCandidates({
 }) {
   const q = search.trim();
   return useQuery({
+    enabled: Boolean(tenantId),
     queryKey: ["object-group-member-candidates", kind, tenantId ?? null, q],
     queryFn: async ({ signal }) => {
       const data = await graphqlClient<{

--- a/app/lib/object-groups/use-object-group-membership.ts
+++ b/app/lib/object-groups/use-object-group-membership.ts
@@ -1,0 +1,225 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { graphqlClient } from "@/lib/graphql/client";
+import {
+  candidatesQuery,
+  type MembershipOperation,
+  membershipMutation,
+  membershipQuery,
+  membershipVariables,
+  membersQuery,
+  OBJECT_GROUPS_QUERY,
+  type ObjectGroupMember,
+  type ObjectGroupMemberPage,
+  type ObjectGroupMembership,
+  type ObjectGroupOption,
+  type ObjectMemberKind,
+} from "@/lib/object-groups/membership";
+
+export const OBJECT_GROUP_MEMBERS_KEY = "object-group-members";
+export const OBJECT_GROUP_MEMBERSHIP_KEY = "object-group-membership";
+
+export function membersQueryKey(
+  kind: ObjectMemberKind,
+  groupId: string,
+  page: number,
+) {
+  return [OBJECT_GROUP_MEMBERS_KEY, kind, groupId, page];
+}
+
+export function membershipQueryKey(
+  kind: ObjectMemberKind,
+  memberId: string,
+): [string, ObjectMemberKind, string] {
+  return [OBJECT_GROUP_MEMBERSHIP_KEY, kind, memberId];
+}
+
+/** Members of one object group, one kind at a time. */
+export function useObjectGroupMembers({
+  groupId,
+  kind,
+  page,
+  pageSize,
+}: {
+  groupId: string;
+  kind: ObjectMemberKind;
+  page: number;
+  pageSize: number;
+}) {
+  return useQuery({
+    enabled: Boolean(groupId),
+    queryKey: membersQueryKey(kind, groupId, page),
+    queryFn: async ({ signal }) => {
+      const data = await graphqlClient<{ list: ObjectGroupMemberPage }>({
+        query: membersQuery(kind),
+        variables: {
+          groupId,
+          limit: pageSize,
+          offset: (page - 1) * pageSize,
+        },
+        signal,
+      });
+      return data.list;
+    },
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+/** Search-to-add candidates for a group panel, scoped to the group's tenant. */
+export function useObjectGroupMemberCandidates({
+  kind,
+  tenantId,
+  search,
+  limit = 20,
+}: {
+  kind: ObjectMemberKind;
+  tenantId?: string | null;
+  search: string;
+  limit?: number;
+}) {
+  const q = search.trim();
+  return useQuery({
+    queryKey: ["object-group-member-candidates", kind, tenantId ?? null, q],
+    queryFn: async ({ signal }) => {
+      const data = await graphqlClient<{
+        list: { total: number; items: ObjectGroupMember[] };
+      }>({
+        query: candidatesQuery(kind),
+        variables: { tenantId: tenantId || null, q: q || null, limit },
+        signal,
+      });
+      return data.list.items;
+    },
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+/** Object groups an entity/resource can be added to, never principal groups. */
+export function useObjectGroupOptions({
+  tenantId,
+  search,
+  limit = 20,
+}: {
+  tenantId?: string | null;
+  search: string;
+  limit?: number;
+}) {
+  const q = search.trim();
+  return useQuery({
+    queryKey: ["object-group-options", tenantId ?? null, q],
+    queryFn: async ({ signal }) => {
+      const data = await graphqlClient<{
+        objectGroups: { total: number; items: ObjectGroupOption[] };
+      }>({
+        query: OBJECT_GROUPS_QUERY,
+        variables: {
+          tenantId: tenantId || null,
+          q: q || null,
+          limit,
+          offset: 0,
+        },
+        signal,
+      });
+      return data.objectGroups.items;
+    },
+    staleTime: 30_000,
+    placeholderData: (previous) => previous,
+  });
+}
+
+/**
+ * Every object group one entity/resource belongs to. Seeded from the row the
+ * inspect sheet already has, then kept honest by the mutation responses.
+ */
+export function useObjectGroupIds({
+  kind,
+  memberId,
+  initialObjectGroupIds,
+}: {
+  kind: ObjectMemberKind;
+  memberId: string;
+  initialObjectGroupIds: string[];
+}) {
+  return useQuery({
+    enabled: Boolean(memberId),
+    queryKey: membershipQueryKey(kind, memberId),
+    queryFn: async ({ signal }) => {
+      const data = await graphqlClient<{ member: ObjectGroupMembership }>({
+        query: membershipQuery(kind),
+        variables: { id: memberId },
+        signal,
+      });
+      return data.member.objectGroupIds;
+    },
+    initialData: initialObjectGroupIds,
+    staleTime: 30_000,
+  });
+}
+
+export type MembershipActionVariables = {
+  memberId: string;
+  objectGroupId?: string;
+  /**
+   * Overrides the success toast. The two directions phrase it differently: the
+   * group panel names the member, the entity/resource field names the group.
+   */
+  message?: string;
+};
+
+/**
+ * The six membership mutations, usable from either direction. Adds and removes
+ * are idempotent server-side (`ON CONFLICT DO NOTHING` / zero-row delete), so
+ * there is deliberately no client-side "already a member" guard here.
+ */
+export function useObjectGroupMembershipActions(kind: ObjectMemberKind) {
+  const queryClient = useQueryClient();
+
+  function mutationFn(operation: MembershipOperation) {
+    return async ({ memberId, objectGroupId }: MembershipActionVariables) => {
+      const data = await graphqlClient<{ result: ObjectGroupMembership }>({
+        query: membershipMutation(kind, operation),
+        variables: membershipVariables(kind, memberId, objectGroupId),
+      });
+      return data.result;
+    };
+  }
+
+  function settle(result: ObjectGroupMembership, message: string) {
+    queryClient.setQueryData(
+      membershipQueryKey(kind, result.id),
+      result.objectGroupIds,
+    );
+    queryClient.invalidateQueries({ queryKey: [OBJECT_GROUP_MEMBERS_KEY] });
+    toast.success(message);
+  }
+
+  function fail(error: Error) {
+    toast.error(error.message);
+  }
+
+  const addToGroup = useMutation({
+    mutationFn: mutationFn("add"),
+    onSuccess: (result, variables) =>
+      settle(result, variables.message ?? "Added to object group"),
+    onError: fail,
+  });
+
+  const removeFromGroup = useMutation({
+    mutationFn: mutationFn("remove"),
+    onSuccess: (result, variables) =>
+      settle(result, variables.message ?? "Removed from object group"),
+    onError: fail,
+  });
+
+  const clearGroups = useMutation({
+    mutationFn: mutationFn("clear"),
+    onSuccess: (result) => settle(result, "Removed from all object groups"),
+    onError: fail,
+  });
+
+  return { addToGroup, removeFromGroup, clearGroups };
+}

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
ATOM-04 (many-to-many object-group membership) and ATOM-03 (`directPolicies(objectId:)` reverse lookup) both shipped backend-only. The admin panel was never updated, so object groups had no membership UI at all and there was no way to ask who an entity or resource is shared with. This is frontend-only (`app/`) and builds against the schema as it already exists on `edge` — no resolver, migration, or test changes under `src/`.

## 1. Object-group membership panel

Object groups now get a **Members** panel in the inspect sheet, added alongside the principal-group branch rather than replacing it (`groupType === "object"` vs `"principal"`).

There is no dedicated "members of this object group" query and none was added — the panel reads the list filters ATOM-04 made work, `entities(parentGroupId:)` and `resources(parentGroupId:)`, under an Entities/Resources tab pair. Each tab paginates the current members, gives a per-row remove, and has a tenant-scoped search-to-add picker (`q` is served by the backend, so the picker filters server-side).

`StatusBadge` is rendered only for entities: `Resource` has no `status` field in the schema, and its `name` is nullable, so resource rows fall back to the id.

## 2. Object groups from the entity/resource side

`EntityInspectDetails` and `ResourceInspectDetails` gained an **Object groups** section: removable chips for each group the object belongs to, plus an "add to group" picker.

- Membership is seeded from the `objectGroupIds` the entity/resource list query already selects, so opening the sheet costs no extra round trip.
- Group ids resolve to names through the existing `useNameMap` in `lib/reconcile`, which is the generalised form of the resolution pattern in `policy-inspect-details.tsx`.
- The picker is sourced from `objectGroups(...)`, not the generic `groups(...)`, so principal groups can never show up there.
- `clearEntityObjectGroups` / `clearResourceObjectGroups` are exposed as a separate, clearly-labelled destructive action behind an `AlertDialog`, not folded into single-remove. It lives on this side of the relationship because clearing is per-member, not per-group.
- Platform-scoped (tenant-less) objects get an explanation instead of a picker — the server rejects grouping them.

Both directions share `app/lib/object-groups/` (documents + a mutation hook), so the two views cannot drift apart. The mutations return the mutated `Entity`/`Resource`, so the response's `objectGroupIds` seeds the query cache directly rather than triggering a refetch, and the group-side member lists are invalidated at the same time.

Adds and removes are idempotent server-side (`ON CONFLICT ... DO NOTHING` for inserts, zero-row deletes on the way out), so there is deliberately **no** client-side "already a member" guard that could go stale.

## 3. Reverse policy lookup — "Access" tab

Entities and resources gained a read-only **Access** tab backed by `directPolicies(objectId:, objectKind:, ...)`, alongside the existing Details / Audit Logs tabs.

Per the resolver's own doc comment, this lists only the direct policies whose permission block *names* the object — by id, by object group, or through a group hierarchy scope. Role-derived access and blocks that reach the object without naming it (platform, tenant, objectKind, objectType) are excluded by the server, so the tab is presented as "who is this shared with", not effective access. Each row states why the policy reaches this object (directly, via a named group, via a group hierarchy scope), resolves the subject id to a name for entity and group subjects, and shows effect plus granted actions.

`objectKind` is sent as the lowercase `"entity"` / `"resource"` that `parse_object_kind` accepts. The tab is read-only by design — creating a grant still goes through the Policies page's create form.

## Checks

`pnpm --dir app lint`, `pnpm --dir app test`, and `pnpm --dir app build` all pass locally. Test count went from 58 to 97: the shared membership module and the direct-policy display helpers are unit-tested, and both new panels have component tests covering the mutation variables actually sent.