### PR TITLE
Sync vendored broker auth proto with upstream enum rename

### DIFF
--- a/proto/broker/v1/auth.proto
+++ b/proto/broker/v1/auth.proto
@@ -38,12 +38,12 @@ service HookService {
 
 // Protocol identifies which messaging protocol the client connected with.
 enum Protocol {
-  Unspecified = 0;
-  MQTT = 1;
-  AMQP_1_0 = 2;
-  AMQP_0_9_1 = 3;
-  HTTP = 4;
-  CoAP = 5;
+  PROTOCOL_UNSPECIFIED = 0;
+  PROTOCOL_MQTT = 1;
+  PROTOCOL_AMQP_1_0 = 2;
+  PROTOCOL_AMQP_0_9_1 = 3;
+  PROTOCOL_HTTP = 4;
+  PROTOCOL_COAP = 5;
 }
 
 message AuthnReq {
@@ -79,9 +79,9 @@ message AuthzReq {
 }
 
 enum Action {
-  None = 0;
-  Publish = 1;
-  Subscribe = 2;
+  ACTION_UNSPECIFIED = 0;
+  ACTION_PUBLISH = 1;
+  ACTION_SUBSCRIBE = 2;
 }
 
 message AuthzRes {
@@ -94,17 +94,17 @@ message AuthzRes {
 }
 
 enum HookType {
-  HookTypeUnspecified = 0;
-  AuthOnRegister = 1;
-  AuthOnPublish = 2;
-  AuthOnSubscribe = 3;
-  AuthOnUnsubscribe = 4;
+  HOOK_TYPE_UNSPECIFIED = 0;
+  HOOK_TYPE_AUTH_ON_REGISTER = 1;
+  HOOK_TYPE_AUTH_ON_PUBLISH = 2;
+  HOOK_TYPE_AUTH_ON_SUBSCRIBE = 3;
+  HOOK_TYPE_AUTH_ON_UNSUBSCRIBE = 4;
 }
 
 enum HookResult {
-  HookResultUnspecified = 0;
-  HookResultOk = 1;
-  HookResultDeny = 2;
+  HOOK_RESULT_UNSPECIFIED = 0;
+  HOOK_RESULT_OK = 1;
+  HOOK_RESULT_DENY = 2;
 }
 
 message HookReq {

--- a/src/broker_auth/service.rs
+++ b/src/broker_auth/service.rs
@@ -329,7 +329,7 @@ fn action_name(action: i32) -> Option<&'static str> {
     match Action::try_from(action) {
         Ok(Action::Publish) => Some("publish"),
         Ok(Action::Subscribe) => Some("subscribe"),
-        Ok(Action::None) | Err(_) => None,
+        Ok(Action::Unspecified) | Err(_) => None,
     }
 }
 
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn unset_and_unknown_actions_are_rejected() {
-        assert_eq!(action_name(Action::None as i32), None);
+        assert_eq!(action_name(Action::Unspecified as i32), None);
         assert_eq!(action_name(99), None);
     }
 

--- a/tests/m29_broker_auth_callout.rs
+++ b/tests/m29_broker_auth_callout.rs
@@ -398,9 +398,13 @@ async fn every_rejection_is_a_verdict_not_an_rpc_error() {
         .into_inner();
     assert!(!unauthenticated.authorized);
 
-    // `Action::None` is the proto's unset value.
+    // `Action::Unspecified` is the proto's unset value.
     let no_action = client
-        .authorize(authz(&device_id.to_string(), &channel_alias, Action::None))
+        .authorize(authz(
+            &device_id.to_string(),
+            &channel_alias,
+            Action::Unspecified,
+        ))
         .await
         .expect("unset action must not be an rpc error")
         .into_inner();


### PR DESCRIPTION
FluxMQ renamed every enum value in broker.auth.v1 to satisfy buf's STANDARD lint rules: values carry their enum name as a prefix and zero values are suffixed _UNSPECIFIED. Field numbers are unchanged, so the wire format is identical and no running deployment is affected.

Re-vendors proto/broker/v1/auth.proto verbatim from absmach/fluxmq@main, which keeps check-vendored-proto.sh green.

prost strips the enum-name prefix, so Action::Publish and Action::Subscribe keep their names. Only the zero value moves: Action::None becomes Action::Unspecified. That is the more honest name — proto3 cannot distinguish an unset enum field from an explicit zero, so the variant has always meant "the sender said nothing".

<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?


## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->

## Have you included tests for your changes?


## Did you document any new/modified features?


### Notes

