### PR TITLE
Add updateProfileVersion mutation, status only

### DIFF
--- a/src/graphql/profiles.rs
+++ b/src/graphql/profiles.rs
@@ -3,7 +3,9 @@ use serde_json::json;
 
 use crate::{
     identity::profile_repo,
-    models::profile::{CreateProfile, CreateProfileVersion, ListProfiles, UpdateProfile},
+    models::profile::{
+        CreateProfile, CreateProfileVersion, ListProfiles, UpdateProfile, UpdateProfileVersion,
+    },
     state::AppState,
 };
 
@@ -11,7 +13,7 @@ use super::{
     auth::{gql_error, require_auth, require_list_access, require_read_access, scope_for_tenant},
     types::{
         parse_id, parse_optional_id, CreateProfileInput, CreateProfileVersionInput, Profile,
-        ProfileList, ProfileVersion, UpdateProfileInput,
+        ProfileList, ProfileVersion, UpdateProfileInput, UpdateProfileVersionInput,
     },
 };
 
@@ -264,6 +266,71 @@ impl ProfileMutation {
 
         result.map(Into::into).map_err(gql_error)
     }
+
+    // Status only — see UpdateProfileVersionInput for why jsonSchema/uiSchema
+    // are not editable here.
+    async fn update_profile_version(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+        input: UpdateProfileVersionInput,
+    ) -> Result<ProfileVersion> {
+        let auth = require_auth(ctx)?;
+        let state = ctx.data::<AppState>()?;
+        let id = parse_id(id, "id")?;
+        let existing = profile_repo::get_profile_version(&state.pool, id)
+            .await
+            .map_err(gql_error)?;
+        let profile = profile_repo::get_profile(&state.pool, existing.profile_id)
+            .await
+            .map_err(gql_error)?;
+        validate_profile_version_status(input.status.as_deref())?;
+
+        let result = async {
+            crate::auth::require_any_capability(
+                &state.pool,
+                &auth,
+                &[
+                    ("manage", scope_for_tenant(profile.tenant_id)),
+                    ("write", scope_for_tenant(profile.tenant_id)),
+                ],
+            )
+            .await?;
+            profile_repo::update_profile_version_with_audit(
+                &state.pool,
+                state.config.events.enabled(),
+                Some(auth.entity_id),
+                profile.tenant_id,
+                id,
+                UpdateProfileVersion {
+                    json_schema: None,
+                    ui_schema: None,
+                    status: input.status,
+                },
+            )
+            .await
+        }
+        .await;
+
+        if let Err(ref err) = result {
+            crate::audit::observe_error(
+                &state.pool,
+                state.config.events.enabled(),
+                &crate::audit::AuditMeta {
+                    actor_entity_id: Some(auth.entity_id),
+                    tenant_id: profile.tenant_id,
+                    target_kind: "profile_version",
+                    target_id: Some(id),
+                    event: "profile_version.update",
+                },
+                &json!({ "profile_id": profile.id }),
+                err,
+            )
+            .await;
+        }
+
+        result.map(Into::into).map_err(gql_error)
+    }
 }
 
 fn validate_profile_status(status: Option<&str>) -> Result<()> {
@@ -271,6 +338,15 @@ fn validate_profile_status(status: Option<&str>) -> Result<()> {
         Some("active" | "deprecated" | "disabled") | None => Ok(()),
         Some(_) => Err(async_graphql::Error::new(
             "status must be active, deprecated, or disabled",
+        )),
+    }
+}
+
+fn validate_profile_version_status(status: Option<&str>) -> Result<()> {
+    match status {
+        Some("draft" | "active" | "deprecated" | "disabled") | None => Ok(()),
+        Some(_) => Err(async_graphql::Error::new(
+            "status must be draft, active, deprecated, or disabled",
         )),
     }
 }

--- a/src/graphql/types/mod.rs
+++ b/src/graphql/types/mod.rs
@@ -1723,6 +1723,15 @@ pub struct UpdateProfileInput {
     pub status: Option<String>,
 }
 
+// Status only — jsonSchema/uiSchema stay immutable once a version is created,
+// since a bound entity's writes validate against exactly the schema its
+// version had at bind time. Retargeting that schema out from under it would
+// silently change what already-bound entities are allowed to write.
+#[derive(InputObject)]
+pub struct UpdateProfileVersionInput {
+    pub status: Option<String>,
+}
+
 #[derive(InputObject)]
 pub struct CreateEntityInput {
     pub id: Option<ID>,

--- a/src/identity/profile_repo.rs
+++ b/src/identity/profile_repo.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{db_err, AppError},
     models::profile::{
         CreateProfile, CreateProfileVersion, ListProfiles, Profile, ProfileList, ProfileVersion,
-        UpdateProfile,
+        UpdateProfile, UpdateProfileVersion,
     },
 };
 
@@ -223,6 +223,57 @@ pub async fn create_profile_version_with_audit(
             event: "profile_version.create",
         },
         &serde_json::json!({ "profile_id": profile_id }),
