### PR TITLE
Log unroutable AMQP payloads as JSON text

### DIFF
--- a/src/events/publisher.rs
+++ b/src/events/publisher.rs
@@ -21,11 +21,13 @@
 
 use axum::async_trait;
 use lapin::{
+    message::BasicReturnMessage,
     options::{BasicPublishOptions, ConfirmSelectOptions, ExchangeDeclareOptions},
     tcp::{OwnedIdentity, OwnedTLSConfig},
     types::FieldTable,
     BasicProperties, Channel, Confirmation, Connection, ConnectionProperties, ExchangeKind,
 };
+use uuid::Uuid;
 
 use crate::config::EventsConfig;
 
@@ -37,6 +39,47 @@ pub struct PublishError(pub String);
 
 fn returned_payload(data: &[u8]) -> std::borrow::Cow<'_, str> {
     String::from_utf8_lossy(data)
+}
+
+fn log_returned_message(event_id: Uuid, confirmation: &'static str, returned: &BasicReturnMessage) {
+    let payload = returned_payload(&returned.data);
+    tracing::warn!(
+        %event_id,
+        %confirmation,
+        exchange = %returned.exchange,
+        routing_key = %returned.routing_key,
+        reply_code = ?returned.reply_code,
+        reply_text = %returned.reply_text,
+        payload = %payload,
+        "AMQP broker returned an unroutable event"
+    );
+}
+
+fn confirmation_result(
+    event_id: Uuid,
+    routing_key: &str,
+    confirmation: Confirmation,
+) -> Result<(), PublishError> {
+    match confirmation {
+        Confirmation::Ack(None) => Ok(()),
+        Confirmation::Ack(Some(returned)) => {
+            log_returned_message(event_id, "ack", &returned);
+            Err(PublishError(format!(
+                "event {event_id} was returned as unroutable (no queue bound to routing key {routing_key:?}); the broker never stored it"
+            )))
+        }
+        Confirmation::Nack(returned) => {
+            if let Some(returned) = returned {
+                log_returned_message(event_id, "nack", &returned);
+            }
+            Err(PublishError(format!(
+                "event {event_id} was nacked by the broker"
+            )))
+        }
+        Confirmation::NotRequested => Err(PublishError(format!(
+            "event {event_id}: broker did not confirm (publisher confirms not active)"
+        ))),
+    }
 }
 
 /// Delivers a batch of domain events to wherever they're consumed.
