### PR TITLE
NOISSUE - Readiness ignore inactive issuers

### DIFF
--- a/product-docs/development/pki/RELEASE-TESTING.md
+++ b/product-docs/development/pki/RELEASE-TESTING.md
@@ -40,7 +40,7 @@ This is a real integration smoke test. It does not replace the full gate.
 
 ### Full PKI integration test
 
-`scripts/pki-test.sh full` discovers and runs every `tests/m??_pki*.rs`
+`scripts/pki-test.sh full` discovers and runs every `tests/m<digits>_pki*.rs`
 integration binary, including the legacy-certificate migration and purge-after-
 revocation regressions. It requires a pre-provisioned disposable SoftHSM token
 and the independent EST client. The repository `Rust` workflow is the
@@ -91,7 +91,7 @@ production connection strings into a shell history, CI log, issue, or PR.
    ./scripts/pki-test.sh smoke
    ```
 
-6. Inspect the output. All seven named binaries must pass; a compile-only
+6. Inspect the output. All seven selected binaries must pass; a compile-only
    result is not a smoke-test pass.
 7. In GitHub, confirm `Rust` and `API Docs` are green on the current release-PR
    commit. Open the Rust job and confirm its `Run real PKI smoke test` step

--- a/scripts/pki-test.sh
+++ b/scripts/pki-test.sh
@@ -79,25 +79,39 @@ if [[ "$mode" == "full" ]]; then
   }
 fi
 
-smoke_tests=(
-  m30_pki_ca_provisioning
-  m32_pki_csr_issuance
-  m35_pki_revocation
-  m36_pki_issuer_crls
-  m37_pki_issuer_ocsp
-  m38_pki_runtime_resolver_v2
-  m41_pki_est
+smoke_test_suffixes=(
+  pki_ca_provisioning
+  pki_csr_issuance
+  pki_revocation
+  pki_issuer_crls
+  pki_issuer_ocsp
+  pki_runtime_resolver_v2
+  pki_est
 )
 
 full_tests=()
-for test_path in tests/m[0-9][0-9]_pki*.rs; do
-  test -e "$test_path" || continue
-  full_tests+=("$(basename "$test_path" .rs)")
+for test_path in tests/m*_pki*.rs; do
+  test_name="$(basename "$test_path" .rs)"
+  [[ "$test_name" =~ ^m[0-9]+_pki.*$ ]] || continue
+  full_tests+=("$test_name")
 done
 test "${#full_tests[@]}" -gt 0 || {
   echo "No PKI integration test binaries found under tests/" >&2
   exit 1
 }
+
+smoke_tests=()
+for suffix in "${smoke_test_suffixes[@]}"; do
+  matches=()
+  for test_name in "${full_tests[@]}"; do
+    [[ "$test_name" =~ ^m[0-9]+_${suffix}$ ]] && matches+=("$test_name")
+  done
+  if [[ "${#matches[@]}" -ne 1 ]]; then
+    echo "Expected exactly one PKI smoke test for $suffix, found ${#matches[@]}" >&2
+    exit 1
+  fi
+  smoke_tests+=("${matches[0]}")
+done
 
 reset_database() {
   psql "$PKI_TEST_MAINT_URL" -v ON_ERROR_STOP=1 \

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -312,27 +312,6 @@ pub async fn observe_error(
     }
 }
 
-/// Emit the structured error observation without writing to either database
-/// channel. This is reserved for failures that occur before authentication on
-/// public endpoints, where allowing anonymous traffic to create durable rows
-/// would turn observability into a write-amplification path.
-pub fn observe_error_log_only(meta: &AuditMeta<'_>, details: &Value, err: &crate::error::AppError) {
-    let outcome = err.audit_outcome();
-    let mut merged = details.clone();
-    if let Value::Object(ref mut map) = merged {
-        map.insert("error".to_string(), Value::String(err.to_string()));
-    }
-    log_audit_event(&AuditEvent {
-        actor_entity_id: meta.actor_entity_id,
-        tenant_id: meta.tenant_id,
-        target_kind: Some(meta.target_kind),
-        target_id: meta.target_id,
-        event: meta.event,
-        outcome,
-        details: merged,
-    });
-}
-
 async fn insert_audit_log<'e, E>(
     executor: E,
     event: &AuditEvent<'_>,

--- a/src/certs/authority/key_provider.rs
+++ b/src/certs/authority/key_provider.rs
@@ -26,7 +26,7 @@ use crate::{
 use super::{repo, AuthorityKeyBackend, AuthorityRecord};
 
 mod pkcs11;
-pub(crate) use pkcs11::circuit_is_open as pkcs11_circuit_is_open;
+pub(crate) use pkcs11::circuit_state as pkcs11_circuit_state;
 pub use pkcs11::{Pkcs11AuthorityKey, Pkcs11KeyProvider};
 
 const PROVIDER_NAME: &str = "encrypted_database";

--- a/src/certs/authority/key_provider/pkcs11.rs
+++ b/src/certs/authority/key_provider/pkcs11.rs
@@ -45,19 +45,17 @@ fn runtime_key(config: &PkiPkcs11Config) -> String {
     format!("{}\0{}", config.module_path, config.token_label)
 }
 
-/// Return the shared runtime circuit state without creating a provider,
-/// opening a PKCS#11 session, or copying the configured PIN. Readiness uses
-/// this to report a known-open signer circuit while remaining probe-safe.
-pub(crate) fn circuit_is_open(config: &PkiPkcs11Config) -> bool {
-    let Some(runtimes) = RUNTIMES.get() else {
-        return false;
-    };
+/// Return the shared runtime circuit state without creating a provider or
+/// opening a PKCS#11 session. `None` distinguishes a missing startup-validated
+/// runtime from a known-closed circuit so readiness fails closed.
+pub(crate) fn circuit_state(config: &PkiPkcs11Config) -> Option<bool> {
+    let runtimes = RUNTIMES.get()?;
     let runtimes = runtimes
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     runtimes
         .get(&runtime_key(config))
-        .is_some_and(|runtime| runtime.circuit_open(Duration::from_secs(config.circuit_reset_secs)))
+        .map(|runtime| runtime.circuit_open(Duration::from_secs(config.circuit_reset_secs)))
 }
 
 #[derive(Clone)]
@@ -887,6 +885,15 @@ mod tests {
             circuit_failure_threshold: 10,
             circuit_reset_secs: 60,
         }
+    }
+
+    #[test]
+    fn circuit_state_distinguishes_an_uninitialized_runtime() {
+        let config = executor_config("readiness-runtime-state");
+        assert_eq!(circuit_state(&config), None);
+
+        let _provider = Pkcs11KeyProvider::new(config.clone());
+        assert_eq!(circuit_state(&config), Some(false));
     }
 
     #[test]

--- a/src/certs/authority/repo.rs
+++ b/src/certs/authority/repo.rs
@@ -31,7 +31,7 @@ pub struct EncryptedKeyRequirement {
 
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub struct LeafIssuerReadiness {
-    pub configured_count: i64,
+    pub active_count: i64,
     pub active_backends: Vec<AuthorityKeyBackend>,
 }
 
@@ -214,14 +214,14 @@ where
     fetch_active_leaf_issuer_for_scope(executor, Some(tenant_id)).await
 }
 
-/// Return the configured issuer count and the key backends used by authorities
-/// that can issue leaves now. Readiness uses this single non-secret snapshot to
-/// distinguish an unused PKI deployment from one whose configured issuers are
-/// all ineligible, while avoiding a second query and a cross-query race.
+/// Return the active issuer count and the key backends used by authorities that
+/// can issue leaves now. Readiness ignores provisioning and historical rows,
+/// while an active-but-disabled or out-of-window issuer remains an error. The
+/// single non-secret snapshot avoids both a second query and a cross-query race.
 pub async fn leaf_issuer_readiness(pool: &PgPool) -> Result<LeafIssuerReadiness, AppError> {
     sqlx::query_as(
         r#"
-        SELECT COUNT(*) AS configured_count,
+        SELECT COUNT(*) FILTER (WHERE status = 'active') AS active_count,
                COALESCE(
                    ARRAY_AGG(DISTINCT key_backend ORDER BY key_backend)
                        FILTER (

--- a/src/certs/enrollment/mod.rs
+++ b/src/certs/enrollment/mod.rs
@@ -12,15 +12,13 @@ pub mod tls;
 
 fn observe_missing_peer(transport: &'static str, error: &crate::error::AppError) {
     crate::metrics::record_pki_enrollment_peer_rejection(transport);
-    crate::audit::observe_error_log_only(
-        &crate::audit::AuditMeta {
-            actor_entity_id: None,
-            tenant_id: None,
-            target_kind: "credential",
-            target_id: None,
-            event: "certificate.reenroll",
-        },
-        &serde_json::json!({"mode": "reenroll", "transport": transport}),
-        error,
+    tracing::debug!(
+        audit.event = "certificate.reenroll",
+        audit.outcome = "deny",
+        audit.target_kind = "credential",
+        enrollment.mode = "reenroll",
+        enrollment.transport = transport,
+        error = %error,
+        "anonymous certificate re-enrollment rejected"
     );
 }

--- a/src/certs/pki_core.rs
+++ b/src/certs/pki_core.rs
@@ -12,6 +12,7 @@ use std::{
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
+use p256::ecdsa::{signature::Verifier, Signature as P256Signature, VerifyingKey};
 use rcgen::{
     CertificateParams, CertificateRevocationListParams, CertificateSigningRequestParams,
     CrlDistributionPoint, CustomExtension, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
@@ -35,8 +36,8 @@ use crate::{config::PkiCaKeyConfig, error::AppError};
 
 use super::authority::{
     key_provider::{
-        AuthorityKeyContext, AuthorityKeyProvider, AuthorityKeyProviderError, ManagedAuthorityKey,
-        ManagedAuthorityKeyProvider,
+        AuthorityKeyContext, AuthorityKeyProvider, AuthorityKeyProviderError,
+        AuthoritySignatureAlgorithm, ManagedAuthorityKey, ManagedAuthorityKeyProvider,
     },
     AuthorityKeyBackend, AuthorityRecord,
 };
@@ -50,11 +51,10 @@ const AIA_OID: &[u64] = &[1, 3, 6, 1, 5, 5, 7, 1, 1];
 const OCSP_ACCESS_METHOD_OID: &[u64] = &[1, 3, 6, 1, 5, 5, 7, 48, 1];
 const CA_ISSUERS_ACCESS_METHOD_OID: &[u64] = &[1, 3, 6, 1, 5, 5, 7, 48, 2];
 
-/// Authority-key ownership has to be established against the provider, but
-/// doing that before every signature turns a public-key comparison into an
-/// HSM login (or CA-key unwrap) on every issuance and artifact request. The
-/// certificate fingerprint is part of the cache value so replacing a
-/// certificate for an authority makes the next signing path verify again.
+/// Authority-key ownership is established against the provider on first use.
+/// The fingerprint cache avoids an extra HSM login or CA-key unwrap on every
+/// request; every signature is still verified against the certificate public
+/// key before it leaves this module, so backend key drift fails closed.
 static VERIFIED_MANAGED_AUTHORITY_KEYS: OnceLock<Mutex<HashMap<uuid::Uuid, String>>> =
     OnceLock::new();
 
@@ -92,13 +92,38 @@ impl SigningKey for PkiSigningKey {
                 provider,
                 context,
                 key,
-                ..
-            } => provider
-                .sign(*context, key, message)
-                .map(|signature| signature.bytes)
-                .map_err(|_| rcgen::Error::RemoteKeyError),
+                raw_public_key,
+            } => {
+                let signature = provider
+                    .sign(*context, key, message)
+                    .map_err(|_| rcgen::Error::RemoteKeyError)?;
+                match signature.algorithm {
+                    AuthoritySignatureAlgorithm::EcdsaP256Sha256 => {
+                        verify_managed_authority_signature(
+                            raw_public_key,
+                            message,
+                            &signature.bytes,
+                        )?;
+                    }
+                }
+                Ok(signature.bytes)
+            }
         }
     }
+}
+
+fn verify_managed_authority_signature(
+    raw_public_key: &[u8],
+    message: &[u8],
+    signature_der: &[u8],
+) -> Result<(), rcgen::Error> {
+    let verifying_key =
+        VerifyingKey::from_sec1_bytes(raw_public_key).map_err(|_| rcgen::Error::RemoteKeyError)?;
+    let signature =
+        P256Signature::from_der(signature_der).map_err(|_| rcgen::Error::RemoteKeyError)?;
+    verifying_key
+        .verify(message, &signature)
+        .map_err(|_| rcgen::Error::RemoteKeyError)
 }
 
 pub struct PkiIssuer {
@@ -1280,6 +1305,10 @@ fn core_encoding_error(error: rcgen::Error) -> AppError {
 mod tests {
     use super::*;
     use crate::certs::profile::{KeyAlgorithmRule, LeafBasicConstraints, SanPolicy};
+    use p256::{
+        ecdsa::{signature::Signer as _, SigningKey as P256SigningKey},
+        elliptic_curve::rand_core::OsRng,
+    };
 
     fn profile(ekus: Vec<ExtendedKeyUsage>) -> CertificateProfile {
         CertificateProfile {
@@ -1328,6 +1357,29 @@ mod tests {
         let mut requested = CertificateParams::default();
         requested.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
         assert!(validate_requested_extensions(&profile, &requested).is_err());
+    }
+
+    #[test]
+    fn managed_authority_signatures_are_checked_against_the_certificate_key() {
+        let expected_key = P256SigningKey::random(&mut OsRng);
+        let replacement_key = P256SigningKey::random(&mut OsRng);
+        let message = b"certificate bytes to sign";
+        let expected_signature: P256Signature = expected_key.sign(message);
+        let replacement_signature: P256Signature = replacement_key.sign(message);
+        let public_key = expected_key.verifying_key().to_encoded_point(false);
+
+        assert!(verify_managed_authority_signature(
+            public_key.as_bytes(),
+            message,
+            expected_signature.to_der().as_bytes(),
+        )
+        .is_ok());
+        assert!(verify_managed_authority_signature(
+            public_key.as_bytes(),
+            message,
+            replacement_signature.to_der().as_bytes(),
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1437,6 +1437,11 @@ fn broker_auth_from_env() -> Result<BrokerAuthConfig> {
 }
 
 fn enrollment_from_env() -> Result<EnrollmentConfig> {
+    if std::env::var_os("ATOM_PKI_ENROLLMENT_REQUEST_BODY_TIMEOUT_SECS").is_some() {
+        anyhow::bail!(
+            "ATOM_PKI_ENROLLMENT_REQUEST_BODY_TIMEOUT_SECS was renamed to ATOM_PKI_ENROLLMENT_REQUEST_TIMEOUT_SECS"
+        );
+    }
     let default = EnrollmentConfig::default();
     let enabled = env_bool_default("ATOM_PKI_ENROLLMENT_ENABLED", default.enabled);
     let cert_path = nonempty_env("ATOM_PKI_ENROLLMENT_TLS_CERT_PATH");
@@ -2043,6 +2048,21 @@ mod tests {
     }
 
     #[test]
+    fn renamed_enrollment_request_timeout_is_rejected() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_hardening_env();
+        let _db_guard = DatabaseUrlGuard::set();
+
+        std::env::set_var("ATOM_PKI_ENROLLMENT_REQUEST_BODY_TIMEOUT_SECS", "32");
+        let error = Config::from_env().expect_err("renamed timeout must fail fast");
+        assert!(error
+            .to_string()
+            .contains("was renamed to ATOM_PKI_ENROLLMENT_REQUEST_TIMEOUT_SECS"));
+
+        clear_hardening_env();
+    }
+
+    #[test]
     fn enrollment_ip_rate_limit_has_its_own_policy() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         clear_hardening_env();
@@ -2197,6 +2217,7 @@ mod tests {
             "ATOM_PKI_ENROLLMENT_TRUST_REFRESH_SECS",
             "ATOM_PKI_ENROLLMENT_TLS_HANDSHAKE_TIMEOUT_SECS",
             "ATOM_PKI_ENROLLMENT_HTTP_HEADER_TIMEOUT_SECS",
+            "ATOM_PKI_ENROLLMENT_REQUEST_BODY_TIMEOUT_SECS",
             "ATOM_PKI_ENROLLMENT_REQUEST_TIMEOUT_SECS",
             "ATOM_PKI_ENROLLMENT_CONNECTION_TIMEOUT_SECS",
             "ATOM_PKI_ENROLLMENT_SHUTDOWN_DRAIN_TIMEOUT_SECS",

--- a/src/health.rs
+++ b/src/health.rs
@@ -265,7 +265,7 @@ async fn certificate_issuer_check(state: &AppState) -> ComponentCheck {
                 .pki_ca_keys
                 .pkcs11
                 .as_ref()
-                .is_some_and(crate::certs::authority::key_provider::pkcs11_circuit_is_open),
+                .and_then(crate::certs::authority::key_provider::pkcs11_circuit_state),
         ),
         Err(error) => ComponentCheck {
             status: ComponentStatus::Error,
@@ -277,14 +277,9 @@ async fn certificate_issuer_check(state: &AppState) -> ComponentCheck {
 fn certificate_issuer_config_check(
     ca_keys: &PkiCaKeyConfig,
     backends: &[AuthorityKeyBackend],
-    pkcs11_circuit_open: bool,
+    pkcs11_circuit_open: Option<bool>,
 ) -> ComponentCheck {
-    if backends.is_empty() {
-        return ComponentCheck {
-            status: ComponentStatus::Disabled,
-            message: "no active certificate issuers".to_string(),
-        };
-    }
+    debug_assert!(!backends.is_empty());
 
     let uses_encrypted_database = backends.contains(&AuthorityKeyBackend::EncryptedDatabase);
     let uses_pkcs11 = backends.contains(&AuthorityKeyBackend::Pkcs11);
@@ -320,7 +315,13 @@ fn certificate_issuer_config_check(
             ),
         };
     }
-    if uses_pkcs11 && pkcs11_circuit_open {
+    if uses_pkcs11 && pkcs11_circuit_open.is_none() {
+        return ComponentCheck {
+            status: ComponentStatus::Error,
+            message: "an active PKCS#11 certificate issuer runtime is not initialized".to_string(),
+        };
+    }
+    if uses_pkcs11 && pkcs11_circuit_open == Some(true) {
         return ComponentCheck {
             status: ComponentStatus::Error,
             message: "an active PKCS#11 certificate issuer circuit is open".to_string(),
@@ -530,7 +531,7 @@ mod tests {
         let status = certificate_issuer_config_check(
             &config.pki_ca_keys,
             &[AuthorityKeyBackend::Pkcs11],
-            false,
+            Some(false),
         );
         assert!(matches!(status.status, ComponentStatus::Ok));
         assert!(status.message.contains("verified at startup"));
@@ -542,13 +543,37 @@ mod tests {
         let status = certificate_issuer_config_check(
             &config.pki_ca_keys,
             &[AuthorityKeyBackend::Pkcs11],
-            false,
+            None,
         );
         let ok = check(ComponentStatus::Ok);
 
         assert!(matches!(status.status, ComponentStatus::Error));
         assert!(status.message.contains("CA key provider is not configured"));
         assert!(!readiness_ok(&ok, &ok, &ok, &ok, &status));
+    }
+
+    #[test]
+    fn readiness_rejects_an_active_issuer_without_a_validated_pkcs11_runtime() {
+        let mut config = Config::for_tests();
+        config.pki_ca_keys.pkcs11 = Some(PkiPkcs11Config {
+            module_path: "/nonexistent/pkcs11-module.so".to_string(),
+            token_label: "missing-token".to_string(),
+            user_pin: SecretText::new("test-pin".to_string()).expect("PIN"),
+            operation_timeout_ms: 1,
+            mutation_hard_timeout_ms: 1,
+            max_retries: 0,
+            max_in_flight: 1,
+            circuit_failure_threshold: 1,
+            circuit_reset_secs: 1,
+        });
+
+        let status = certificate_issuer_config_check(
+            &config.pki_ca_keys,
+            &[AuthorityKeyBackend::Pkcs11],
+            None,
+        );
+        assert!(matches!(status.status, ComponentStatus::Error));
+        assert!(status.message.contains("runtime is not initialized"));
     }
 
     #[test]
@@ -569,7 +594,7 @@ mod tests {
         let status = certificate_issuer_config_check(
             &config.pki_ca_keys,
             &[AuthorityKeyBackend::Pkcs11],
-            true,
+            Some(true),
         );
         assert!(matches!(status.status, ComponentStatus::Error));
         assert!(status.message.contains("circuit is open"));

--- a/src/health.rs
+++ b/src/health.rs
@@ -248,9 +248,9 @@ async fn signing_keys_check(state: &AppState) -> (ComponentCheck, Option<Signing
 /// affect the HSM provider's circuit breaker.
 async fn certificate_issuer_check(state: &AppState) -> ComponentCheck {
     match authority_repo::leaf_issuer_readiness(&state.pool).await {
-        Ok(readiness) if readiness.configured_count == 0 => ComponentCheck {
+        Ok(readiness) if readiness.active_count == 0 => ComponentCheck {
             status: ComponentStatus::Disabled,
-            message: "no certificate issuers configured".to_string(),
+            message: "no active certificate issuers".to_string(),
         },
         Ok(readiness) if readiness.active_backends.is_empty() => ComponentCheck {
             status: ComponentStatus::Error,
@@ -501,8 +501,8 @@ mod tests {
             &ok,
             &check(ComponentStatus::Error),
         ));
-        // A deployment without PKI configured stays ready — the check
-        // reports Disabled and does not block.
+        // A deployment without an active PKI issuer stays ready — provisioning
+        // and historical issuer rows report Disabled and do not block.
         assert!(readiness_ok(
             &ok,
             &ok,

--- a/tests/m29_pki_authorities.rs
+++ b/tests/m29_pki_authorities.rs
@@ -90,6 +90,7 @@ async fn authorities_are_scope_safe_and_rotation_ready() {
 
     let root_id = Uuid::new_v4();
     let platform_id = Uuid::new_v4();
+    let historical_leaf_id = Uuid::new_v4();
     let platform_leaf_id = Uuid::new_v4();
     insert_authority(&pool, &TestAuthority::root(root_id))
         .await
@@ -102,10 +103,76 @@ async fn authorities_are_scope_safe_and_rotation_ready() {
     .unwrap();
     insert_authority(
         &pool,
-        &TestAuthority::platform_leaf(platform_leaf_id, root_id, 1, 3),
+        &TestAuthority::platform_leaf(historical_leaf_id, root_id, 1, 3),
     )
     .await
     .unwrap();
+
+    for status in [
+        "provisioning",
+        "pending_signature",
+        "failed",
+        "retiring",
+        "retired",
+        "revoked",
+        "expired",
+    ] {
+        sqlx::query(
+            r#"UPDATE pki_authorities
+               SET status = $2,
+                   issuance_enabled = false,
+                   csr_pem = 'test-pending-csr',
+                   failure_reason = $3
+               WHERE id = $1"#,
+        )
+        .bind(historical_leaf_id)
+        .bind(status)
+        .bind((status == "failed").then_some("test provisioning failure"))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let readiness = repo::leaf_issuer_readiness(&pool).await.unwrap();
+        assert_eq!(readiness.active_count, 0, "status {status}");
+        assert!(readiness.active_backends.is_empty(), "status {status}");
+    }
+
+    insert_authority(
+        &pool,
+        &TestAuthority::platform_leaf(platform_leaf_id, root_id, 2, 4),
+    )
+    .await
+    .unwrap();
+    let readiness = repo::leaf_issuer_readiness(&pool).await.unwrap();
+    assert_eq!(readiness.active_count, 1);
+    assert_eq!(readiness.active_backends, vec![AuthorityKeyBackend::Pkcs11]);
+
+    sqlx::query("UPDATE pki_authorities SET issuance_enabled = false WHERE id = $1")
+        .bind(platform_leaf_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let readiness = repo::leaf_issuer_readiness(&pool).await.unwrap();
+    assert_eq!(readiness.active_count, 1);
+    assert!(readiness.active_backends.is_empty());
+    sqlx::query("UPDATE pki_authorities SET issuance_enabled = true WHERE id = $1")
+        .bind(platform_leaf_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE pki_authorities SET not_after = now() - interval '1 second' WHERE id = $1")
+        .bind(platform_leaf_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let readiness = repo::leaf_issuer_readiness(&pool).await.unwrap();
+    assert_eq!(readiness.active_count, 1);
+    assert!(readiness.active_backends.is_empty());
+    sqlx::query("UPDATE pki_authorities SET not_after = now() + interval '365 days' WHERE id = $1")
+        .bind(platform_leaf_id)
+        .execute(&pool)
+        .await
+        .unwrap();
 
     assert!(authority::validate_authority_shape(AuthorityKind::Root, None, None).is_ok());
     assert!(authority::validate_authority_shape(
@@ -128,7 +195,7 @@ async fn authorities_are_scope_safe_and_rotation_ready() {
     insert_authority(&pool, &tenant_b_v1).await.unwrap();
 
     let readiness = repo::leaf_issuer_readiness(&pool).await.unwrap();
-    assert_eq!(readiness.configured_count, 3);
+    assert_eq!(readiness.active_count, 3);
     assert_eq!(readiness.active_backends, vec![AuthorityKeyBackend::Pkcs11]);
 
     let active_a = repo::active_leaf_issuer_for_scope(&pool, Some(tenant_a))
@@ -231,7 +298,7 @@ async fn authorities_are_scope_safe_and_rotation_ready() {
     let invalid_parent_error = insert_authority(&pool, &invalid_parent).await.unwrap_err();
     assert!(is_database_code(&invalid_parent_error, "23514"));
 
-    let duplicate_global_issuer = TestAuthority::platform_leaf(Uuid::new_v4(), root_id, 2, 32);
+    let duplicate_global_issuer = TestAuthority::platform_leaf(Uuid::new_v4(), root_id, 3, 32);
     let duplicate_global_error = insert_authority(&pool, &duplicate_global_issuer)
         .await
         .unwrap_err();

--- a/tests/m39_pki_enrollment.rs
+++ b/tests/m39_pki_enrollment.rs
@@ -281,9 +281,20 @@ async fn native_enrollment_enforces_the_pr014_contract() {
     .await
     .unwrap();
     assert_eq!(injected.status, 401, "{}", injected.body);
-    // Missing peer certificates are rejected by the extractor before an
-    // authenticated handler exists, so this security-sensitive failure is
-    // intentionally log-only and does not create an outbox row.
+    // Missing-peer failures happen before authentication on this public
+    // endpoint. They are observable through metrics and tracing, but must not
+    // let anonymous traffic amplify durable outbox writes.
+    let native_denials: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*)
+           FROM event_outbox
+           WHERE event = 'certificate.reenroll'
+             AND payload->>'outcome' = 'deny'
+             AND payload->'details'->>'transport' = 'native'"#,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(native_denials, 0);
 
     // A certificate asserted in the TLS handshake but signed outside Atom's
     // trust bundle is rejected during the in-process handshake.


### PR DESCRIPTION
# What type of PR is this?

Bug fix and PKI hardening.

## What does this do?

- Makes readiness consider only active certificate issuers.
- Reports PKI as disabled when no active issuer exists, while failing closed when an active issuer is not currently eligible to issue.
- Includes PKCS#11 runtime and circuit-breaker state in readiness without opening new HSM sessions.
- Verifies managed-authority signatures against the certificate public key, detecting stale ownership caches or backend key drift before issuing certificates.
- Keeps anonymous missing-client-certificate reenrollment failures observable through metrics and tracing without allowing durable outbox-write amplification.
- Improves PKI test discovery so milestone numbers are not hard-coded.
- Rejects the obsolete `ATOM_PKI_ENROLLMENT_REQUEST_BODY_TIMEOUT_SECS` typo with guidance to use `ATOM_PKI_ENROLLMENT_REQUEST_TIMEOUT_SECS`.

## Which issue(s) does this PR fix/relate to?

NOISSUE.

## Have you included tests for your changes?

Yes.

- Expanded authority-readiness coverage for inactive and ineligible issuers.
- Added signature-mismatch coverage for managed authority keys.
- Updated native reenrollment coverage to assert that anonymous denials do not create durable outbox events.
- Updated the PKI test runner and smoke-test discovery.
- `cargo fmt --check` passes; GitHub CI runs the full Rust and API documentation suites.

## Did you document any new/modified features?

Yes. The PKI release-testing documentation was updated to describe the readiness and test-discovery behavior.

### Notes

The branch is rebased onto the current `main`.