+    )
+    .await?;
+    Ok(version)
+}
+
+pub async fn update_profile_version(
+    pool: &PgPool,
+    id: Uuid,
+    req: UpdateProfileVersion,
+) -> Result<ProfileVersion, AppError> {
+    update_profile_version_with_audit(pool, false, None, None, id, req).await
+}
+
+pub async fn update_profile_version_with_audit(
+    pool: &PgPool,
+    events_enabled: bool,
+    actor_id: Option<Uuid>,
+    tenant_id: Option<Uuid>,
+    id: Uuid,
+    req: UpdateProfileVersion,
+) -> Result<ProfileVersion, AppError> {
+    let mut tx = pool.begin().await.map_err(db_err)?;
+    let version = sqlx::query_as::<_, ProfileVersion>(
+        r#"UPDATE profile_versions
+           SET json_schema = COALESCE($2, json_schema),
+               ui_schema   = COALESCE($3, ui_schema),
+               status      = COALESCE($4, status)
+           WHERE id = $1
+           RETURNING id, profile_id, version, json_schema, ui_schema, status, created_at"#,
+    )
+    .bind(id)
+    .bind(req.json_schema)
+    .bind(req.ui_schema)
+    .bind(req.status)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| match e {
+        sqlx::Error::RowNotFound => AppError::not_found(format!("profile version {id} not found")),
+        other => AppError::Database(other),
+    })?;
+    crate::audit::commit_with_observation(
+        tx,
+        events_enabled,
+        &crate::audit::AuditMeta {
+            actor_entity_id: actor_id,
+            tenant_id,
+            target_kind: "profile_version",
+            target_id: Some(id),
+            event: "profile_version.update",
+        },
+        &serde_json::json!({}),
     )
     .await?;
     Ok(version)

--- a/tests/m10_graphql_profiles.rs
+++ b/tests/m10_graphql_profiles.rs
@@ -186,6 +186,77 @@ async fn update_profile_mutation_updates_metadata_and_status() {
 
 #[tokio::test]
 #[ignore]
+async fn update_profile_version_mutation_updates_status_only() {
+    let pool = common::pool().await;
+    let schema_body = json!({"type": "object"});
+    let profile_id = profile_with_schema(&pool, schema_body.clone()).await;
+    let versions = profile_repo::list_profile_versions(&pool, profile_id)
+        .await
+        .expect("list versions");
+    let version_id = versions[0].id;
+    let schema = build_schema(state(pool));
+
+    let response = schema
+        .execute(authed(format!(
+            r#"
+            mutation {{
+              updateProfileVersion(
+                id: "{version_id}",
+                input: {{ status: "deprecated" }}
+              ) {{
+                id
+                status
+                jsonSchema
+              }}
+            }}
+            "#
+        )))
+        .await;
+
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    let version = &response.data.into_json().expect("json data")["updateProfileVersion"];
+    assert_eq!(version["id"], version_id.to_string());
+    assert_eq!(version["status"], "deprecated");
+    // jsonSchema stays exactly what it was created with — updateProfileVersion
+    // has no way to touch it, since entities already bound to this version
+    // validate writes against it.
+    assert_eq!(version["jsonSchema"], schema_body);
+}
+
+#[tokio::test]
+#[ignore]
+async fn update_profile_version_mutation_rejects_unknown_status() {
+    let pool = common::pool().await;
+    let profile_id = profile_with_schema(&pool, json!({})).await;
+    let versions = profile_repo::list_profile_versions(&pool, profile_id)
+        .await
+        .expect("list versions");
+    let version_id = versions[0].id;
+    let schema = build_schema(state(pool));
+
+    let response = schema
+        .execute(authed(format!(
+            r#"
+            mutation {{
+              updateProfileVersion(
+                id: "{version_id}",
+                input: {{ status: "not-a-status" }}
+              ) {{
+                id
+              }}
+            }}
+            "#
+        )))
+        .await;
+
+    assert!(!response.errors.is_empty());
+    assert!(response.errors[0]
+        .message
+        .contains("status must be draft, active, deprecated, or disabled"));
+}
+
+#[tokio::test]
+#[ignore]
 async fn create_entity_with_profile_id_derives_kind() {
     let pool = common::pool().await;
     let profile_id = seeded_client_profile(&pool).await;


### PR DESCRIPTION
## Summary
- Adds a GraphQL `updateProfileVersion(id, input)` mutation, exposing only `status` — magistrala-ui's device type versions UI needs to let editors change a version's status after creation (draft -> active, retire one, etc.), and Atom previously had no mutation for that, only `createProfileVersion`.
- `jsonSchema`/`uiSchema` stay immutable: entities already bound to a version validate every write against exactly that schema, so the input type deliberately does not expose them.
- Adds `profile_repo::update_profile_version[_with_audit]`, mirroring the existing `update_profile_with_audit` COALESCE pattern, plus `validate_profile_version_status` (`draft | active | deprecated | disabled`).

## Test plan
- [x] `cargo check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (unit tests)
- [x] `cargo test -- --include-ignored --test-threads=1` against a fresh local Postgres — all profile/identity/authz/audit/bootstrap suites pass; only failures were pre-existing live-broker tests (`m27_live_amqp_delivery`) needing `TEST_AMQP_URL`, unrelated to this change
- [x] New tests: `update_profile_version_mutation_updates_status_only` (jsonSchema unchanged after a status-only update) and `update_profile_version_mutation_rejects_unknown_status`