@@ -278,29 +321,11 @@ impl EventPublisher for AmqpPublisher {
         for (event_id, confirm_res) in pending {
             match confirm_res {
                 Ok(confirm) => match confirm.await {
-                    Ok(Confirmation::Ack(None)) => results.push(Ok(())),
-                    Ok(Confirmation::Ack(Some(returned))) => {
-                        let payload = returned_payload(&returned.data);
-                        tracing::warn!(
-                            %event_id,
-                            exchange = %returned.exchange,
-                            routing_key = %returned.routing_key,
-                            reply_code = ?returned.reply_code,
-                            reply_text = %returned.reply_text,
-                            payload = %payload,
-                            "AMQP broker returned an unroutable event"
-                        );
-                        results.push(Err(PublishError(format!(
-                            "event {event_id} was returned as unroutable (no queue bound to routing key {:?}); the broker never stored it",
-                            self.routing_key
-                        ))));
-                    }
-                    Ok(Confirmation::Nack(_)) => results.push(Err(PublishError(format!(
-                        "event {event_id} was nacked by the broker"
-                    )))),
-                    Ok(Confirmation::NotRequested) => results.push(Err(PublishError(format!(
-                        "event {event_id}: broker did not confirm (publisher confirms not active)"
-                    )))),
+                    Ok(confirmation) => results.push(confirmation_result(
+                        event_id,
+                        &self.routing_key,
+                        confirmation,
+                    )),
                     Err(e) => {
                         results.push(Err(PublishError(format!("confirm event {event_id}: {e}"))))
                     }
@@ -315,7 +340,40 @@ impl EventPublisher for AmqpPublisher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lapin::message::Delivery;
+    use std::{
+        io::Write,
+        sync::{Arc, Mutex},
+    };
     use uuid::Uuid;
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("capture buffer lock").write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_logs(f: impl FnOnce()) -> String {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer_output = Arc::clone(&output);
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(move || SharedWriter(Arc::clone(&writer_output)))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+
+        let bytes = output.lock().expect("capture buffer lock").clone();
+        String::from_utf8(bytes).expect("tracing output is UTF-8")
+    }
 
     fn sample_event() -> DomainEventPayload {
         DomainEventPayload {
@@ -360,6 +418,38 @@ mod tests {
     #[test]
     fn returned_non_utf8_payload_is_rendered_without_panicking() {
         assert_eq!(returned_payload(&[b'{', 0xff, b'}']), "{�}");
+    }
+
+    #[test]
+    fn nack_returned_message_logs_decoded_payload_and_metadata() {
+        let event_id = Uuid::new_v4();
+        let payload = br#"{"event":"resource.create","outcome":"allow"}"#.to_vec();
+        let returned = BasicReturnMessage {
+            delivery: Delivery::mock(
+                0,
+                "atom.events".into(),
+                "atom.events".into(),
+                false,
+                payload,
+            ),
+            reply_code: 312,
+            reply_text: "NO_ROUTE".into(),
+        };
+
+        let output = capture_logs(|| {
+            let error =
+                confirmation_result(event_id, "atom.events", Confirmation::Nack(Some(returned)))
+                    .expect_err("the broker nack must fail publication");
+            assert!(error.0.contains("nacked by the broker"));
+        });
+
+        assert!(output.contains("AMQP broker returned an unroutable event"));
+        assert!(output.contains("confirmation=nack"));
+        assert!(output.contains("exchange=atom.events"));
+        assert!(output.contains("routing_key=atom.events"));
+        assert!(output.contains("reply_code=312"));
+        assert!(output.contains("reply_text=NO_ROUTE"));
+        assert!(output.contains(r#"payload={"event":"resource.create","outcome":"allow"}"#));
     }
 
     #[tokio::test]

--- a/src/events/publisher.rs
+++ b/src/events/publisher.rs
@@ -35,6 +35,10 @@ use super::DomainEventPayload;
 #[error("{0}")]
 pub struct PublishError(pub String);
 
+fn returned_payload(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    String::from_utf8_lossy(data)
+}
+
 /// Delivers a batch of domain events to wherever they're consumed.
 /// Implementations must not panic; a delivery failure is reported per event
 /// so the outbox poller can retry failing rows without losing or duplicate-delivering
@@ -275,17 +279,31 @@ impl EventPublisher for AmqpPublisher {
             match confirm_res {
                 Ok(confirm) => match confirm.await {
                     Ok(Confirmation::Ack(None)) => results.push(Ok(())),
-                    Ok(Confirmation::Ack(Some(_))) => results.push(Err(PublishError(format!(
-                        "event {event_id} was returned as unroutable (no queue bound to routing key {:?}); the broker never stored it",
-                        self.routing_key
-                    )))),
+                    Ok(Confirmation::Ack(Some(returned))) => {
+                        let payload = returned_payload(&returned.data);
+                        tracing::warn!(
+                            %event_id,
+                            exchange = %returned.exchange,
+                            routing_key = %returned.routing_key,
+                            reply_code = ?returned.reply_code,
+                            reply_text = %returned.reply_text,
+                            payload = %payload,
+                            "AMQP broker returned an unroutable event"
+                        );
+                        results.push(Err(PublishError(format!(
+                            "event {event_id} was returned as unroutable (no queue bound to routing key {:?}); the broker never stored it",
+                            self.routing_key
+                        ))));
+                    }
                     Ok(Confirmation::Nack(_)) => results.push(Err(PublishError(format!(
                         "event {event_id} was nacked by the broker"
                     )))),
                     Ok(Confirmation::NotRequested) => results.push(Err(PublishError(format!(
                         "event {event_id}: broker did not confirm (publisher confirms not active)"
                     )))),
-                    Err(e) => results.push(Err(PublishError(format!("confirm event {event_id}: {e}")))),
+                    Err(e) => {
+                        results.push(Err(PublishError(format!("confirm event {event_id}: {e}"))))
+                    }
                 },
                 Err(err) => results.push(Err(err)),
             }
@@ -327,6 +345,21 @@ mod tests {
     async fn log_publisher_succeeds_on_empty_batch() {
         let publisher = LogPublisher;
         assert!(publisher.publish(&[]).await.is_ok());
+    }
+
+    #[test]
+    fn returned_json_payload_is_rendered_as_text() {
+        let payload = br#"{"event":"resource.create","outcome":"allow"}"#;
+
+        assert_eq!(
+            returned_payload(payload),
+            r#"{"event":"resource.create","outcome":"allow"}"#
+        );
+    }
+
+    #[test]
+    fn returned_non_utf8_payload_is_rendered_without_panicking() {
+        assert_eq!(returned_payload(&[b'{', 0xff, b'}']), "{�}");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,11 @@ use atom::{
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
+// Lapin logs the complete BasicReturnMessage with Debug formatting, which
+// renders its JSON payload as a byte array. AmqpPublisher emits the same
+// unroutable-message warning with a decoded payload and broker metadata.
+const LAPIN_RETURNED_MESSAGE_FILTER: &str = "lapin::returned_messages=error";
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
@@ -206,9 +211,19 @@ async fn init_cache(cfg: &config::CacheConfig) -> anyhow::Result<Option<cache::C
     Ok(Some(client))
 }
 
+fn tracing_filter(level: &str) -> anyhow::Result<EnvFilter> {
+    let filter = EnvFilter::try_new(level)
+        .context("ATOM_LOG_LEVEL/RUST_LOG must be a valid tracing filter")?
+        .add_directive(
+            LAPIN_RETURNED_MESSAGE_FILTER
+                .parse()
+                .context("the static lapin tracing filter must be valid")?,
+        );
+    Ok(filter)
+}
+
 fn init_tracing(logging: &config::LoggingConfig) -> anyhow::Result<()> {
-    let filter = EnvFilter::try_new(&logging.level)
-        .context("ATOM_LOG_LEVEL/RUST_LOG must be a valid tracing filter")?;
+    let filter = tracing_filter(&logging.level)?;
 
     match logging.format {
         config::LogFormat::Text => tracing_subscriber::fmt().with_env_filter(filter).init(),
@@ -219,6 +234,60 @@ fn init_tracing(logging: &config::LoggingConfig) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tracing_tests {
+    use super::*;
+    use std::{
+        io::Write,
+        sync::{Arc, Mutex},
+    };
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("capture buffer lock").write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn tracing_suppresses_lapin_returned_message_byte_dump() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer_output = Arc::clone(&output);
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_env_filter(tracing_filter("warn").expect("valid tracing filter"))
+            .with_writer(move || SharedWriter(Arc::clone(&writer_output)))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(
+                target: "lapin::returned_messages",
+                data = ?[123_u8, 34, 101, 118, 101, 110, 116],
+                "Server returned us a message"
+            );
+            tracing::warn!(
+                target: "atom::events::publisher",
+                payload = %r#"{"event":"resource.create"}"#,
+                "AMQP broker returned an unroutable event"
+            );
+        });
+
+        let output = String::from_utf8(output.lock().expect("capture buffer lock").clone())
+            .expect("tracing output is UTF-8");
+        assert!(!output.contains("Server returned us a message"));
+        assert!(!output.contains("[123, 34, 101"));
+        assert!(output.contains("AMQP broker returned an unroutable event"));
+        assert!(output.contains(r#"{"event":"resource.create"}"#));
+    }
 }
 
 async fn bootstrap_pki_root(pool: &sqlx::PgPool, path: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

- suppress Lapin's internal returned-message warning, which renders the complete JSON body as a decimal byte array
- emit an Atom-owned warning for unroutable AMQP events with event ID, exchange, routing key, broker reply metadata, and a decoded `payload` string
- decode invalid UTF-8 lossily so malformed broker-returned content cannot panic logging
- add regression coverage for payload rendering and log filtering

## Why

Atom publishes domain events with AMQP's mandatory flag. When the broker cannot route a message, Lapin logs the complete `BasicReturnMessage` using Debug formatting before returning it to Atom. That makes a JSON event appear as an unreadable `data: [123, 34, ...]` byte array.

Atom already receives that returned message through `Confirmation::Ack(Some(...))`. This change filters only Lapin's duplicate `lapin::returned_messages` warning and logs the same failure from Atom with the payload decoded as text. Delivery semantics are unchanged: the event remains failed, undelivered, and retryable.

## Automated verification

Run:

```bash
cargo fmt --all --check
cargo test --locked --lib returned_
cargo test --locked --bin atom tracing_suppresses_lapin_returned_message_byte_dump
cargo clippy --locked -- -D warnings
```

The focused tests assert that:

- valid JSON bytes are rendered as JSON text
- invalid UTF-8 is rendered safely without a panic
- `Server returned us a message` and its decimal byte dump are absent
- Atom's replacement warning and decoded JSON payload are present

Local results: formatting passed; the two library tests and one tracing test passed. Full Clippy was started on Windows but stopped making progress after dependency checking; GitHub's Linux CI should run the complete locked Clippy and test suite.

## Human verification

1. Start Atom with event publishing enabled and point `ATOM_EVENTS_AMQP_ROUTING_KEY` at a routing key that has no queue/binding.
2. Trigger any mutation that enqueues a domain event.
3. Wait for the event outbox publisher to attempt delivery.
4. Confirm the logs do not contain:
   `Server returned us a message BasicReturnMessage`
5. Confirm they contain one Atom warning similar to:
   `AMQP broker returned an unroutable event ... payload={"schema_version":1,...}`
6. Confirm the corresponding `event_outbox` row remains undelivered and records an `unroutable` error.