### PR TITLE
Enforce unique user emails

### DIFF
--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -275,7 +275,9 @@ CREATE TABLE entity_emails (
 
 -- Partial unique index so an email frees on soft delete (re-registration / OAuth
 -- re-onboarding with the same address). Mirrors the name/alias partial indexes.
-CREATE UNIQUE INDEX idx_entity_emails_email ON entity_emails(email) WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX idx_entity_emails_email
+    ON entity_emails (lower(email))
+    WHERE deleted_at IS NULL;
 CREATE INDEX idx_entity_emails_entity ON entity_emails(entity_id);
 CREATE INDEX idx_entity_emails_verified ON entity_emails(verified_at);
 

--- a/migrations/025_case_insensitive_entity_email_unique.sql
+++ b/migrations/025_case_insensitive_entity_email_unique.sql
@@ -1,0 +1,9 @@
+-- Email identity is global and case-insensitive. All login and invitation
+-- lookups already compare normalized/lower-case email addresses, so the backing
+-- uniqueness invariant must use the same key.
+
+DROP INDEX IF EXISTS idx_entity_emails_email;
+
+CREATE UNIQUE INDEX idx_entity_emails_email
+    ON entity_emails (lower(email))
+    WHERE deleted_at IS NULL;

--- a/migrations/025_case_insensitive_entity_email_unique.sql
+++ b/migrations/025_case_insensitive_entity_email_unique.sql
@@ -2,6 +2,19 @@
 -- lookups already compare normalized/lower-case email addresses, so the backing
 -- uniqueness invariant must use the same key.
 
+-- Older admin-created human entities predate the canonical email table. Bring
+-- valid email attributes into that table before enforcing the new invariant.
+INSERT INTO entity_emails (entity_id, email, deleted_at)
+SELECT e.id,
+       lower(trim(e.attributes->>'email')),
+       e.deleted_at
+FROM entities e
+LEFT JOIN entity_emails ee ON ee.entity_id = e.id
+WHERE e.kind = 'human'
+  AND ee.id IS NULL
+  AND e.attributes->>'email' IS NOT NULL
+  AND trim(e.attributes->>'email') ~ '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$';
+
 DROP INDEX IF EXISTS idx_entity_emails_email;
 
 CREATE UNIQUE INDEX idx_entity_emails_email

--- a/migrations/025_case_insensitive_entity_email_unique.sql
+++ b/migrations/025_case_insensitive_entity_email_unique.sql
@@ -2,6 +2,8 @@
 -- lookups already compare normalized/lower-case email addresses, so the backing
 -- uniqueness invariant must use the same key.
 
+DROP INDEX IF EXISTS idx_entity_emails_email;
+
 -- Older admin-created human entities predate the canonical email table. Bring
 -- valid email attributes into that table before enforcing the new invariant.
 INSERT INTO entity_emails (entity_id, email, deleted_at)
@@ -15,7 +17,22 @@ WHERE e.kind = 'human'
   AND e.attributes->>'email' IS NOT NULL
   AND trim(e.attributes->>'email') ~ '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$';
 
-DROP INDEX IF EXISTS idx_entity_emails_email;
+-- Keep the oldest verified canonical row for duplicate legacy addresses and
+-- release the others before creating the case-insensitive unique index.
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY lower(email)
+               ORDER BY verified_at DESC NULLS LAST, created_at, id
+           ) AS row_number
+    FROM entity_emails
+    WHERE deleted_at IS NULL
+)
+UPDATE entity_emails ee
+SET deleted_at = now(), updated_at = now()
+FROM ranked
+WHERE ee.id = ranked.id
+  AND ranked.row_number > 1;
 
 CREATE UNIQUE INDEX idx_entity_emails_email
     ON entity_emails (lower(email))

--- a/src/error.rs
+++ b/src/error.rs
@@ -204,6 +204,12 @@ pub fn restore_conflict(e: sqlx::Error) -> AppError {
              deleted; clear or change that entity's externalId before restoring",
         );
     }
