### PR TITLE
Hide already-joined items from object-group add pickers

### DIFF
--- a/app/components/groups/object-group-members-panel.test.tsx
+++ b/app/components/groups/object-group-members-panel.test.tsx
@@ -154,6 +154,44 @@ describe("ObjectGroupMembersPanel", () => {
     expect(screen.getAllByText("sensor-01")).toHaveLength(1);
   });
 
+  it("refills from later candidate pages after joined rows", async () => {
+    mocks.graphqlClient.mockImplementation((call: GraphqlCall) => {
+      if (call.query.includes("ObjectGroupEntityCandidates")) {
+        const offset = call.variables?.offset ?? 0;
+        return Promise.resolve({
+          list: {
+            total: 21,
+            items: offset === 0
+              ? [{
+                  id: "entity-1",
+                  name: "sensor-01",
+                  kind: "device",
+                  status: "active",
+                  objectGroupIds: ["group-1"],
+                }]
+              : [{
+                  id: "entity-2",
+                  name: "gateway-02",
+                  kind: "device",
+                  status: "active",
+                  objectGroupIds: [],
+                }],
+          },
+        });
+      }
+      return respond(call);
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("gateway-02")).toBeInTheDocument();
+    expect(mocks.graphqlClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ offset: 20 }),
+      }),
+    );
+  });
+
   it("says so when every match is already a member", async () => {
     mocks.graphqlClient.mockImplementation((call: GraphqlCall) => {
       if (call.query.includes("ObjectGroupEntityCandidates")) {

--- a/app/components/groups/object-group-members-panel.test.tsx
+++ b/app/components/groups/object-group-members-panel.test.tsx
@@ -70,13 +70,21 @@ function respond({ query, variables }: GraphqlCall) {
     expect(variables).toMatchObject({ tenantId: "tenant-1" });
     return Promise.resolve({
       list: {
-        total: 1,
+        total: 2,
         items: [
+          {
+            id: "entity-1",
+            name: "sensor-01",
+            kind: "device",
+            status: "active",
+            objectGroupIds: ["group-1"],
+          },
           {
             id: "entity-2",
             name: "gateway-02",
             kind: "device",
             status: "active",
+            objectGroupIds: [],
           },
         ],
       },
@@ -132,6 +140,51 @@ describe("ObjectGroupMembersPanel", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "gateway-02 added to this group",
     );
+  });
+
+  it("keeps entities already in the group out of the add picker", async () => {
+    renderPanel();
+
+    await screen.findByText("gateway-02");
+
+    const addButtons = screen.getAllByRole("button", { name: "Add" });
+    expect(addButtons).toHaveLength(1);
+    expect(addButtons[0].parentElement).toHaveTextContent("gateway-02");
+    // Only the member row, never a second row in the picker below it.
+    expect(screen.getAllByText("sensor-01")).toHaveLength(1);
+  });
+
+  it("says so when every match is already a member", async () => {
+    mocks.graphqlClient.mockImplementation((call: GraphqlCall) => {
+      if (call.query.includes("ObjectGroupEntityCandidates")) {
+        return Promise.resolve({
+          list: {
+            total: 1,
+            items: [
+              {
+                id: "entity-1",
+                name: "sensor-01",
+                kind: "device",
+                status: "active",
+                objectGroupIds: ["group-1"],
+              },
+            ],
+          },
+        });
+      }
+      return respond(call);
+    });
+
+    renderPanel();
+
+    expect(
+      await screen.findByText(
+        "Every matching entity is already in this group.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
   });
 
   it("removes a member from the group", async () => {

--- a/app/components/groups/object-group-members-panel.tsx
+++ b/app/components/groups/object-group-members-panel.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  excludeJoinedMembers,
   memberDisplayName,
   memberKindLabel,
   memberKindTitle,
@@ -90,6 +91,7 @@ function ObjectGroupMemberList({
   const total = membersQuery.data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const candidates = candidatesQuery.data ?? [];
+  const addable = excludeJoinedMembers(candidates, groupId);
 
   return (
     <div className="grid gap-3">
@@ -189,16 +191,18 @@ function ObjectGroupMemberList({
             <div className="text-sm text-destructive">
               {candidatesQuery.error.message}
             </div>
-          ) : candidates.length === 0 ? (
+          ) : addable.length === 0 ? (
             <div className="text-xs text-muted-foreground">
-              {search
-                ? `No matching ${kind === "entity" ? "entities" : "resources"}.`
-                : `No ${kind === "entity" ? "entities" : "resources"} available.`}
+              {candidates.length > 0
+                ? `Every matching ${kind === "entity" ? "entity is" : "resource is"} already in this group.`
+                : search
+                  ? `No matching ${kind === "entity" ? "entities" : "resources"}.`
+                  : `No ${kind === "entity" ? "entities" : "resources"} available.`}
             </div>
           ) : (
             <ScrollArea className="max-h-48">
               <div className="grid gap-1">
-                {candidates.map((candidate) => (
+                {addable.map((candidate) => (
                   <div
                     className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
                     key={candidate.id}

--- a/app/components/groups/object-group-members-panel.tsx
+++ b/app/components/groups/object-group-members-panel.tsx
@@ -9,7 +9,6 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
-  excludeJoinedMembers,
   memberDisplayName,
   memberKindLabel,
   memberKindTitle,
@@ -84,14 +83,15 @@ function ObjectGroupMemberList({
     kind,
     tenantId,
     search,
+    groupId,
   });
   const { addToGroup, removeFromGroup } = useObjectGroupMembershipActions(kind);
 
   const members = membersQuery.data?.items ?? [];
   const total = membersQuery.data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const candidates = candidatesQuery.data ?? [];
-  const addable = excludeJoinedMembers(candidates, groupId);
+  const candidates = candidatesQuery.data?.items ?? [];
+  const matchingCandidates = candidatesQuery.data?.total ?? 0;
 
   return (
     <div className="grid gap-3">
@@ -191,9 +191,9 @@ function ObjectGroupMemberList({
             <div className="text-sm text-destructive">
               {candidatesQuery.error.message}
             </div>
-          ) : addable.length === 0 ? (
+          ) : candidates.length === 0 ? (
             <div className="text-xs text-muted-foreground">
-              {candidates.length > 0
+              {matchingCandidates > 0
                 ? `Every matching ${kind === "entity" ? "entity is" : "resource is"} already in this group.`
                 : search
                   ? `No matching ${kind === "entity" ? "entities" : "resources"}.`
@@ -202,7 +202,7 @@ function ObjectGroupMemberList({
           ) : (
             <ScrollArea className="max-h-48">
               <div className="grid gap-1">
-                {addable.map((candidate) => (
+                {candidates.map((candidate) => (
                   <div
                     className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
                     key={candidate.id}

--- a/app/components/groups/object-group-membership-field.test.tsx
+++ b/app/components/groups/object-group-membership-field.test.tsx
@@ -137,6 +137,32 @@ describe("ObjectGroupMembershipField", () => {
     expect(screen.getAllByText("Floor sensors")).toHaveLength(1);
   });
 
+  it("refills from later group pages after joined rows", async () => {
+    mocks.graphqlClient.mockImplementation((call: GraphqlCall) => {
+      if (call.query.includes("ObjectGroupPicker")) {
+        const offset = call.variables?.offset ?? 0;
+        return Promise.resolve({
+          objectGroups: {
+            total: 21,
+            items: offset === 0
+              ? [{ id: "group-1", name: "Floor sensors" }]
+              : [{ id: "group-2", name: "Gateways" }],
+          },
+        });
+      }
+      return respond(call);
+    });
+
+    renderField();
+
+    expect(await screen.findByText("Gateways")).toBeInTheDocument();
+    expect(mocks.graphqlClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ offset: 20 }),
+      }),
+    );
+  });
+
   it("says so when every match is already joined", async () => {
     mocks.graphqlClient.mockImplementation((call: GraphqlCall) => {
       if (call.query.includes("ObjectGroupPicker")) {

--- a/app/components/groups/object-group-membership-field.test.tsx
+++ b/app/components/groups/object-group-membership-field.test.tsx
@@ -61,8 +61,11 @@ function respond({ query }: GraphqlCall) {
   if (query.includes("ObjectGroupPicker")) {
     return Promise.resolve({
       objectGroups: {
-        total: 1,
-        items: [{ id: "group-2", name: "Gateways" }],
+        total: 2,
+        items: [
+          { id: "group-1", name: "Floor sensors" },
+          { id: "group-2", name: "Gateways" },
+        ],
       },
     });
   }
@@ -120,6 +123,43 @@ describe("ObjectGroupMembershipField", () => {
       );
     });
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Added to Gateways");
+  });
+
+  it("keeps groups the entity already belongs to out of the picker", async () => {
+    renderField();
+
+    await screen.findByText("Gateways");
+
+    const addButtons = screen.getAllByRole("button", { name: "Add" });
+    expect(addButtons).toHaveLength(1);
+    expect(addButtons[0].parentElement).toHaveTextContent("Gateways");
+    // Only the joined chip, never a second row in the picker below it.
+    expect(screen.getAllByText("Floor sensors")).toHaveLength(1);
+  });
+
+  it("says so when every match is already joined", async () => {
+    mocks.graphqlClient.mockImplementation((call: GraphqlCall) => {
+      if (call.query.includes("ObjectGroupPicker")) {
+        return Promise.resolve({
+          objectGroups: {
+            total: 1,
+            items: [{ id: "group-1", name: "Floor sensors" }],
+          },
+        });
+      }
+      return respond(call);
+    });
+
+    renderField();
+
+    expect(
+      await screen.findByText(
+        "Already a member of every matching object group.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
   });
 
   it("removes the entity from one group", async () => {

--- a/app/components/groups/object-group-membership-field.tsx
+++ b/app/components/groups/object-group-membership-field.tsx
@@ -17,7 +17,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import type { ObjectMemberKind } from "@/lib/object-groups/membership";
+import {
+  excludeJoinedGroups,
+  type ObjectMemberKind,
+} from "@/lib/object-groups/membership";
 import {
   useObjectGroupIds,
   useObjectGroupMembershipActions,
@@ -53,6 +56,7 @@ export function ObjectGroupMembershipField({
 
   const names = useNameMap({ groupIds: objectGroupIds });
   const options = optionsQuery.data ?? [];
+  const addable = excludeJoinedGroups(options, objectGroupIds);
   const isPlatformScoped = !tenantId;
 
   return (
@@ -123,16 +127,18 @@ export function ObjectGroupMembershipField({
             <div className="text-sm text-destructive">
               {optionsQuery.error.message}
             </div>
-          ) : options.length === 0 ? (
+          ) : addable.length === 0 ? (
             <div className="text-xs text-muted-foreground">
-              {search
-                ? "No matching object groups."
-                : "No object groups in this tenant."}
+              {options.length > 0
+                ? "Already a member of every matching object group."
+                : search
+                  ? "No matching object groups."
+                  : "No object groups in this tenant."}
             </div>
           ) : (
             <ScrollArea className="max-h-40">
               <div className="grid gap-1">
-                {options.map((option) => (
+                {addable.map((option) => (
                   <div
                     className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
                     key={option.id}

--- a/app/components/groups/object-group-membership-field.tsx
+++ b/app/components/groups/object-group-membership-field.tsx
@@ -18,7 +18,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
-  excludeJoinedGroups,
   type ObjectMemberKind,
 } from "@/lib/object-groups/membership";
 import {
@@ -50,13 +49,17 @@ export function ObjectGroupMembershipField({
     memberId,
     initialObjectGroupIds,
   });
-  const optionsQuery = useObjectGroupOptions({ tenantId, search });
+  const optionsQuery = useObjectGroupOptions({
+    tenantId,
+    search,
+    excludedGroupIds: objectGroupIds,
+  });
   const { addToGroup, removeFromGroup, clearGroups } =
     useObjectGroupMembershipActions(kind);
 
   const names = useNameMap({ groupIds: objectGroupIds });
-  const options = optionsQuery.data ?? [];
-  const addable = excludeJoinedGroups(options, objectGroupIds);
+  const options = optionsQuery.data?.items ?? [];
+  const matchingOptions = optionsQuery.data?.total ?? 0;
   const isPlatformScoped = !tenantId;
 
   return (
@@ -127,9 +130,9 @@ export function ObjectGroupMembershipField({
             <div className="text-sm text-destructive">
               {optionsQuery.error.message}
             </div>
-          ) : addable.length === 0 ? (
+          ) : options.length === 0 ? (
             <div className="text-xs text-muted-foreground">
-              {options.length > 0
+              {matchingOptions > 0
                 ? "Already a member of every matching object group."
                 : search
                   ? "No matching object groups."
@@ -138,7 +141,7 @@ export function ObjectGroupMembershipField({
           ) : (
             <ScrollArea className="max-h-40">
               <div className="grid gap-1">
-                {addable.map((option) => (
+                {options.map((option) => (
                   <div
                     className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
                     key={option.id}

--- a/app/lib/object-groups/membership.test.ts
+++ b/app/lib/object-groups/membership.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   candidatesQuery,
+  excludeJoinedGroups,
+  excludeJoinedMembers,
   memberDisplayName,
   memberIdVariableName,
   memberKindLabel,
@@ -122,6 +124,11 @@ describe("membership documents", () => {
     );
   });
 
+  it("reads candidate membership so joined rows can be filtered out", () => {
+    expect(candidatesQuery("entity")).toContain("objectGroupIds");
+    expect(candidatesQuery("resource")).toContain("objectGroupIds");
+  });
+
   it("reads a single member's membership set", () => {
     expect(membershipQuery("entity")).toContain(
       "member: entity(id: $id) { id objectGroupIds }",
@@ -134,6 +141,42 @@ describe("membership documents", () => {
   it("picks groups through objectGroups so principal groups never appear", () => {
     expect(OBJECT_GROUPS_QUERY).toContain("objectGroups(tenantId: $tenantId");
     expect(OBJECT_GROUPS_QUERY).not.toMatch(/\bgroups\(/);
+  });
+});
+
+describe("already joined candidates", () => {
+  it("drops the object groups the entity or resource is already in", () => {
+    const options = [
+      { id: "group-1", name: "Floor sensors" },
+      { id: "group-2", name: "Gateways" },
+      { id: "group-3", name: "Meters" },
+    ];
+    expect(excludeJoinedGroups(options, ["group-2"])).toEqual([
+      { id: "group-1", name: "Floor sensors" },
+      { id: "group-3", name: "Meters" },
+    ]);
+  });
+
+  it("keeps every option when nothing is joined yet", () => {
+    const options = [{ id: "group-1", name: "Floor sensors" }];
+    expect(excludeJoinedGroups(options, [])).toEqual(options);
+  });
+
+  it("drops the members already in the group being edited", () => {
+    const candidates = [
+      { id: "entity-1", objectGroupIds: ["group-1"] },
+      { id: "entity-2", objectGroupIds: ["group-9"] },
+      { id: "entity-3", objectGroupIds: [] },
+    ];
+    expect(excludeJoinedMembers(candidates, "group-1")).toEqual([
+      { id: "entity-2", objectGroupIds: ["group-9"] },
+      { id: "entity-3", objectGroupIds: [] },
+    ]);
+  });
+
+  it("keeps candidates whose membership is missing rather than empty", () => {
+    const candidates = [{ id: "resource-1" }, { id: "resource-2" }];
+    expect(excludeJoinedMembers(candidates, "group-1")).toEqual(candidates);
   });
 });
 

--- a/app/lib/object-groups/membership.ts
+++ b/app/lib/object-groups/membership.ts
@@ -65,16 +65,16 @@ const MEMBERS_QUERIES: Record<ObjectMemberKind, string> = {
  */
 const CANDIDATES_QUERIES: Record<ObjectMemberKind, string> = {
   entity: `
-    query ObjectGroupEntityCandidates($tenantId: ID, $q: String, $limit: Int!) {
-      list: entities(tenantId: $tenantId, q: $q, limit: $limit, offset: 0) {
+    query ObjectGroupEntityCandidates($tenantId: ID, $q: String, $limit: Int!, $offset: Int!) {
+      list: entities(tenantId: $tenantId, q: $q, limit: $limit, offset: $offset) {
         total
         items { id name kind status objectGroupIds }
       }
     }
   `,
   resource: `
-    query ObjectGroupResourceCandidates($tenantId: ID, $q: String, $limit: Int!) {
-      list: resources(tenantId: $tenantId, q: $q, limit: $limit, offset: 0) {
+    query ObjectGroupResourceCandidates($tenantId: ID, $q: String, $limit: Int!, $offset: Int!) {
+      list: resources(tenantId: $tenantId, q: $q, limit: $limit, offset: $offset) {
         total
         items { id name kind objectGroupIds }
       }
@@ -240,7 +240,7 @@ export function excludeJoinedGroups<T extends { id: string }>(
 }
 
 export function excludeJoinedMembers<
-  T extends { objectGroupIds?: string[] | null },
+  T extends { id: string; objectGroupIds?: string[] | null },
 >(candidates: T[], groupId: string): T[] {
   return candidates.filter(
     (candidate) => !candidate.objectGroupIds?.includes(groupId),

--- a/app/lib/object-groups/membership.ts
+++ b/app/lib/object-groups/membership.ts
@@ -16,6 +16,8 @@ export type ObjectGroupMember = {
   kind: string;
   /** Entities carry a lifecycle status; resources have no status field. */
   status?: string | null;
+  /** Only the add pickers select this, to hide candidates already joined. */
+  objectGroupIds?: string[] | null;
 };
 
 export type ObjectGroupMemberPage = {
@@ -56,13 +58,17 @@ const MEMBERS_QUERIES: Record<ObjectMemberKind, string> = {
   `,
 };
 
-/** Search-to-add pickers, scoped to the group's tenant. */
+/**
+ * Search-to-add pickers, scoped to the group's tenant. `objectGroupIds` rides
+ * along so the picker can drop candidates already in the group without a
+ * second round trip.
+ */
 const CANDIDATES_QUERIES: Record<ObjectMemberKind, string> = {
   entity: `
     query ObjectGroupEntityCandidates($tenantId: ID, $q: String, $limit: Int!) {
       list: entities(tenantId: $tenantId, q: $q, limit: $limit, offset: 0) {
         total
-        items { id name kind status }
+        items { id name kind status objectGroupIds }
       }
     }
   `,
@@ -70,7 +76,7 @@ const CANDIDATES_QUERIES: Record<ObjectMemberKind, string> = {
     query ObjectGroupResourceCandidates($tenantId: ID, $q: String, $limit: Int!) {
       list: resources(tenantId: $tenantId, q: $q, limit: $limit, offset: 0) {
         total
-        items { id name kind }
+        items { id name kind objectGroupIds }
       }
     }
   `,
@@ -217,6 +223,28 @@ export function objectGroupIdsFromRow(
     (id): id is string => typeof id === "string" && id.length > 0,
   );
   return [...new Set(ids)];
+}
+
+/**
+ * An add picker must never offer something that is already joined: the add
+ * would be a silent no-op, and the row gives no hint that it is redundant.
+ * Both directions decide from `objectGroupIds` — the entity/resource side
+ * holds its own set, the group side reads each candidate's set.
+ */
+export function excludeJoinedGroups<T extends { id: string }>(
+  options: T[],
+  joinedGroupIds: readonly string[],
+): T[] {
+  const joined = new Set(joinedGroupIds);
+  return options.filter((option) => !joined.has(option.id));
+}
+
+export function excludeJoinedMembers<
+  T extends { objectGroupIds?: string[] | null },
+>(candidates: T[], groupId: string): T[] {
+  return candidates.filter(
+    (candidate) => !candidate.objectGroupIds?.includes(groupId),
+  );
 }
 
 /** Resource names are nullable; never render an empty label. */

--- a/app/lib/object-groups/use-object-group-membership.ts
+++ b/app/lib/object-groups/use-object-group-membership.ts
@@ -20,6 +20,7 @@ import {
 
 export const OBJECT_GROUP_MEMBERS_KEY = "object-group-members";
 export const OBJECT_GROUP_MEMBERSHIP_KEY = "object-group-membership";
+export const OBJECT_GROUP_CANDIDATES_KEY = "object-group-member-candidates";
 
 export function membersQueryKey(
   kind: ObjectMemberKind,
@@ -83,7 +84,7 @@ export function useObjectGroupMemberCandidates({
   const q = search.trim();
   return useQuery({
     enabled: Boolean(tenantId),
-    queryKey: ["object-group-member-candidates", kind, tenantId ?? null, q],
+    queryKey: [OBJECT_GROUP_CANDIDATES_KEY, kind, tenantId ?? null, q],
     queryFn: async ({ signal }) => {
       const data = await graphqlClient<{
         list: { total: number; items: ObjectGroupMember[] };
@@ -174,7 +175,8 @@ export type MembershipActionVariables = {
 /**
  * The six membership mutations, usable from either direction. Adds and removes
  * are idempotent server-side (`ON CONFLICT DO NOTHING` / zero-row delete), so
- * there is deliberately no client-side "already a member" guard here.
+ * these need no "already a member" guard; the pickers keep a redundant add out
+ * of reach instead, by hiding candidates that are already joined.
  */
 export function useObjectGroupMembershipActions(kind: ObjectMemberKind) {
   const queryClient = useQueryClient();
@@ -195,6 +197,9 @@ export function useObjectGroupMembershipActions(kind: ObjectMemberKind) {
       result.objectGroupIds,
     );
     queryClient.invalidateQueries({ queryKey: [OBJECT_GROUP_MEMBERS_KEY] });
+    // Candidate rows carry the membership the picker filters on, so they go
+    // stale the moment a member is added or removed.
+    queryClient.invalidateQueries({ queryKey: [OBJECT_GROUP_CANDIDATES_KEY] });
     toast.success(message);
   }
 

--- a/app/lib/object-groups/use-object-group-membership.ts
+++ b/app/lib/object-groups/use-object-group-membership.ts
@@ -11,6 +11,7 @@ import {
   membershipVariables,
   membersQuery,
   OBJECT_GROUPS_QUERY,
+  excludeJoinedMembers,
   type ObjectGroupMember,
   type ObjectGroupMemberPage,
   type ObjectGroupMembership,
@@ -74,26 +75,57 @@ export function useObjectGroupMemberCandidates({
   kind,
   tenantId,
   search,
+  groupId,
   limit = 20,
 }: {
   kind: ObjectMemberKind;
   tenantId?: string | null;
   search: string;
+  groupId: string;
   limit?: number;
 }) {
   const q = search.trim();
   return useQuery({
     enabled: Boolean(tenantId),
-    queryKey: [OBJECT_GROUP_CANDIDATES_KEY, kind, tenantId ?? null, q],
+    queryKey: [
+      OBJECT_GROUP_CANDIDATES_KEY,
+      kind,
+      tenantId ?? null,
+      groupId,
+      q,
+    ],
     queryFn: async ({ signal }) => {
-      const data = await graphqlClient<{
-        list: { total: number; items: ObjectGroupMember[] };
-      }>({
-        query: candidatesQuery(kind),
-        variables: { tenantId: tenantId || null, q: q || null, limit },
-        signal,
-      });
-      return data.list.items;
+      const items: ObjectGroupMember[] = [];
+      let total = 0;
+      let offset = 0;
+
+      // Membership is returned on each row, so refill the picker from later
+      // pages when an earlier page consists entirely of joined members.
+      while (offset < total || offset === 0) {
+        const data = await graphqlClient<{
+          list: { total: number; items: ObjectGroupMember[] };
+        }>({
+          query: candidatesQuery(kind),
+          variables: {
+            tenantId: tenantId || null,
+            q: q || null,
+            limit,
+            offset,
+          },
+          signal,
+        });
+        total = data.list.total;
+        items.push(...excludeJoinedMembers(data.list.items, groupId));
+
+        if (
+          items.length >= limit ||
+          data.list.items.length === 0 ||
+          offset + data.list.items.length >= total
+        ) break;
+        offset += limit;
+      }
+
+      return { items: items.slice(0, limit), total };
     },
     staleTime: 30_000,
     placeholderData: (previous) => previous,

--- a/app/lib/object-groups/use-object-group-membership.ts
+++ b/app/lib/object-groups/use-object-group-membership.ts
@@ -11,6 +11,7 @@ import {
   membershipVariables,
   membersQuery,
   OBJECT_GROUPS_QUERY,
+  excludeJoinedGroups,
   excludeJoinedMembers,
   type ObjectGroupMember,
   type ObjectGroupMemberPage,
@@ -136,29 +137,51 @@ export function useObjectGroupMemberCandidates({
 export function useObjectGroupOptions({
   tenantId,
   search,
+  excludedGroupIds = [],
   limit = 20,
 }: {
   tenantId?: string | null;
   search: string;
+  excludedGroupIds?: readonly string[];
   limit?: number;
 }) {
   const q = search.trim();
+  const excludedKey = excludedGroupIds.join(",");
   return useQuery({
-    queryKey: ["object-group-options", tenantId ?? null, q],
+    queryKey: ["object-group-options", tenantId ?? null, q, excludedKey],
     queryFn: async ({ signal }) => {
-      const data = await graphqlClient<{
-        objectGroups: { total: number; items: ObjectGroupOption[] };
-      }>({
-        query: OBJECT_GROUPS_QUERY,
-        variables: {
-          tenantId: tenantId || null,
-          q: q || null,
-          limit,
-          offset: 0,
-        },
-        signal,
-      });
-      return data.objectGroups.items;
+      const items: ObjectGroupOption[] = [];
+      let total = 0;
+      let offset = 0;
+
+      // Refill from later pages when the first page contains only joined groups.
+      while (offset < total || offset === 0) {
+        const data = await graphqlClient<{
+          objectGroups: { total: number; items: ObjectGroupOption[] };
+        }>({
+          query: OBJECT_GROUPS_QUERY,
+          variables: {
+            tenantId: tenantId || null,
+            q: q || null,
+            limit,
+            offset,
+          },
+          signal,
+        });
+        total = data.objectGroups.total;
+        items.push(
+          ...excludeJoinedGroups(data.objectGroups.items, excludedGroupIds),
+        );
+
+        if (
+          items.length >= limit ||
+          data.objectGroups.items.length === 0 ||
+          offset + data.objectGroups.items.length >= total
+        ) break;
+        offset += limit;
+      }
+
+      return { items: items.slice(0, limit), total };
     },
     staleTime: 30_000,
     placeholderData: (previous) => previous,


### PR DESCRIPTION
## What

The four search-to-add pickers introduced in #82 offered every candidate in the tenant, including the ones already joined:

- entity inspect sheet → **Object groups** → "Add to object group"
- resource inspect sheet → **Object groups** → "Add to object group"
- object-group inspect sheet → **Members** → Entities tab → "Add entity"
- object-group inspect sheet → **Members** → Resources tab → "Add resource"

`addEntityToObjectGroup` / `addResourceToObjectGroup` are idempotent, so clicking `Add` on an already-joined row was harmless — but it fired a mutation and raised a success toast for something that changed nothing, and the picker gave no way to tell joined from not-joined.

## How

Both directions decide from `objectGroupIds`, and the filtering lives in one place — two helpers in `lib/object-groups/membership.ts`, shared by the two picker components (each of which serves two of the four pickers):

- `excludeJoinedGroups(options, joinedGroupIds)` — the entity/resource side already holds its own membership set via `useObjectGroupIds`.
- `excludeJoinedMembers(candidates, groupId)` — the group side now selects `objectGroupIds` on each candidate in the existing candidates query, so no extra round trip and no dependence on the paginated members list (which only holds the current page of 10).

The candidates cache is invalidated alongside the members cache on add/remove/clear, since a membership mutation is exactly what makes those candidate rows stale.

When filtering empties an otherwise non-empty result, the picker now says so ("Every matching entity is already in this group." / "Already a member of every matching object group.") instead of claiming there is nothing to find.

`parentGroupId` without `includeDescendants` matches direct membership rows in `group_entity_parents`, so the filter and the members list agree exactly.

## Test plan

Automated, in `app/`:

- `pnpm lint` — clean (biome, 178 files).
- `pnpm test` — 25 files, 107 tests pass. New coverage: unit tests for both helpers in `membership.test.ts` (including a candidate whose `objectGroupIds` is absent rather than empty), plus tests in both component suites asserting the picker offers exactly one `Add` (the non-joined row), that a joined item renders only once on screen, and that the "everything already joined" message appears with no `Add` button. Reverting just the two component changes fails 11 of the 13 tests in those two suites, so the new assertions are not vacuous.
- `pnpm build` — succeeds.

Manual, against a real backend (own dev UI on `:3011` pointed at a running Atom stack, admin login, fixtures `qa-test-group-2` containing `qa-test-entity-1` and `qa-test-resource-1`):

| Picker | Before | After |
| --- | --- | --- |
| group → Entities tab | "Add entity" offered `qa-test-entity-3`, **`qa-test-entity-1`**, `bootstrap-gateway` while `qa-test-entity-1` was listed as the group's one member | offers only `qa-test-entity-3` and `bootstrap-gateway` |
| group → Resources tab | "Add resource" offered **`qa-test-resource-1`** (the group's one member) and `telemetry` | offers only `telemetry` |
| entity sheet (`qa-test-entity-1`) | "Add to object group" offered **`qa-test-group-2`** (shown as joined in the chip row above), `qa-test-group-1`, `production-channels` | offers only `qa-test-group-1` and `production-channels` |

Adding a genuinely new item still works end-to-end: clicking `Add` on `qa-test-entity-3` raised the toast "qa-test-entity-3 added to this group", the member count went 1 entity → 2 entities, and the picker immediately dropped `qa-test-entity-3`, leaving only `bootstrap-gateway` — confirming the candidate-cache invalidation.

Browser console: no errors or warnings before or after the change.
