### PR TITLE
Add tenant ID filtering

### DIFF
--- a/src/graphql/tenants.rs
+++ b/src/graphql/tenants.rs
@@ -44,6 +44,7 @@ impl TenantQuery {
     async fn tenants(
         &self,
         ctx: &Context<'_>,
+        id: Option<ID>,
         q: Option<String>,
         name: Option<String>,
         alias: Option<String>,
@@ -58,6 +59,7 @@ impl TenantQuery {
         let state = ctx.data::<AppState>()?;
         let deleted = parse_deleted_filter(deleted);
         let params = ListTenants {
+            id: parse_optional_id(id, "id")?,
             q,
             name,
             alias,

--- a/src/models/tenant.rs
+++ b/src/models/tenant.rs
@@ -51,6 +51,7 @@ pub struct UpdateTenant {
 
 #[derive(Debug, Deserialize)]
 pub struct ListTenants {
+    pub id: Option<Uuid>,
     pub q: Option<String>,
     pub name: Option<String>,
     pub alias: Option<String>,

--- a/src/tenants/repo.rs
+++ b/src/tenants/repo.rs
@@ -1914,6 +1914,7 @@ mod tests {
         let active = list_tenants(
             &pool,
             ListTenants {
+                id: None,
                 q: None,
                 name: None,
                 alias: None,

--- a/src/tenants/repo.rs
+++ b/src/tenants/repo.rs
@@ -328,6 +328,7 @@ pub async fn get_tenant(pool: &PgPool, id: Uuid) -> Result<Tenant, AppError> {
 pub async fn list_tenants(pool: &PgPool, params: ListTenants) -> Result<TenantList, AppError> {
     let limit = params.limit.clamp(1, 100);
     let offset = params.offset.max(0);
+    let id = params.id;
     let name = params.name;
     let alias = params.alias;
     let status = params.status;
@@ -337,16 +338,18 @@ pub async fn list_tenants(pool: &PgPool, params: ListTenants) -> Result<TenantLi
 
     let items = sqlx::query_as::<_, Tenant>(&format!(
         r#"SELECT {TENANT_COLS} FROM tenants
-           WHERE ($1::text IS NULL OR name = $1)
-             AND ($2::text IS NULL OR lower(alias) = lower($2))
-             AND ($3::text IS NULL OR status = $3)
-             AND ($4::text IS NULL OR name ILIKE $4 OR alias ILIKE $4 OR array_to_string(tags, ',') ILIKE $4 OR attributes::text ILIKE $4)
-             AND ($7::text = 'all'
-                  OR ($7::text = 'live' AND deleted_at IS NULL)
-                  OR ($7::text = 'deleted' AND deleted_at IS NOT NULL))
-           ORDER BY {order_by}
-           LIMIT $5 OFFSET $6"#,
+           WHERE ($1::uuid IS NULL OR id = $1)
+             AND ($2::text IS NULL OR name = $2)
+             AND ($3::text IS NULL OR lower(alias) = lower($3))
+             AND ($4::text IS NULL OR status = $4)
+             AND ($5::text IS NULL OR name ILIKE $5 OR alias ILIKE $5 OR array_to_string(tags, ',') ILIKE $5 OR attributes::text ILIKE $5)
+             AND ($8::text = 'all'
+                  OR ($8::text = 'live' AND deleted_at IS NULL)
+                  OR ($8::text = 'deleted' AND deleted_at IS NOT NULL))
+             ORDER BY {order_by}
+           LIMIT $6 OFFSET $7"#,
     ))
+    .bind(id)
     .bind(name.clone())
     .bind(alias.clone())
     .bind(status.clone())
@@ -360,14 +363,16 @@ pub async fn list_tenants(pool: &PgPool, params: ListTenants) -> Result<TenantLi
 
     let total: i64 = sqlx::query_scalar(
         r#"SELECT COUNT(*) FROM tenants
-           WHERE ($1::text IS NULL OR name = $1)
-             AND ($2::text IS NULL OR lower(alias) = lower($2))
-             AND ($3::text IS NULL OR status = $3)
-             AND ($4::text IS NULL OR name ILIKE $4 OR alias ILIKE $4 OR array_to_string(tags, ',') ILIKE $4 OR attributes::text ILIKE $4)
-             AND ($5::text = 'all'
-                  OR ($5::text = 'live' AND deleted_at IS NULL)
-                  OR ($5::text = 'deleted' AND deleted_at IS NOT NULL))"#,
+           WHERE ($1::uuid IS NULL OR id = $1)
+             AND ($2::text IS NULL OR name = $2)
+             AND ($3::text IS NULL OR lower(alias) = lower($3))
+             AND ($4::text IS NULL OR status = $4)
+             AND ($5::text IS NULL OR name ILIKE $5 OR alias ILIKE $5 OR array_to_string(tags, ',') ILIKE $5 OR attributes::text ILIKE $5)
+             AND ($6::text = 'all'
+                  OR ($6::text = 'live' AND deleted_at IS NULL)
+                  OR ($6::text = 'deleted' AND deleted_at IS NOT NULL))"#,
     )
+    .bind(id)
     .bind(name)
     .bind(alias)
     .bind(status)

--- a/tests/m19_tenant_listing.rs
+++ b/tests/m19_tenant_listing.rs
@@ -133,6 +133,7 @@ async fn visible_tenant_ids(pool: &sqlx::PgPool, entity_id: Uuid) -> Vec<Uuid> {
         entity_id,
         None,
         ListTenants {
+            id: None,
             q: None,
             name: None,
             alias: None,
@@ -623,6 +624,7 @@ async fn ceiling_visible_tenant_ids(
         entity_id,
         Some(credential_id),
         ListTenants {
+            id: None,
             q: None,
             name: None,
             alias: None,

--- a/tests/m21_soft_delete.rs
+++ b/tests/m21_soft_delete.rs
@@ -515,6 +515,7 @@ async fn deleted_filter_lists_soft_deleted_objects() {
     let live_tenants = atom::tenants::repo::list_tenants(
         &pool,
         ListTenants {
+            id: None,
             q: Some(tenant_name.clone()),
             name: None,
             alias: None,
@@ -535,6 +536,7 @@ async fn deleted_filter_lists_soft_deleted_objects() {
     let deleted_tenants = atom::tenants::repo::list_tenants(
         &pool,
         ListTenants {
+            id: None,
             q: Some(tenant_name),
             name: None,
             alias: None,

--- a/tests/m44_list_sorting.rs
+++ b/tests/m44_list_sorting.rs
@@ -394,6 +394,7 @@ async fn tenant_lists_apply_order_before_pagination() {
     let tenants = atom::tenants::repo::list_tenants(
         &pool,
         ListTenants {
+            id: None,
             q: Some(prefix.clone()),
             name: None,
             alias: None,


### PR DESCRIPTION
## Summary
- add an optional exact ID filter to the tenants GraphQL query
- apply the filter to both tenant rows and total counts

## Commit
- `a3634a5` Support tenant ID filtering

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/atom-ui-fix cargo check`

This supports the workspace ID search in the corresponding Magistrala UI PR.