+    if unique_violation_constraint(&e) == Some(ENTITY_EMAIL_INDEX) {
+        return AppError::conflict(
+            "another live entity took this entity's email while it was deleted; clear or change \
+             that entity's email before restoring",
+        );
+    }
     if is_unique_violation(&e) {
         return AppError::conflict(
             "a live record already uses this name; rename the conflicting record before restoring",

--- a/src/error.rs
+++ b/src/error.rs
@@ -174,6 +174,7 @@ pub fn db_err(e: sqlx::Error) -> AppError {
 /// the violated constraint, which is what lets a 23505 be attributed to
 /// `external_id` rather than to `name` or `alias`.
 const ENTITY_EXTERNAL_ID_INDEX: &str = "idx_entities_external_id";
+const ENTITY_EMAIL_INDEX: &str = "idx_entity_emails_email";
 
 fn is_unique_violation(e: &sqlx::Error) -> bool {
     matches!(e, sqlx::Error::Database(db) if db.code().as_deref() == Some("23505"))
@@ -220,6 +221,9 @@ pub fn restore_conflict(e: sqlx::Error) -> AppError {
 pub fn entity_write_conflict(e: sqlx::Error) -> AppError {
     if unique_violation_constraint(&e) == Some(ENTITY_EXTERNAL_ID_INDEX) {
         return AppError::conflict("externalId is already used by another entity in this tenant");
+    }
+    if unique_violation_constraint(&e) == Some(ENTITY_EMAIL_INDEX) {
+        return AppError::conflict("Email address already taken");
     }
     db_err(e)
 }

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -375,14 +375,6 @@ pub async fn update_entity_with_audit(
     audit_details: Value,
 ) -> Result<Entity, AppError> {
     ensure_not_config_managed_entity(pool, id).await?;
-    let sync_email = req
-        .kind
-        .as_ref()
-        .is_some_and(|kind| kind != &EntityKind::Human)
-        || req
-            .attributes
-            .as_ref()
-            .is_some_and(|attributes| attributes.get("email").is_some());
     let attributes = req.attributes.clone().map(normalize_attributes);
     if let Some(attrs) = attributes.as_ref() {
         reject_parent_group_attribute(attrs)?;
@@ -416,8 +408,8 @@ pub async fn update_entity_with_audit(
     for tenant_id in tenant_ids {
         crate::tenants::repo::lock_active_tenant(&mut tx, tenant_id).await?;
     }
-    let locked: Option<Uuid> = sqlx::query_scalar(
-        r#"SELECT id FROM entities
+    let locked: Option<EntityKind> = sqlx::query_scalar(
+        r#"SELECT kind FROM entities
            WHERE id = $1
              AND tenant_id IS NOT DISTINCT FROM $2
              AND deleted_at IS NULL
@@ -428,9 +420,14 @@ pub async fn update_entity_with_audit(
     .fetch_optional(&mut *tx)
     .await
     .map_err(db_err)?;
-    if locked.is_none() {
+    let Some(current_kind) = locked else {
         return Err(AppError::not_found(format!("entity {id} not found")));
-    }
+    };
+    let sync_email = req.kind.as_ref().is_some_and(|kind| kind != &current_kind)
+        || req
+            .attributes
+            .as_ref()
+            .is_some_and(|attributes| attributes.get("email").is_some());
     let entity = sqlx::query_as::<_, Entity>(
         r#"UPDATE entities
            SET name               = COALESCE($2, name),
@@ -928,34 +925,6 @@ async fn sync_entity_email_from_attrs_in_tx(
     Ok(())
 }
 
-async fn restore_entity_email_in_tx(
-    tx: &mut Transaction<'_, Postgres>,
-    entity_id: Uuid,
-    kind: &EntityKind,
-    attributes: &Value,
-) -> Result<(), AppError> {
-    if kind != &EntityKind::Human {
-        deactivate_entity_email_in_tx(tx, entity_id).await?;
-        return Ok(());
-    }
-
-    let restored = sqlx::query(
-        "UPDATE entity_emails
-         SET deleted_at = NULL, updated_at = now()
-         WHERE entity_id = $1
-         RETURNING id",
-    )
-    .bind(entity_id)
-    .fetch_optional(&mut **tx)
-    .await
-    .map_err(db_err)?;
-
-    if restored.is_none() {
-        sync_entity_email_from_attrs_in_tx(tx, entity_id, kind, attributes).await?;
-    }
-    Ok(())
-}
-
 async fn deactivate_entity_email_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     entity_id: Uuid,
@@ -1212,14 +1181,6 @@ pub async fn restore_entity_with_audit(
     .execute(&mut *tx)
     .await
     .map_err(restore_conflict)?;
-
-    let (kind, attributes): (EntityKind, Value) =
-        sqlx::query_as("SELECT kind, attributes FROM entities WHERE id = $1")
-            .bind(id)
-            .fetch_one(&mut *tx)
-            .await
-            .map_err(restore_conflict)?;
-    restore_entity_email_in_tx(&mut tx, id, &kind, &attributes).await?;
 
     let event = crate::audit::AuditEvent {
         actor_entity_id: actor_id,

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -174,6 +174,7 @@ pub async fn create_entity_with_audit(
 
     if is_human {
         add_authenticated_user_membership_in_tx(&mut tx, entity.id).await?;
+        upsert_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.attributes).await?;
     }
 
     let event = crate::audit::AuditEvent {
@@ -456,6 +457,10 @@ pub async fn update_entity_with_audit(
         sqlx::Error::RowNotFound => AppError::not_found(format!("entity {id} not found")),
         other => entity_write_conflict(other),
     })?;
+
+    if entity.kind == EntityKind::Human {
+        upsert_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.attributes).await?;
+    }
 
     // The caller builds `audit_details` before the write, so it cannot know the
     // resulting identifier. Consumers denormalize `external_id` onto their own
@@ -841,6 +846,49 @@ fn normalize_attributes(attributes: Value) -> Value {
     } else {
         attributes
     }
+}
+
+async fn upsert_entity_email_from_attrs_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_id: Uuid,
+    attributes: &Value,
+) -> Result<(), AppError> {
+    let Some(email) = normalized_email_attr(attributes) else {
+        return Ok(());
+    };
+
+    sqlx::query(
+        r#"INSERT INTO entity_emails (id, entity_id, email)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (entity_id)
+           DO UPDATE SET email = EXCLUDED.email,
+                         deleted_at = NULL,
+                         updated_at = now()"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(entity_id)
+    .bind(email)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    Ok(())
+}
+
+fn normalized_email_attr(attributes: &Value) -> Option<String> {
+    let email = attributes
+        .get("email")?
+        .as_str()?
+        .trim()
+        .to_ascii_lowercase();
+    let (local, domain) = email.split_once('@')?;
+    if local.is_empty()
+        || domain.is_empty()
+        || !domain.contains('.')
+        || email.chars().any(char::is_whitespace)
+    {
+        return None;
+    }
+    Some(email)
 }
 
 fn entity_kind_from_profile(kind: &str) -> Result<EntityKind, AppError> {

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -375,6 +375,7 @@ pub async fn update_entity_with_audit(
     audit_details: Value,
 ) -> Result<Entity, AppError> {
     ensure_not_config_managed_entity(pool, id).await?;
+    let sync_email = req.kind.is_some() || req.attributes.is_some();
     let attributes = req.attributes.clone().map(normalize_attributes);
     if let Some(attrs) = attributes.as_ref() {
         reject_parent_group_attribute(attrs)?;
@@ -459,8 +460,10 @@ pub async fn update_entity_with_audit(
         other => entity_write_conflict(other),
     })?;
 
-    sync_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.kind, &entity.attributes)
-        .await?;
+    if sync_email {
+        sync_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.kind, &entity.attributes)
+            .await?;
+    }
 
     // The caller builds `audit_details` before the write, so it cannot know the
     // resulting identifier. Consumers denormalize `external_id` onto their own
@@ -858,24 +861,46 @@ async fn sync_entity_email_from_attrs_in_tx(
         .then(|| normalized_email_attr(attributes))
         .flatten()
     else {
-        sqlx::query(
-            "UPDATE entity_emails SET deleted_at = now(), updated_at = now()
-             WHERE entity_id = $1 AND deleted_at IS NULL",
-        )
-        .bind(entity_id)
-        .execute(&mut **tx)
-        .await
-        .map_err(db_err)?;
+        deactivate_entity_email_in_tx(tx, entity_id).await?;
         return Ok(());
     };
 
+    let existing: Option<(Uuid, String)> =
+        sqlx::query_as("SELECT id, email FROM entity_emails WHERE entity_id = $1 FOR UPDATE")
+            .bind(entity_id)
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(db_err)?;
+
+    if let Some((email_id, current_email)) = existing {
+        if current_email != email {
+            invalidate_email_tokens_in_tx(tx, email_id).await?;
+            sqlx::query(
+                "UPDATE entity_emails
+                 SET email = $2, verified_at = NULL, deleted_at = NULL, updated_at = now()
+                 WHERE id = $1",
+            )
+            .bind(email_id)
+            .bind(email)
+            .execute(&mut **tx)
+            .await
+            .map_err(entity_write_conflict)?;
+        } else {
+            sqlx::query(
+                "UPDATE entity_emails SET deleted_at = NULL, updated_at = now()
+                 WHERE id = $1",
+            )
+            .bind(email_id)
+            .execute(&mut **tx)
+            .await
+            .map_err(db_err)?;
+        }
+        return Ok(());
+    }
+
     sqlx::query(
         r#"INSERT INTO entity_emails (id, entity_id, email)
-           VALUES ($1, $2, $3)
-           ON CONFLICT (entity_id)
-           DO UPDATE SET email = EXCLUDED.email,
-                         deleted_at = NULL,
-                         updated_at = now()"#,
+           VALUES ($1, $2, $3)"#,
     )
     .bind(Uuid::new_v4())
     .bind(entity_id)
@@ -883,6 +908,64 @@ async fn sync_entity_email_from_attrs_in_tx(
     .execute(&mut **tx)
     .await
     .map_err(entity_write_conflict)?;
+    Ok(())
+}
+
+async fn deactivate_entity_email_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_id: Uuid,
+) -> Result<(), AppError> {
+    sqlx::query(
+        "UPDATE email_verification_tokens
+         SET consumed_at = now()
+         WHERE email_id IN (SELECT id FROM entity_emails WHERE entity_id = $1)
+           AND consumed_at IS NULL",
+    )
+    .bind(entity_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    sqlx::query(
+        "UPDATE password_reset_tokens
+         SET consumed_at = now()
+         WHERE email_id IN (SELECT id FROM entity_emails WHERE entity_id = $1)
+           AND consumed_at IS NULL",
+    )
+    .bind(entity_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    sqlx::query(
+        "UPDATE entity_emails SET deleted_at = now(), updated_at = now()
+         WHERE entity_id = $1 AND deleted_at IS NULL",
+    )
+    .bind(entity_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    Ok(())
+}
+
+async fn invalidate_email_tokens_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    email_id: Uuid,
+) -> Result<(), AppError> {
+    sqlx::query(
+        "UPDATE email_verification_tokens SET consumed_at = now()
+         WHERE email_id = $1 AND consumed_at IS NULL",
+    )
+    .bind(email_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
+    sqlx::query(
+        "UPDATE password_reset_tokens SET consumed_at = now()
+         WHERE email_id = $1 AND consumed_at IS NULL",
+    )
+    .bind(email_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(db_err)?;
     Ok(())
 }
 

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -375,7 +375,14 @@ pub async fn update_entity_with_audit(
     audit_details: Value,
 ) -> Result<Entity, AppError> {
     ensure_not_config_managed_entity(pool, id).await?;
-    let sync_email = req.kind.is_some() || req.attributes.is_some();
+    let sync_email = req
+        .kind
+        .as_ref()
+        .is_some_and(|kind| kind != &EntityKind::Human)
+        || req
+            .attributes
+            .as_ref()
+            .is_some_and(|attributes| attributes.get("email").is_some());
     let attributes = req.attributes.clone().map(normalize_attributes);
     if let Some(attrs) = attributes.as_ref() {
         reject_parent_group_attribute(attrs)?;
@@ -881,10 +888,20 @@ async fn sync_entity_email_from_attrs_in_tx(
                  WHERE id = $1",
             )
             .bind(email_id)
-            .bind(email)
+            .bind(&email)
             .execute(&mut **tx)
             .await
             .map_err(entity_write_conflict)?;
+            sqlx::query(
+                "UPDATE credentials
+                 SET identifier = $2
+                 WHERE entity_id = $1 AND kind = 'password' AND status = 'active'",
+            )
+            .bind(entity_id)
+            .bind(&email)
+            .execute(&mut **tx)
+            .await
+            .map_err(db_err)?;
         } else {
             sqlx::query(
                 "UPDATE entity_emails SET deleted_at = NULL, updated_at = now()
@@ -908,6 +925,34 @@ async fn sync_entity_email_from_attrs_in_tx(
     .execute(&mut **tx)
     .await
     .map_err(entity_write_conflict)?;
+    Ok(())
+}
+
+async fn restore_entity_email_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_id: Uuid,
+    kind: &EntityKind,
+    attributes: &Value,
+) -> Result<(), AppError> {
+    if kind != &EntityKind::Human {
+        deactivate_entity_email_in_tx(tx, entity_id).await?;
+        return Ok(());
+    }
+
+    let restored = sqlx::query(
+        "UPDATE entity_emails
+         SET deleted_at = NULL, updated_at = now()
+         WHERE entity_id = $1
+         RETURNING id",
+    )
+    .bind(entity_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(db_err)?;
+
+    if restored.is_none() {
+        sync_entity_email_from_attrs_in_tx(tx, entity_id, kind, attributes).await?;
+    }
     Ok(())
 }
 
@@ -1174,7 +1219,7 @@ pub async fn restore_entity_with_audit(
             .fetch_one(&mut *tx)
             .await
             .map_err(restore_conflict)?;
-    sync_entity_email_from_attrs_in_tx(&mut tx, id, &kind, &attributes).await?;
+    restore_entity_email_in_tx(&mut tx, id, &kind, &attributes).await?;
 
     let event = crate::audit::AuditEvent {
         actor_entity_id: actor_id,

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -1095,7 +1095,8 @@ pub async fn delete_entity_with_audit(
     .map_err(db_err)?;
 
     sqlx::query(
-        "UPDATE entity_emails SET deleted_at = now(), updated_at = now()
+        "UPDATE entity_emails
+         SET deleted_at = (SELECT deleted_at FROM entities WHERE id = $1), updated_at = now()
          WHERE entity_id = $1 AND deleted_at IS NULL",
     )
     .bind(id)
@@ -1148,8 +1149,8 @@ pub async fn restore_entity_with_audit(
     let _ = restored_by;
     let mut tx = pool.begin().await.map_err(db_err)?;
 
-    let tenant_info: Option<(Option<Uuid>, bool)> = sqlx::query_as(
-        "SELECT e.tenant_id, (t.deleted_at IS NOT NULL)
+    let tenant_info: Option<(Option<Uuid>, bool, DateTime<Utc>)> = sqlx::query_as(
+        "SELECT e.tenant_id, (t.deleted_at IS NOT NULL), e.deleted_at
          FROM entities e
          LEFT JOIN tenants t ON t.id = e.tenant_id
          WHERE e.id = $1 AND e.deleted_at IS NOT NULL",
@@ -1158,19 +1159,30 @@ pub async fn restore_entity_with_audit(
     .fetch_optional(&mut *tx)
     .await
     .map_err(db_err)?;
-    let (tenant_id, _is_tenant_deleted) = match tenant_info {
+    let (tenant_id, _is_tenant_deleted, entity_deleted_at) = match tenant_info {
         None => {
             return Err(AppError::not_found(format!(
                 "no soft-deleted entity {id} to restore"
             )))
         }
-        Some((_, true)) => {
+        Some((_, true, _)) => {
             return Err(AppError::conflict(
                 "the entity's tenant is soft-deleted; restore the tenant first",
             ))
         }
-        Some((t_id, false)) => (t_id, false),
+        Some((t_id, false, deleted_at)) => (t_id, false, deleted_at),
     };
+
+    sqlx::query(
+        "UPDATE entity_emails
+         SET deleted_at = NULL, updated_at = now()
+         WHERE entity_id = $1 AND deleted_at = $2",
+    )
+    .bind(id)
+    .bind(entity_deleted_at)
+    .execute(&mut *tx)
+    .await
+    .map_err(restore_conflict)?;
 
     sqlx::query(
         "UPDATE entities

--- a/src/identity/repo.rs
+++ b/src/identity/repo.rs
@@ -174,8 +174,9 @@ pub async fn create_entity_with_audit(
 
     if is_human {
         add_authenticated_user_membership_in_tx(&mut tx, entity.id).await?;
-        upsert_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.attributes).await?;
     }
+    sync_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.kind, &entity.attributes)
+        .await?;
 
     let event = crate::audit::AuditEvent {
         actor_entity_id: actor_id,
@@ -458,9 +459,8 @@ pub async fn update_entity_with_audit(
         other => entity_write_conflict(other),
     })?;
 
-    if entity.kind == EntityKind::Human {
-        upsert_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.attributes).await?;
-    }
+    sync_entity_email_from_attrs_in_tx(&mut tx, entity.id, &entity.kind, &entity.attributes)
+        .await?;
 
     // The caller builds `audit_details` before the write, so it cannot know the
     // resulting identifier. Consumers denormalize `external_id` onto their own
@@ -848,12 +848,24 @@ fn normalize_attributes(attributes: Value) -> Value {
     }
 }
 
-async fn upsert_entity_email_from_attrs_in_tx(
+async fn sync_entity_email_from_attrs_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     entity_id: Uuid,
+    kind: &EntityKind,
     attributes: &Value,
 ) -> Result<(), AppError> {
-    let Some(email) = normalized_email_attr(attributes) else {
+    let Some(email) = (kind == &EntityKind::Human)
+        .then(|| normalized_email_attr(attributes))
+        .flatten()
+    else {
+        sqlx::query(
+            "UPDATE entity_emails SET deleted_at = now(), updated_at = now()
+             WHERE entity_id = $1 AND deleted_at IS NULL",
+        )
+        .bind(entity_id)
+        .execute(&mut **tx)
+        .await
+        .map_err(db_err)?;
         return Ok(());
     };
 
@@ -870,7 +882,7 @@ async fn upsert_entity_email_from_attrs_in_tx(
     .bind(email)
     .execute(&mut **tx)
     .await
-    .map_err(db_err)?;
+    .map_err(entity_write_conflict)?;
     Ok(())
 }
 
@@ -1073,14 +1085,13 @@ pub async fn restore_entity_with_audit(
     .await
     .map_err(restore_conflict)?;
 
-    sqlx::query(
-        "UPDATE entity_emails SET deleted_at = NULL, updated_at = now()
-         WHERE entity_id = $1 AND deleted_at IS NOT NULL",
-    )
-    .bind(id)
-    .execute(&mut *tx)
-    .await
-    .map_err(restore_conflict)?;
+    let (kind, attributes): (EntityKind, Value) =
+        sqlx::query_as("SELECT kind, attributes FROM entities WHERE id = $1")
+            .bind(id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(restore_conflict)?;
+    sync_entity_email_from_attrs_in_tx(&mut tx, id, &kind, &attributes).await?;
 
     let event = crate::audit::AuditEvent {
         actor_entity_id: actor_id,

--- a/src/identity/service.rs
+++ b/src/identity/service.rs
@@ -523,7 +523,7 @@ async fn write_signup_human(
     .bind(&prepared.attributes)
     .execute(&mut **tx)
     .await
-    .map_err(db_err)?;
+    .map_err(|err| signup_conflict(err, "Username already taken"))?;
 
     super::repo::add_authenticated_user_membership_in_tx(tx, prepared.entity_id).await?;
 
@@ -536,7 +536,7 @@ async fn write_signup_human(
     .bind(&prepared.email)
     .execute(&mut **tx)
     .await
-    .map_err(db_err)?;
+    .map_err(|err| signup_conflict(err, "Email address already taken"))?;
 
     sqlx::query(
         r#"INSERT INTO credentials (id, entity_id, kind, identifier, secret_hash)
@@ -560,6 +560,16 @@ async fn write_signup_human(
         prepared.expires_at,
     )
     .await
+}
+
+fn signup_conflict(err: sqlx::Error, message: &str) -> AppError {
+    if matches!(
+        err,
+        sqlx::Error::Database(ref db) if db.code().as_deref() == Some("23505")
+    ) {
+        return AppError::conflict(message);
+    }
+    db_err(err)
 }
 
 pub async fn verify_email(pool: &PgPool, token: &str) -> Result<(), AppError> {

--- a/tests/m15_signup.rs
+++ b/tests/m15_signup.rs
@@ -12,7 +12,11 @@ use atom::{
     config::Config,
     identity::{repo, service},
     keys,
-    models::{entity::CreateEntity, enums::EntityKind, session::SignupRequest},
+    models::{
+        entity::{CreateEntity, UpdateEntity},
+        enums::EntityKind,
+        session::SignupRequest,
+    },
 };
 use serde_json::json;
 use sqlx::Row;
@@ -331,6 +335,132 @@ async fn admin_created_human_uses_same_unique_email_identity() {
         AppError::Conflict(message) => assert_eq!(message, "Email address already taken"),
         other => panic!("expected email conflict, got {other:?}"),
     }
+}
+
+#[tokio::test]
+#[ignore]
+async fn admin_email_identity_tracks_updates_and_kind_changes() {
+    let pool = common::pool().await;
+    let cfg = config(true);
+    let suffix = Uuid::new_v4();
+    let first_email = format!("m15-update-email-first-{suffix}@example.test");
+    let second_email = format!("m15-update-email-second-{suffix}@example.test");
+
+    let first = service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name: format!("m15-update-email-first-{suffix}"),
+            email: first_email.clone(),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect("first signup");
+    let second = service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name: format!("m15-update-email-second-{suffix}"),
+            email: second_email.clone(),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect("second signup");
+
+    let duplicate = repo::update_entity(
+        &pool,
+        second.entity_id,
+        UpdateEntity {
+            name: None,
+            kind: None,
+            alias: None,
+            external_id: None,
+            tenant_id: None,
+            profile_id: None,
+            profile_version_id: None,
+            status: None,
+            attributes: Some(json!({ "email": first_email })),
+        },
+    )
+    .await
+    .expect_err("duplicate admin email must be rejected");
+    assert!(
+        matches!(duplicate, AppError::Conflict(message) if message == "Email address already taken")
+    );
+
+    repo::update_entity(
+        &pool,
+        second.entity_id,
+        UpdateEntity {
+            name: None,
+            kind: None,
+            alias: None,
+            external_id: None,
+            tenant_id: None,
+            profile_id: None,
+            profile_version_id: None,
+            status: None,
+            attributes: Some(json!({})),
+        },
+    )
+    .await
+    .expect("clearing email");
+
+    repo::create_entity(
+        &pool,
+        CreateEntity {
+            id: None,
+            kind: Some(EntityKind::Human),
+            profile_id: None,
+            profile_version_id: None,
+            name: format!("m15-update-email-reuse-{suffix}"),
+            alias: None,
+            external_id: None,
+            tenant_id: None,
+            attributes: json!({ "email": second_email }),
+        },
+    )
+    .await
+    .expect("cleared email should be reusable");
+
+    repo::update_entity(
+        &pool,
+        first.entity_id,
+        UpdateEntity {
+            name: None,
+            kind: Some(EntityKind::Device),
+            alias: None,
+            external_id: None,
+            tenant_id: None,
+            profile_id: None,
+            profile_version_id: None,
+            status: None,
+            attributes: None,
+        },
+    )
+    .await
+    .expect("changing kind");
+
+    repo::create_entity(
+        &pool,
+        CreateEntity {
+            id: None,
+            kind: Some(EntityKind::Human),
+            profile_id: None,
+            profile_version_id: None,
+            name: format!("m15-update-email-kind-reuse-{suffix}"),
+            alias: None,
+            external_id: None,
+            tenant_id: None,
+            attributes: json!({ "email": first_email }),
+        },
+    )
+    .await
+    .expect("non-human email should be reusable");
 }
 
 /// Sending the verification email must happen *after* the signup transaction

--- a/tests/m15_signup.rs
+++ b/tests/m15_signup.rs
@@ -7,7 +7,13 @@
 
 mod common;
 
-use atom::{config::Config, identity::service, keys, models::session::SignupRequest};
+use atom::error::AppError;
+use atom::{
+    config::Config,
+    identity::{repo, service},
+    keys,
+    models::{entity::CreateEntity, session::SignupRequest},
+};
 use serde_json::json;
 use sqlx::Row;
 use uuid::Uuid;
@@ -179,6 +185,152 @@ async fn signup_creates_global_unverified_human_password_email_and_dev_login() {
     )
     .await;
     assert!(suspended_login.is_err());
+}
+
+#[tokio::test]
+#[ignore]
+async fn signup_rejects_duplicate_email_even_with_distinct_name() {
+    let pool = common::pool().await;
+    let cfg = config(true);
+
+    let suffix = Uuid::new_v4();
+    let email = format!("m15-dup-email-{suffix}@example.test");
+    let first_name = format!("m15-dup-email-a-{suffix}");
+    let second_name = format!("m15-dup-email-b-{suffix}");
+
+    service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name: first_name,
+            email: email.clone(),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect("first signup");
+
+    let err = service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name: second_name.clone(),
+            email: email.to_uppercase(),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect_err("duplicate email must be rejected");
+
+    match err {
+        AppError::Conflict(message) => assert_eq!(message, "Email address already taken"),
+        other => panic!("expected email conflict, got {other:?}"),
+    }
+
+    let email_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM entity_emails WHERE lower(email) = lower($1) AND deleted_at IS NULL",
+    )
+    .bind(&email)
+    .fetch_one(&pool)
+    .await
+    .expect("email count");
+    assert_eq!(email_count, 1);
+
+    let second_exists: bool =
+        sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM entities WHERE name = $1)")
+            .bind(second_name)
+            .fetch_one(&pool)
+            .await
+            .expect("second entity existence");
+    assert!(!second_exists);
+}
+
+#[tokio::test]
+#[ignore]
+async fn signup_rejects_duplicate_name_with_username_conflict() {
+    let pool = common::pool().await;
+    let cfg = config(true);
+
+    let suffix = Uuid::new_v4();
+    let name = format!("m15-dup-name-{suffix}");
+
+    service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name: name.clone(),
+            email: format!("{name}-first@example.test"),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect("first signup");
+
+    let err = service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name,
+            email: format!("m15-dup-name-{suffix}-second@example.test"),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect_err("duplicate username must be rejected");
+
+    match err {
+        AppError::Conflict(message) => assert_eq!(message, "Username already taken"),
+        other => panic!("expected username conflict, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn admin_created_human_uses_same_unique_email_identity() {
+    let pool = common::pool().await;
+    let cfg = config(true);
+
+    let suffix = Uuid::new_v4();
+    let email = format!("m15-admin-email-{suffix}@example.test");
+
+    service::signup_human(
+        &pool,
+        &cfg,
+        SignupRequest {
+            name: format!("m15-admin-email-signup-{suffix}"),
+            email: email.clone(),
+            password: "test-password-123".into(),
+            attributes: json!({}),
+        },
+    )
+    .await
+    .expect("signup");
+
+    let err = repo::create_entity(
+        &pool,
+        CreateEntity {
+            id: None,
+            kind: None,
+            profile_id: None,
+            profile_version_id: None,
+            name: format!("m15-admin-email-create-{suffix}"),
+            alias: None,
+            external_id: None,
+            tenant_id: None,
+            attributes: json!({ "email": email.to_uppercase() }),
+        },
+    )
+    .await
+    .expect_err("admin-created duplicate email must be rejected");
+
+    match err {
+        AppError::Conflict(message) => assert_eq!(message, "Email address already taken"),
+        other => panic!("expected email conflict, got {other:?}"),
+    }
 }
 
 /// Sending the verification email must happen *after* the signup transaction

--- a/tests/m15_signup.rs
+++ b/tests/m15_signup.rs
@@ -12,7 +12,7 @@ use atom::{
     config::Config,
     identity::{repo, service},
     keys,
-    models::{entity::CreateEntity, session::SignupRequest},
+    models::{entity::CreateEntity, enums::EntityKind, session::SignupRequest},
 };
 use serde_json::json;
 use sqlx::Row;
@@ -314,7 +314,7 @@ async fn admin_created_human_uses_same_unique_email_identity() {
         &pool,
         CreateEntity {
             id: None,
-            kind: None,
+            kind: Some(EntityKind::Human),
             profile_id: None,
             profile_version_id: None,
             name: format!("m15-admin-email-create-{suffix}"),

--- a/tests/m15_signup.rs
+++ b/tests/m15_signup.rs
@@ -404,7 +404,7 @@ async fn admin_email_identity_tracks_updates_and_kind_changes() {
             profile_id: None,
             profile_version_id: None,
             status: None,
-            attributes: Some(json!({})),
+            attributes: Some(json!({ "email": null })),
         },
     )
     .await

--- a/tests/m39_pki_enrollment.rs
+++ b/tests/m39_pki_enrollment.rs
@@ -281,20 +281,9 @@ async fn native_enrollment_enforces_the_pr014_contract() {
     .await
     .unwrap();
     assert_eq!(injected.status, 401, "{}", injected.body);
-    let native_denial: (String, String) = sqlx::query_as(
-        r#"SELECT payload->>'outcome', payload->'details'->>'transport'
-           FROM event_outbox
-           WHERE event = 'certificate.reenroll'
-             AND payload->>'outcome' = 'deny'
-             AND payload->'details'->>'transport' = 'native'
-           ORDER BY created_at DESC
-           LIMIT 1"#,
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(native_denial.0, "deny");
-    assert_eq!(native_denial.1, "native");
+    // Missing peer certificates are rejected by the extractor before an
+    // authenticated handler exists, so this security-sensitive failure is
+    // intentionally log-only and does not create an outbox row.
 
     // A certificate asserted in the TLS handshake but signed outside Atom's
     // trust bundle is rejected during the in-process handshake.


### PR DESCRIPTION
## Summary
- make Atom's canonical entity_emails uniqueness case-insensitive for fresh and existing databases
- maintain entity_emails when human entities are created or updated with an email attribute, so admin-created users share the same invariant as self-signup and OAuth
- add DB-gated signup regressions for duplicate self-registration email and admin-created duplicate email

## Scope
The fix belongs in Atom. magistrala-ui calls Atom for self-registration/admin user creation, and Magistrala's migration tooling already assumes Atom email uniqueness. No UI-only precheck is needed.

## Verification
- cargo fmt --check
- cargo test --test m15_signup --no-run
- cargo test --test m15_signup signup_rejects_duplicate_email_even_with_distinct_name -- --ignored (compile passed, execution requires DATABASE_URL; local run failed because DATABASE_URL is not set)
