### PR TITLE
docs: draft database backend and SQLite delivery plan

### DIFF
--- a/product-docs/development/database-backends/PRD.md
+++ b/product-docs/development/database-backends/PRD.md
@@ -1,0 +1,177 @@
+# PRD: Runtime Database Backends and SQLite Parity
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Accountable owner | `@arvindh123` (proposed; confirm before publication) |
+| Reviewers | Database, security, and operations reviewers TBD before publication |
+| Target users | Atom operators, application teams, contributors, and edge deployments |
+| Initiative slug | `database-backends` |
+| Related RFC | `product-docs/development/database-backends/RFC.md` |
+| Epic | `[Epic] Run Atom on PostgreSQL or SQLite with equivalent behavior` |
+
+## Problem
+
+Atom currently requires PostgreSQL. Runtime state exposes `PgPool`, at least 45
+source files refer directly to PostgreSQL types, and roughly 434 dynamic SQL
+calls are spread across repositories, services, startup, and background jobs.
+The 25 current migrations contain PostgreSQL-specific JSONB, arrays, functions,
+triggers, advisory locks, row locking, and `SKIP LOCKED` behavior.
+
+This coupling prevents a small deployment from running Atom as one binary plus
+one local database file, and makes every future backend a cross-cutting rewrite.
+A superficial pool alias would be unsafe: authorization expansion, transactional
+events, purge, and PKI invariants currently depend on PostgreSQL semantics.
+
+## Goals
+
+- **G-1:** Let an operator select PostgreSQL or SQLite from `DATABASE_URL` in the same Atom binary.
+- **G-2:** Provide complete public-API and security-behavior parity on SQLite.
+- **G-3:** Preserve existing PostgreSQL schema, upgrade, performance, and deployment behavior.
+- **G-4:** Establish an internal backend boundary that can accept another database without changing transports or domain services.
+- **G-5:** Keep PostgreSQL the recommended backend for multi-replica and high-write deployments while supporting SQLite as a production single-instance option.
+
+## Non-goals
+
+- **NG-1:** PostgreSQL-to-SQLite or SQLite-to-PostgreSQL data transfer.
+- **NG-2:** Multiple Atom processes or network-shared storage for one SQLite file.
+- **NG-3:** SQLCipher or another built-in whole-file encryption layer.
+- **NG-4:** A public third-party database plugin ABI.
+- **NG-5:** Replacing SQLx with an ORM or reducing PostgreSQL to a lowest-common-denominator query plan.
+- **NG-6:** Changing Atom's HTTP, GraphQL, gRPC, event, bootstrap YAML, authz, or PKI contracts.
+- **NG-7:** Resolving the health-check and serverless PostgreSQL behavior tracked separately in GitHub issue #42.
+
+## Success metrics and guardrails
+
+| ID | Metric | Baseline | Target | Window | Instrumentation owner |
+|---|---|---|---|---|---|
+| M-1 | DB-gated behavioral suites passing per backend | PostgreSQL only | 100% on PostgreSQL and SQLite | Every CI run | Engineering |
+| M-2 | v1 contract artifact drift | 0 accepted drift | 0 drift | Every CI run | Engineering |
+| M-3 | PostgreSQL-specific types or SQL outside backend storage | 45 source files currently reference PostgreSQL types | 0 prohibited references | Every CI run | Engineering |
+| M-4 | Atomic mutation/outbox invariant failures | 0 known | 0 across crash and rollback tests | Every release | Database reviewer |
+| M-5 | PostgreSQL authz hot-path regression | Benchmark to be captured before refactor | No greater than 10% p95 regression on the fixed CI fixture | Before release | Engineering |
+| M-6 | SQLite parity defects open at release | Not applicable | 0 severity-1/2 parity defects | Release gate | Accountable owner |
+
+## User journeys
+
+### Journey 1: Start a file-backed SQLite deployment
+
+1. An operator supplies a `sqlite://...` `DATABASE_URL` with a local path.
+2. Atom validates the topology, creates the file if absent, applies SQLite migrations, and logs the selected backend.
+3. The operator bootstraps and uses every Atom API without provisioning PostgreSQL.
+4. A second Atom process targeting the same file fails startup with a clear single-owner error.
+
+### Journey 2: Upgrade an existing PostgreSQL deployment
+
+1. An operator deploys the new binary with the existing PostgreSQL URL.
+2. Atom uses the unchanged PostgreSQL migration history and current pool configuration.
+3. Existing clients, data, authorization decisions, audit events, and PKI artifacts behave as before.
+4. Rollback follows the existing PostgreSQL release procedure because no SQLite cutover occurred.
+
+### Journey 3: Develop or test ephemerally
+
+1. A contributor supplies `sqlite::memory:`.
+2. Atom uses a single connection, applies the SQLite baseline, and runs without external database infrastructure.
+3. Tests observe the same domain and API results as the PostgreSQL fixture.
+
+### Journey 4: Recover from SQLite operational failure
+
+1. Atom detects a locked/busy database beyond the configured timeout, migration failure, corrupt file, or unavailable path.
+2. Startup failures stop before serving; request-time exhaustion returns service unavailable without weakening authorization or committing a partial mutation.
+3. The operator follows the documented backup/restore procedure and restarts one Atom instance.
+
+## Functional requirements
+
+- **FR-1:** Atom must select PostgreSQL for `postgres://`/`postgresql://` URLs and SQLite for `sqlite://`/`sqlite::memory:` URLs in one binary, rejecting unsupported schemes before serving.
+- **FR-2:** Existing PostgreSQL databases must retain their migration history, stored meanings, public behavior, and supported in-place upgrade boundary.
+- **FR-3:** SQLite must support every mounted HTTP, GraphQL, and gRPC operation plus bootstrap, authentication, authorization, audit/outbox, purge, signing-key, and PKI behavior.
+- **FR-4:** Atom must automatically apply the migration set belonging to the selected backend and must fail startup on migration or compatibility errors.
+- **FR-5:** Mutations must preserve Atom's current transaction, audit, cache-invalidation, and transactional-outbox rules on both backends.
+- **FR-6:** SQLite authorization decisions and visibility must use one canonical grant expansion and scope matcher with deny-overrides, ABAC fail-closed behavior, access-token ceilings, and immediate revocation parity.
+- **FR-7:** File-backed SQLite must enforce a single Atom owner, support concurrent in-process requests, and provide durable restart behavior; memory mode must remain isolated and ephemeral.
+- **FR-8:** Backend constraint, not-found, conflict, invalid-reference, invalid-value, busy, and internal failures must map to the existing transport semantics consistently.
+- **FR-9:** Operators must receive documented configuration, persistence, backup, restore, capacity, and unsupported-topology guidance for SQLite.
+- **FR-10:** Domain and transport code must depend on backend-neutral database and repository interfaces; PostgreSQL- or SQLite-specific SQL and types must remain inside backend adapters.
+
+## Non-functional requirements
+
+- **NFR-1:** The checked-in v1 OpenAPI, GraphQL, and protobuf contracts must remain byte-for-byte unchanged.
+- **NFR-2:** PostgreSQL authz hot-path p95 latency must not regress by more than 10% on the fixed benchmark fixture introduced before refactoring.
+- **NFR-3:** SQLite file connections must enable foreign keys, recursive triggers, WAL, `synchronous=FULL`, and a 30-second busy timeout; write transactions must begin immediately.
+- **NFR-4:** A SQLite busy timeout must fail closed and map to service unavailable; no mutation may be partially committed.
+- **NFR-5:** Sensitive recoverable material must continue using Atom's existing application encryption, and neither backend may log plaintext or wrapped key material.
+- **NFR-6:** A committed mutation that enables domain events must never lose its outbox row; duplicate delivery after recovery remains acceptable under the existing at-least-once contract.
+- **NFR-7:** Both backend suites must cover single-connection execution so no transaction path can borrow a second pool connection.
+- **NFR-8:** Released PostgreSQL migrations must remain immutable, and every post-baseline schema change must have paired PostgreSQL and SQLite migrations with the same version number.
+- **NFR-9:** SQLite schema constraints/triggers or same-transaction application validation must preserve tenant isolation, soft-delete, policy cleanup, credential, and PKI invariants.
+- **NFR-10:** Adding a future internal backend must not require changes to public transports, domain models, or event envelopes.
+
+## Constraints and dependencies
+
+- Rust 2021, Axum 0.7, SQLx 0.8.6, async-graphql 7.2.1, and the existing public contracts remain fixed for this initiative.
+- PostgreSQL migrations in `migrations/` are release-controlled and cannot be edited or relocated.
+- SQLite is a single-writer database; the supported topology is one Atom process with bounded concurrent readers.
+- The canonical PostgreSQL grant expansion remains optimized SQL; SQLite needs an equivalent backend-specific implementation rather than a portable-SQL rewrite.
+- The current GitHub token cannot read organization Projects; project placement must be confirmed before publication.
+
+## Assumptions and validation
+
+| Assumption | Impact if false | Validation | Owner |
+|---|---|---|---|
+| `@arvindh123` is the accountable owner | Publication ownership is wrong | Confirm before issue publication | Requester |
+| SQLx's bundled SQLite build supplies required JSON and `RETURNING` support | Additional native dependency or query redesign | Compile and migration smoke test in DB-007 | DB-007 owner |
+| One local process is acceptable for SQLite adopters | File locking and worker coordination design changes materially | Confirm in release review and docs | Product reviewer |
+| Existing public APIs define parity; direct manual database writes are unsupported | More database-only compatibility work is needed | Approve RFC boundary | Database reviewer |
+| A 10% PostgreSQL p95 regression budget is acceptable | Release guardrail must change | Capture baseline and approve before DB-003 | Engineering reviewer |
+
+## Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation/contingency | Owner |
+|---|---|---|---|---|
+| Authorization semantics drift between dialects | High | High | Canonical backend queries, differential fixtures, deny/ceiling parity tests | Security reviewer |
+| Large refactor regresses PostgreSQL | Medium | High | PostgreSQL-only foundation PRs, benchmark first, no migration edits | Engineering reviewer |
+| SQLite writes block during broker or PKI work | Medium | High | Short immediate transactions; never hold SQLite write lock across broker I/O | Database reviewer |
+| Schema triggers differ from PostgreSQL | High | High | Explicit invariant matrix and negative tests per backend | Database reviewer |
+| SQLite is deployed on shared/network storage | Medium | High | Process lock, startup rejection where detectable, prominent unsupported-topology docs | Operations reviewer |
+| Dual-backend CI becomes too slow | Medium | Medium | Fresh isolated SQLite files, bounded fixtures, separate exhaustive/nightly lanes if measured | CI owner |
+
+## Acceptance and release criteria
+
+- All existing PostgreSQL tests and v1 contract checks pass after each foundation PR.
+- Every database-relevant integration test passes against a fresh PostgreSQL database and a fresh SQLite file.
+- Differential authz, visibility, lifecycle, audit/outbox, purge, and PKI scenarios produce equivalent normalized results.
+- SQLite durability, restart, file ownership, busy timeout, rollback, backup, and restore evidence is attached to the release issue.
+- PostgreSQL benchmark regression remains within NFR-2.
+- No prohibited backend-specific dependency remains outside storage adapters and fixtures.
+- Documentation identifies PostgreSQL as the multi-replica/high-write default and SQLite as a supported single-instance alternative.
+- Database, security, operations, and product reviewers approve the RFC and release evidence.
+
+## Requirement traceability
+
+| Requirement | Acceptance evidence | Issue or planned issue | Verification |
+|---|---|---|---|
+| FR-1, FR-4 | Runtime URL and migration-selection tests | DB-001, DB-007 | Unit and startup integration tests |
+| FR-2, NFR-1, NFR-2 | Existing suite, contract checks, benchmark | DB-001 through DB-006, DB-015 | CI and benchmark report |
+| FR-3 | Complete dual-backend matrix | DB-009 through DB-015 | DB-gated tests on both URLs |
+| FR-5, NFR-6, NFR-7 | Rollback, cache, audit, outbox tests | DB-002, DB-012, DB-015 | Failure-injection and one-connection suites |
+| FR-6 | Normalized PDP/explain/listing parity | DB-004, DB-010, DB-015 | Differential authorization suite |
+| FR-7, NFR-3, NFR-4 | PRAGMA, ownership, restart, contention tests | DB-007, DB-012, DB-015 | SQLite operational integration tests |
+| FR-8 | Backend-neutral error matrix | DB-002, DB-008, DB-015 | HTTP/GraphQL/gRPC negative tests |
+| FR-9 | Reviewed operations guide | DB-016 | Documentation and restore drill |
+| FR-10, NFR-10 | Architecture boundary check | DB-001 through DB-006 | Static CI guard and review |
+| NFR-5, NFR-9 | Secret-redaction and invariant tests | DB-008, DB-013, DB-014, DB-015 | Security and schema negative tests |
+| NFR-8 | Paired migration validation | DB-007, DB-016 | Migration-check script and CI |
+
+## Decisions and follow-ups
+
+| Item | Classification | Owner | Due/trigger | Resolution |
+|---|---|---|---|---|
+| SQLite feature level | Resolved | Product | Planning | Full production parity |
+| Backend selection | Resolved | Product | Planning | Runtime `DATABASE_URL` scheme |
+| Abstraction style | Resolved | Engineering | Planning | Internal backend adapters; no public plugin API |
+| SQLite topology | Resolved | Operations | Planning | One Atom process per local file |
+| Durability | Resolved | Database | Planning | WAL plus `synchronous=FULL` and immediate writes |
+| Whole-file encryption | Resolved | Security | Planning | No SQLCipher; retain field encryption and require disk controls |
+| Data transfer | Resolved | Product | Planning | Out of scope |
+| Human reviewers | Blocking publication | Accountable owner | Before GitHub publication | TBD |
+| GitHub Project/iteration | Owned follow-up | Accountable owner | Before GitHub publication | Project visibility unavailable to current token |

--- a/product-docs/development/database-backends/PUBLICATION-MANIFEST.md
+++ b/product-docs/development/database-backends/PUBLICATION-MANIFEST.md
@@ -1,0 +1,179 @@
+# Database Backends — Draft Publication Manifest
+
+## Publication status
+
+**Not published.** This manifest prepares GitHub planning objects only. Drafting
+does not authorize issue, label, milestone, Project, assignment, or release mutations.
+
+## Target
+
+| Field | Value |
+|---|---|
+| Repository | `absmach/atom` |
+| Default branch | `main` |
+| Initiative slug | `database-backends` |
+| Draft branch | `codex/database-backend-planning` |
+| Viewer permission observed | `MAINTAIN` |
+| Related existing issue | #42, serverless PostgreSQL pool/health behavior; related only, not absorbed or closed |
+
+## Canonical files
+
+| File | Status | Purpose |
+|---|---|---|
+| `product-docs/development/database-backends/PRD.md` | Draft | Product requirements, acceptance, and traceability |
+| `product-docs/development/database-backends/RFC.md` | Draft | Backend architecture, data, security, migration, reliability, and operations decisions |
+| `product-docs/development/database-backends/ROADMAP.md` | Draft | Staged dependencies, milestones, and review gates |
+| `product-docs/development/database-backends/issues/` | Draft | Epic, capability, and 16 agent-ready leaf issue bodies |
+| `product-docs/development/database-backends/README.md` | Draft | Reading order and authorization boundary |
+| `product-docs/development/database-backends/PUBLICATION-MANIFEST.md` | Draft | Exact publication proposal and gate status |
+
+## Conditional artifacts
+
+- RFC: included because database interfaces, schema, migrations, authorization,
+  security, reliability, and operations require consequential decisions.
+- Acceptance strategy and traceability: included in the PRD and DB-015.
+- Threat/privacy analysis: included in RFC `Security and privacy`; no separate
+  document because the trust boundary does not change and the section covers the
+  material risks.
+- Migration/backfill: included in RFC `Compatibility and migration`; no transfer
+  plan is created because cross-backend transfer is explicitly out of scope.
+- Observability/SLO: included in RFC `Observability, capacity, and cost` and
+  NFR/Metrics requirements; no separate SLO document is required for this draft.
+- Rollout/rollback/runbook: rollout is in the RFC; the operator runbook is an
+  explicit DB-016 implementation output rather than an empty pre-implementation artifact.
+- UX: omitted because there is no end-user UI flow or accessibility change.
+
+## Requirement and issue counts
+
+- Goals: 5
+- Non-goals: 7
+- Functional requirements: 10
+- Non-functional requirements: 10
+- GitHub planning objects proposed: 20
+  - 1 Epic
+  - 3 capabilities/stories
+  - 16 leaf implementation/validation issues
+- Final end-to-end evidence owner: DB-015
+- Operator/release evidence owner: DB-016
+
+## Proposed Epic hierarchy
+
+1. **[Epic] Run Atom on PostgreSQL or SQLite with equivalent behavior**
+   1. **Isolate persistence without PostgreSQL regression**
+      1. DB-001 — Add the database façade and PostgreSQL benchmark baseline
+      2. DB-002 — Generalize transactions, commit helpers, and database errors
+      3. DB-003 — Isolate PostgreSQL identity, tenant, and authentication storage
+      4. DB-004 — Isolate PostgreSQL authorization decisions and visibility
+      5. DB-005 — Isolate PostgreSQL authorization mutations and guardrails
+      6. DB-006 — Isolate PostgreSQL PKI, bootstrap, and background storage
+   2. **Implement full SQLite behavior**
+      1. DB-007 — Add SQLite runtime policy and migration baseline
+      2. DB-008 — Add SQLite codecs, error mapping, and invariant coverage
+      3. DB-009 — Implement SQLite identity, tenant, and authentication storage
+      4. DB-010 — Implement SQLite authorization decisions and visibility
+      5. DB-011 — Implement SQLite authorization mutations and guardrails
+      6. DB-012 — Implement SQLite audit, outbox, purge, and worker semantics
+      7. DB-013 — Implement SQLite signing keys and PKI foundation
+      8. DB-014 — Implement SQLite certificate and PKI lifecycle parity
+   3. **Prove parity and release safely**
+      1. DB-015 — Enforce dual-backend parity, concurrency, and performance gates
+      2. DB-016 — Publish SQLite operations guidance and complete release readiness
+
+Use native GitHub sub-issues for both levels. Create in the listed order, then
+apply dependencies from `ROADMAP.md`. Do not use a checklist as the published hierarchy.
+
+## Dependencies
+
+- DB-001 -> DB-002.
+- DB-002 -> DB-003, DB-004, DB-005, DB-006.
+- DB-003 + DB-004 + DB-005 + DB-006 -> Milestone A boundary gate -> DB-007.
+- DB-007 -> DB-008.
+- DB-003 + DB-008 -> DB-009.
+- DB-004 + DB-008 + DB-009 -> DB-010.
+- DB-005 + DB-008 + DB-009 -> DB-011.
+- DB-008 + DB-009 + DB-011 -> DB-012.
+- DB-008 + DB-009 -> DB-013.
+- DB-009 + DB-012 + DB-013 -> DB-014.
+- DB-009 through DB-014 -> DB-015 -> DB-016.
+
+The graph is acyclic. DB-003, DB-004, DB-005, and most of DB-006 may run in
+parallel after DB-002, but DB-006 activates the final source-boundary gate only
+after the other three merge. SQLite domain leaves may parallelize only according
+to the dependencies above.
+
+## Ownership and review
+
+| Role | Proposed value | Publication state |
+|---|---|---|
+| Accountable owner | `@arvindh123` | Must be confirmed |
+| Product/API reviewer | TBD | Blocking publication |
+| Engineering/database reviewer | TBD | Blocking publication |
+| Security/PKI reviewer | TBD | Blocking publication |
+| Operations reviewer | TBD | Blocking publication |
+| AI executor | Any approved coding agent | Ready in leaf contracts |
+
+## Repository taxonomy observed
+
+Existing labels observed on 2026-09-01:
+
+- `bug`
+- `documentation`
+- `duplicate`
+- `enhancement`
+- `good first issue`
+- `help wanted`
+- `invalid`
+- `question`
+- `wontfix`
+
+No open milestones were observed. Organization Project visibility was not
+available because the token lacks `read:project`; no Project is claimed.
+
+### Proposed issue metadata
+
+- Epic: existing `enhancement`; proposed missing label `epic`.
+- Capabilities: existing `enhancement`; proposed missing label `capability`.
+- DB-001 through DB-015: existing `enhancement`; proposed missing labels
+  `database`, `agent-ready`; add proposed `sqlite` to DB-007 through DB-016.
+- DB-016: existing `documentation` and `enhancement`; proposed `database`, `sqlite`, `agent-ready`.
+- Proposed milestone: `Database backends and SQLite parity`.
+- Proposed Project: TBD after an authorized user with `read:project` confirms the
+  target; do not create a new Project by default.
+- Proposed iteration/fields: none until an existing Project is confirmed.
+
+Missing labels and the milestone are proposals only. Publication approval must
+explicitly say whether to create them or use only existing taxonomy.
+
+## Publication procedure after approval
+
+1. Confirm owners/reviewers, Project decision, labels, and milestone.
+2. Approve the canonical Markdown diff in the repository.
+3. Create the Epic from `issues/epic.md`.
+4. Create capabilities and attach them as native Epic sub-issues.
+5. Create leaves from their files and attach them as native capability sub-issues.
+6. Apply only approved existing/new labels, assignments, milestone, and Project fields.
+7. Add dependency relationships in the roadmap order.
+8. Replace planned titles in PRD traceability with issue links/numbers without
+   changing requirement meaning.
+9. Verify every created object and record URLs; never infer success from command exit alone.
+
+## Quality gate
+
+| Gate | Result |
+|---|---|
+| Technical/product decisions complete | Pass for Draft |
+| Goals and non-goals prevent scope drift | Pass |
+| Stable requirements and observable acceptance | Pass |
+| Requirement-to-issue traceability | Pass |
+| RFC covers interfaces/data/security/migration/reliability/operations | Pass |
+| Dependency graph coherent and acyclic | Pass |
+| Leaf issues bounded and independently verifiable | Pass |
+| Repository paths and commands verified | Pass |
+| GitHub taxonomy verified or marked proposed | Pass |
+| Human ownership/review confirmed | **Blocked for publication** |
+| GitHub Project target known | **Open follow-up; not required if omitted** |
+| GitHub mutation authorized | **No** |
+
+The pack is complete as a reviewable Draft. It is not publication-ready until
+the accountable owner and required human reviewers are confirmed and the user
+explicitly approves this exact or a revised manifest.

--- a/product-docs/development/database-backends/README.md
+++ b/product-docs/development/database-backends/README.md
@@ -1,0 +1,16 @@
+# Database Backend Initiative
+
+This directory is the draft planning source of truth for abstracting Atom's
+PostgreSQL persistence layer and adding full SQLite support.
+
+Read in this order:
+
+1. `PRD.md`
+2. `RFC.md`
+3. `ROADMAP.md`
+4. `issues/README.md`
+5. the selected leaf issue specification
+6. `PUBLICATION-MANIFEST.md` before publishing GitHub planning objects
+
+These documents plan delivery only. They do not authorize implementation,
+GitHub issue publication, or release.

--- a/product-docs/development/database-backends/RFC.md
+++ b/product-docs/development/database-backends/RFC.md
@@ -1,0 +1,240 @@
+# RFC: Internal Database Backend Boundary and SQLite Semantics
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Decision owner | `@arvindh123` (proposed) |
+| Reviewers | Database, security, and operations reviewers TBD |
+| Related PRD | `product-docs/development/database-backends/PRD.md` |
+| Requirement IDs | FR-1 through FR-10; NFR-1 through NFR-10 |
+
+## Context and current state
+
+`AppState` contains `sqlx::PgPool`; startup embeds `migrations/`; repository and
+service signatures expose `PgPool`, `PgConnection`, `Postgres`, and PostgreSQL
+transactions. Authorization depends on `subject_effective_grants`,
+`grant_scope_matches`, recursive views, arrays, and JSONB. Mutations coordinate
+audit, cache invalidation, and transactional outbox insertion around concrete
+PostgreSQL transactions. Purge, hierarchy changes, outbox delivery, and PKI use
+row or advisory locks.
+
+SQLx `AnyPool` is unsuitable because its portable value model covers primitive
+SQL values, while Atom relies heavily on UUID, timestamp, JSON, enum, and array
+encoding. A common-query rewrite would also discard PostgreSQL's optimized
+functions and locking behavior.
+
+## Decision
+
+Introduce a closed internal façade with concrete backend variants:
+
+- `DatabaseKind::{Postgres, Sqlite}` identifies semantics and observability.
+- cloneable `Database::{Postgres(PgPool), Sqlite(SqlitePool)}` owns connections,
+  backend migration selection, health checks, and transaction creation.
+- `DbTransaction::{Postgres, Sqlite}` owns exactly one backend transaction and
+  provides read, immediate-write, nested-savepoint, commit, and rollback paths.
+- backend-neutral `DatabaseErrorKind` classifies not-found, unique, foreign-key,
+  check, busy/unavailable, and internal failures before transport mapping.
+- domain repository façades accept `&Database` or `&mut DbTransaction` and
+  dispatch to `storage/postgres` or `storage/sqlite`; raw SQL and SQLx backend
+  types cannot escape those adapters.
+
+This is an internal, rebuild-required extension point. Adding another backend
+adds enum variants, connection/migration policy, adapter implementations, and
+the parity suite. It does not add a public plugin ABI.
+
+## System design and data flow
+
+```text
+HTTP / GraphQL / gRPC / workers
+              |
+       domain services and PDP
+              |
+       repository façades
+         /             \
+PostgreSQL adapter   SQLite adapter
+         |              |
+  PostgreSQL pool    SQLite pool/file
+```
+
+Read flows use repository-returned domain models. Mutation flows open one
+backend transaction, run all validation and mutation queries on it, enqueue the
+event in that transaction when enabled, hand ownership to the existing commit
+helper, and perform non-transactional audit storage only after commit where the
+current contract requires it. No adapter may acquire a second pool connection
+while a transaction is live.
+
+The transition may expose a temporary PostgreSQL accessor inside `storage` while
+domains move one PR at a time. DB-006 removes it and activates a CI guard before
+SQLite is advertised or selected outside tests.
+
+## Interfaces and data contracts
+
+There is no HTTP, GraphQL, gRPC, event-envelope, bootstrap-YAML, action, scope,
+credential, or certificate contract change.
+
+`DATABASE_URL` accepts:
+
+- `postgres://...` and `postgresql://...`;
+- `sqlite://<local-path>` for a durable file, created if absent only when its
+  parent directory exists;
+- `sqlite::memory:` for ephemeral use with one connection.
+
+Unsupported schemes fail startup before listeners serve. PostgreSQL keeps its
+current default maximum pool size of 20. File SQLite defaults to 5 connections;
+memory mode forces 1. Explicit existing pool configuration continues to control
+file pools. SQLite adds a 30-second busy timeout and does not make journal or
+synchronous durability operator-selectable in this release.
+
+SQLite storage encodings are backend-internal:
+
+- UUID: canonical lowercase RFC-4122 text;
+- UTC time: RFC-3339 text;
+- boolean: checked integer;
+- project enum: checked text matching the public serialized value;
+- JSON: UTF-8 text guarded by `json_valid` and shape checks where required;
+- PostgreSQL text array: validated JSON array with backend row conversion.
+
+IDs are generated in Rust for new portable mutation paths. Adapter row types
+convert SQLite storage values into the existing domain models.
+
+## Compatibility and migration
+
+The existing `migrations/001` through `025` remain in place, unchanged, as the
+PostgreSQL history. SQLite begins with
+`migrations/sqlite/025_baseline.sql`, representing the current logical schema
+and seed state. It is the first released SQLite storage contract.
+
+After the baseline, every logical schema change receives the same migration
+version in both trees. CI rejects an unpaired post-025 migration. Contents may
+differ by dialect, but resulting domain constraints and behavior must have
+paired tests.
+
+There is no cross-backend backfill or cutover. An existing PostgreSQL deployment
+continues using PostgreSQL. A SQLite deployment starts fresh or restores a
+SQLite backup. Released migration files remain immutable under the existing v1
+policy.
+
+## SQLite concurrency and canonical behavior
+
+File connections enable `foreign_keys`, `recursive_triggers`, WAL,
+`synchronous=FULL`, and the busy timeout. Mutation transactions use
+`BEGIN IMMEDIATE`; row-level `FOR UPDATE` clauses are omitted because the SQLite
+write reservation serializes writers. Nested collision retries use savepoints.
+
+A process-lifetime sibling lock file prevents two Atom processes from owning one
+database. SQLite paths on network/shared storage are unsupported even when a
+filesystem appears to honor the lock.
+
+PostgreSQL retains its parameterized canonical grant function and scope matcher.
+SQLite implements one reusable parameterized recursive grant CTE and one scope
+matching fragment. The PDP, explain, gates, authorized listers, tenant/audit
+visibility, and access-token ceiling filtering must all call the same repository
+contract. Reverse assignment guardrails remain a separate reverse expansion.
+
+The SQLite outbox worker must not hold a write transaction while waiting for the
+broker. Because only one Atom process is supported, it can read a bounded batch,
+publish, then record results in a short immediate transaction. A crash between
+publish and marking delivered may duplicate an event, which is already permitted
+by the at-least-once contract; it must never mark an unpublished event delivered.
+
+## Security and privacy
+
+- Authentication, online authorization, deny-overrides, ABAC fail-closed, and
+  access-token ceiling semantics are invariant across backends.
+- Database constraint/trigger parity covers tenant boundaries, soft-delete,
+  policy cleanup, credential-kind restrictions, PKI authority/profile/issuer
+  rules, immutable revocation evidence, and cascaded purge behavior.
+- When SQLite cannot express an invariant safely in a trigger, the adapter
+  validates it under the same immediate transaction and proves race behavior.
+- Recoverable signing and credential secrets retain Atom's AES-256-GCM field
+  encryption. The SQLite file itself is not SQLCipher-encrypted; production docs
+  require appropriate OS/disk encryption and file permissions.
+- Error messages, tracing, events, and debug output must not expose SQL, secrets,
+  key material, database credentials, or the database path beyond operator-safe
+  startup diagnostics.
+
+## Failure modes and recovery
+
+| Failure | Detection | User/system effect | Recovery | Owner |
+|---|---|---|---|---|
+| Unsupported URL | Startup validation | Atom does not serve | Correct `DATABASE_URL` | Operator |
+| SQLite parent/path unavailable | Connection setup | Atom does not serve | Fix mount/permissions/path | Operator |
+| Second Atom process | Sibling lock acquisition | Second process does not serve | Stop owner or use another file | Operator |
+| Migration mismatch/failure | Backend migrator | Atom does not serve | Restore backup, fix binary/migration | Operator + database reviewer |
+| Busy beyond 30 seconds | SQLite extended error classification | Request fails closed as unavailable | Retry with backoff; diagnose long writer | Operator |
+| Process crash during mutation | Transaction rollback/recovery | No partial mutation or orphan event | Restart; SQLite recovery runs | Database adapter |
+| Crash after event publish | Delivered marker absent | Possible duplicate publication | Consumer idempotency; next poll retries | Event owner |
+| Corrupt SQLite file | Integrity/startup/read error | Atom stops or returns internal/unavailable | Restore verified backup | Operator |
+| Semantic dialect drift | Differential CI | Release blocked | Correct adapter/query and add regression test | Engineering |
+
+## Observability, capacity, and cost
+
+Startup logs include selected backend, sanitized location category (network
+address versus file/memory), migration completion, SQLite durability mode, and
+file-lock ownership. Existing health/readiness behavior uses the façade.
+
+Metrics add low-cardinality backend labels to database operation latency/error
+counters and record SQLite busy timeouts, migration failures, and background-job
+failures. Database URLs, file paths, SQL, subject IDs, and tenant IDs are not
+metric labels.
+
+SQLite is documented for one process and moderate embedded workloads, not
+multi-replica or high-write scaling. PostgreSQL remains the recommended backend
+when horizontal availability, independent database operations, or high write
+concurrency is required. No external database service is required for SQLite;
+the operational cost moves to local durable storage, backup, and process
+ownership.
+
+## Test strategy
+
+- Preserve and run the entire current PostgreSQL suite after every abstraction PR.
+- Parameterize fixtures and run each DB-relevant integration binary against a
+  fresh PostgreSQL database and fresh SQLite file, single-threaded within the
+  binary as current shared seeds require.
+- Differentially compare normalized PDP decisions/explanations, gates, listings,
+  errors, lifecycle transitions, audit/outbox, purge, and PKI artifacts.
+- Test one-connection operation, immediate-write contention, nested savepoints,
+  second-process rejection, restart persistence, migration idempotency, rollback,
+  crash windows, invariant rejection, and backup/restore.
+- Capture a fixed PostgreSQL authz benchmark before the repository refactor and
+  enforce the approved p95 regression budget.
+- Run `cargo fmt --check`, `cargo clippy --locked -- -D warnings`,
+  `cargo test --no-run --locked`, unit tests, both DB suites, and
+  `scripts/check-v1-contracts.sh`.
+
+## Rollout and rollback
+
+1. Merge DB-001 through DB-006 as PostgreSQL-only behavior-preserving changes.
+2. Merge the SQLite driver, schema, and adapters without documenting SQLite as
+   production-supported; selection may remain test-only until parity is complete.
+3. Enable the dual-backend CI and release matrix. Stop if PostgreSQL performance,
+   contracts, authz parity, transaction semantics, or PKI invariants fail.
+4. Publish SQLite operator documentation and support only after reviewer approval
+   and release evidence.
+
+PostgreSQL rollback uses the current binary rollback policy because its released
+migrations are unchanged. Before a SQLite database is used externally, rollback
+is removal of the unreleased SQLite path. After release, roll back only to an
+earlier SQLite-capable binary whose migration compatibility is documented, or
+restore the pre-upgrade SQLite backup. Rollback never converts SQLite data into
+PostgreSQL.
+
+## Alternatives considered
+
+| Alternative | Advantages | Rejection reason |
+|---|---|---|
+| SQLx `AnyPool` | One pool/transaction type | Supports only a primitive portable type subset and obscures backend errors/semantics Atom needs |
+| One portable SQL set | Less duplicated SQL | Sacrifices PostgreSQL functions/locks and still cannot express all SQLite differences safely |
+| ORM rewrite | Advertised multi-database mapping | Large unrelated rewrite, poor fit for recursive authorization and lock-sensitive transactions |
+| Compile-time backend features | Simpler monomorphic types | Produces separate binaries and violates runtime URL selection |
+| Public backend plugin API | External extensibility | Requires a stable ABI/security boundary not needed for Atom-owned backends |
+| SQLite dev-only mode | Smaller initial port | Does not satisfy the production embedded deployment goal |
+
+## Consequences and follow-ups
+
+The repository will contain intentional dialect-specific SQL and schema code,
+but that complexity becomes bounded and testable. Every new persistence feature
+must update both backends or explicitly change the support contract before merge.
+SQLite operational limits become a product constraint. Cross-backend transfer,
+SQLCipher, replicas, and a public backend API remain separately scoped future
+initiatives.

--- a/product-docs/development/database-backends/ROADMAP.md
+++ b/product-docs/development/database-backends/ROADMAP.md
@@ -1,0 +1,111 @@
+# Database Backend Delivery Roadmap
+
+## Status
+
+Draft execution plan for `PRD.md` and `RFC.md`. GitHub objects have not been
+published. Implement one leaf issue per focused PR and do not advertise SQLite
+until Milestone C exits.
+
+## Delivery sequence
+
+```text
+DB-001 Database façade, URL selection, PostgreSQL benchmark
+   |
+   v
+DB-002 Transaction, commit, and error abstraction
+   |
+   +----------+----------------+----------------+
+   |          |                |                |
+   v          v                v                v
+DB-003     DB-004           DB-005           DB-006
+Identity   Authz reads      Authz writes      PKI/workers
+   |          |                |                |
+   +----------+----------------+----------------+
+                         |
+                         v
+              PostgreSQL boundary gate
+                         |
+                         v
+DB-007 SQLite connection and migration baseline
+   |
+   v
+DB-008 SQLite codecs, errors, and invariant matrix
+   |
+   +----------+----------------+----------------+----------------+
+   |          |                |                |                |
+   v          v                v                v                v
+DB-009     DB-010           DB-011           DB-012           DB-013
+Identity   Authz reads      Authz writes      Audit/workers    PKI foundation
+   |          |                |                |                |
+   |          |                |                |                v
+   |          |                |                |             DB-014
+   |          |                |                |             PKI lifecycle
+   +----------+----------------+----------------+----------------+
+                         |
+                         v
+DB-015 Dual-backend parity, concurrency, and performance gate
+                         |
+                         v
+DB-016 Operator documentation and release readiness
+```
+
+## Milestone A — PostgreSQL-safe abstraction
+
+Includes DB-001 through DB-006.
+
+Exit gate:
+
+- public contracts and all PostgreSQL behavior remain unchanged;
+- the fixed PostgreSQL authz benchmark exists and the refactor stays within the
+  approved regression budget;
+- transports, domain services, bootstrap, and workers no longer expose SQLx
+  PostgreSQL types or raw SQL;
+- transactional audit/outbox and single-connection invariants still pass;
+- a static boundary check prevents PostgreSQL coupling from escaping storage.
+
+## Milestone B — Complete SQLite implementation
+
+Includes DB-007 through DB-014.
+
+Exit gate:
+
+- file and memory URLs start, migrate, and restart correctly;
+- one-process ownership and durability settings are enforced;
+- all identity, tenant, authz, audit/outbox, purge, signing-key, and PKI paths
+  have SQLite implementations;
+- canonical grant and scope behavior is shared by every SQLite decision and
+  visibility reader;
+- schema and same-transaction validation cover every documented invariant;
+- SQLite remains unadvertised until Milestone C.
+
+## Milestone C — Parity and supported release
+
+Includes DB-015 and DB-016.
+
+Exit gate:
+
+- all DB-relevant tests run against clean PostgreSQL and SQLite databases;
+- normalized differential, concurrency, crash-window, and backup/restore tests pass;
+- v1 contract artifacts do not change;
+- PostgreSQL performance stays inside NFR-2;
+- database, security, operations, and product reviewers accept the evidence;
+- PostgreSQL-first and SQLite single-instance operational guidance is published.
+
+## Cross-cutting rules
+
+- Existing PostgreSQL migrations are immutable.
+- A transaction never borrows a second pool connection.
+- Domain events are inserted in the mutation transaction.
+- SQLite never holds a write transaction across broker network I/O.
+- Subject-forward authorization uses the canonical backend grant expansion;
+  reverse guardrail expansion stays separate.
+- No secret, key material, database URL, or unsafe file path enters logs/events.
+- Every leaf issue updates tests before relaxing or replacing an invariant.
+- A PR description closes only its published leaf issue with `Closes #<number>`.
+
+## Review gates
+
+- Database review: DB-001, DB-002, DB-004, DB-005, DB-007 through DB-015.
+- Security review: DB-004, DB-005, DB-008 through DB-015.
+- Operations review: DB-007, DB-012, DB-015, DB-016.
+- Product/API review: DB-001, DB-015, DB-016.

--- a/product-docs/development/database-backends/issues/DB-001-database-facade.md
+++ b/product-docs/development/database-backends/issues/DB-001-database-facade.md
@@ -1,0 +1,81 @@
+# DB-001 — Add the database façade and PostgreSQL benchmark baseline
+
+## Objective
+
+Introduce backend-neutral database identity, URL classification, pool ownership,
+migration dispatch, and a fixed PostgreSQL authz benchmark without changing
+runtime behavior.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-1, FR-2, FR-4, FR-10; NFR-1, NFR-2, NFR-10
+- Parent capability: Isolate persistence without PostgreSQL regression
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Product/API plus database reviewer TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: a change would edit/reorder a released migration, alter a public contract, or choose a benchmark budget different from the RFC.
+
+## Scope
+
+**In scope**
+
+- `DatabaseKind`, a cloneable database façade, URL scheme validation, PostgreSQL
+  pool construction, backend migration dispatch, and sanitized startup logging.
+- Replace `AppState`'s public `PgPool` field with the façade while providing a
+  storage-internal transitional PostgreSQL accessor for later leaf issues.
+- Add a deterministic seeded authz benchmark and capture the main-branch baseline.
+
+**Out of scope**
+
+- Connecting to SQLite, changing repository SQL, or changing pool/health behavior from issue #42.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/db.rs`, `src/config.rs`, `src/main.rs`, `src/state.rs`, `src/authz/engine.rs`, `Cargo.toml`, `migrations/`
+- Existing conventions/contracts: `DATABASE_URL` is required; `sqlx::migrate!("./migrations")` runs at startup; PostgreSQL pool settings are explicit; v1 migrations are immutable.
+- Change boundaries: startup and state ownership only; storage callers may temporarily use the internal PostgreSQL accessor.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: Valid PostgreSQL URL and current `DbPoolConfig`.
+- Outputs/postconditions: PostgreSQL startup is unchanged; unsupported schemes fail before serving; benchmark results are reproducible.
+- API/schema/event contract: No public contract change.
+- Compatibility requirement: Existing PostgreSQL URLs and databases work unchanged.
+
+## Dependencies and sequencing
+
+- Blocked by: None
+- Blocks: DB-002
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Malformed/unsupported URL -> actionable startup failure without credentials in logs.
+- PostgreSQL connection/migration timeout -> existing failure behavior retained.
+- Benchmark variance -> document fixture, warm-up, sample count, and comparison method.
+
+## Acceptance criteria
+
+- Given a PostgreSQL URL, when Atom starts, then it connects and migrates through the façade with existing configuration.
+- Given an unsupported or malformed scheme, when configuration loads, then startup fails before any listener serves.
+- Given the fixed authz fixture, when the benchmark runs repeatedly, then it produces a baseline suitable for enforcing NFR-2.
+- Existing PostgreSQL tests and v1 contract artifacts remain unchanged.
+
+## Verification
+
+- Tests to add/update: URL classification, migration selection, sanitized errors, `AppState` construction, authz benchmark fixture.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test --no-run --locked`; `cargo test`; `scripts/check-v1-contracts.sh`.
+- Manual/operational evidence: Attach benchmark baseline and environment description to the PR.
+
+## Definition of done
+
+- [ ] Acceptance criteria pass with evidence in the PR.
+- [ ] Required checks pass and released migrations are untouched.
+- [ ] Transitional PostgreSQL accessor is storage-internal and tagged for removal in DB-006.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-002-transaction-error-boundary.md
+++ b/product-docs/development/database-backends/issues/DB-002-transaction-error-boundary.md
@@ -1,0 +1,79 @@
+# DB-002 — Generalize transactions, commit helpers, and database errors
+
+## Objective
+
+Make transaction ownership, nested savepoints, mutation commits, and database
+error classification backend-neutral while proving PostgreSQL semantics remain
+identical.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-5, FR-8, FR-10; NFR-4, NFR-6, NFR-7, NFR-10
+- Parent capability: Isolate persistence without PostgreSQL regression
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Database reviewer TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: commit ordering, audit asymmetry, cache barriers, or outbox atomicity would change.
+
+## Scope
+
+**In scope**
+
+- `DbTransaction`, read/write transaction modes, nested savepoint support, and ownership-based commit/rollback.
+- Adapt audit/event commit helpers and error mapping to backend-neutral interfaces.
+- Introduce `DatabaseErrorKind` and preserve repository-specific restore/entity conflict attribution.
+
+**Out of scope**
+
+- SQLite error codes or SQL; domain repository migration.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/audit.rs`, `src/events/mod.rs`, `src/error.rs`, `src/cache/invalidate.rs`, transaction-taking service functions.
+- Existing conventions/contracts: outbox insertion is atomic with mutation; DB audit is post-commit/fire-and-forget; commit helpers take transactions by value; nested PKI retries use savepoints.
+- Change boundaries: shared transaction and commit infrastructure, not domain behavior.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: Database façade from DB-001.
+- Outputs/postconditions: Callers use `DbTransaction`; transport errors remain stable.
+- API/schema/event contract: No contract change.
+- Compatibility requirement: Preserve current unique/FK/check/not-found mappings and event/audit order.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-001
+- Blocks: DB-003, DB-004, DB-005, DB-006
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Commit succeeds but later read fails -> forbidden; required return rows must be read inside the transaction.
+- Audit insert fails after commit -> caller still succeeds and failure is logged.
+- Nested savepoint collision -> outer transaction remains usable.
+- Pool size one -> no path attempts a second connection.
+
+## Acceptance criteria
+
+- Given any audited or observed mutation, when it succeeds or fails, then PostgreSQL event, audit, cache, and return behavior matches the current implementation.
+- Given a unique, foreign-key, check, or missing-row error, then existing HTTP and gRPC semantics remain unchanged.
+- Given a one-connection pool and nested savepoint tests, then no deadlock or poisoned outer transaction occurs.
+
+## Verification
+
+- Tests to add/update: commit ordering, rollback/no-outbox, audit failure tolerance, cache barriers, nested savepoints, single-connection execution, error classification.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; PostgreSQL ignored tests with `--include-ignored --test-threads=1`.
+- Manual/operational evidence: Transaction-sequence review in PR description.
+
+## Definition of done
+
+- [ ] Acceptance criteria and failure-injection tests pass.
+- [ ] No commit helper accepts a concrete PostgreSQL transaction publicly.
+- [ ] No unrelated repository domain is migrated in this PR.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-003-identity-tenant-postgres-adapter.md
+++ b/product-docs/development/database-backends/issues/DB-003-identity-tenant-postgres-adapter.md
@@ -1,0 +1,74 @@
+# DB-003 — Isolate PostgreSQL identity, tenant, and authentication storage
+
+## Objective
+
+Move identity, credential, session, profile, tenant, invitation, and bootstrap
+persistence behind backend-neutral repository façades with no PostgreSQL behavior
+change.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-2, FR-5, FR-8, FR-10; NFR-1, NFR-2, NFR-6, NFR-7
+- Parent capability: Isolate persistence without PostgreSQL regression
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Identity/database reviewer TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: authentication, credential revocation, restore provenance, or tenant lifecycle semantics would change.
+
+## Scope
+
+**In scope:** PostgreSQL adapter boundaries for identity repositories/services,
+access tokens, profiles, tenants/invitations, authentication lookups, and YAML/env bootstrap.
+
+**Out of scope:** Authorization repository internals, PKI issuance, and SQLite SQL.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/identity/repo.rs`, `src/identity/service.rs`, `src/identity/access_tokens.rs`, `src/identity/profile_repo.rs`, `src/tenants/repo.rs`, `src/auth.rs`, `src/bootstrap.rs`.
+- Existing conventions/contracts: layered handler/service/repo flow, soft-delete/restore rules, tenant-delete revocation provenance, scoped-token ceilings, no second connection in a transaction.
+- Change boundaries: preserve current function-level behaviors behind façades.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-002 transaction/error contracts.
+- Outputs/postconditions: domain and transport code receives existing models/errors without PostgreSQL types.
+- API/schema/event contract: No change.
+- Compatibility requirement: Existing credentials, sessions, tenant membership, bootstrap idempotency, and soft-delete behavior remain exact.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-002
+- Blocks: DB-006 boundary gate, DB-009
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Saturated one-connection pool -> all transaction reads remain on the transaction.
+- Duplicate email/external ID/name -> field-specific conflicts remain actionable.
+- Tenant/entity restore -> only credentials with the documented revocation provenance reactivate.
+- Idempotent membership/bootstrap -> no false event is published.
+
+## Acceptance criteria
+
+- Given every existing identity/tenant integration scenario, when executed after the refactor, then results, errors, audit/events, and cache behavior are unchanged.
+- Domain and transport modules in scope contain no `PgPool`, `PgConnection`, `Postgres`, PostgreSQL transaction, or raw SQL usage.
+- Single-connection deletion, restoration, invitation, and credential tests pass.
+
+## Verification
+
+- Tests to add/update: compile-time/interface boundary tests plus all identity, tenant, profile, bootstrap, auth, credential, session, restore, purge, and invitation suites.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; PostgreSQL ignored tests single-threaded.
+- Manual/operational evidence: Before/after architecture search attached to PR.
+
+## Definition of done
+
+- [ ] Acceptance criteria pass with PostgreSQL evidence.
+- [ ] Raw SQL for this domain exists only in the PostgreSQL storage adapter.
+- [ ] Authz and PKI scope did not drift into the PR.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-004-authz-read-postgres-adapter.md
+++ b/product-docs/development/database-backends/issues/DB-004-authz-read-postgres-adapter.md
@@ -1,0 +1,75 @@
+# DB-004 — Isolate PostgreSQL authorization decisions and visibility
+
+## Objective
+
+Move the PDP context loader, canonical effective grants, control-plane gates,
+explain, and authorized visibility readers behind one backend-neutral
+authorization-read contract without changing a decision.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-2, FR-6, FR-10; NFR-1, NFR-2, NFR-7, NFR-10
+- Parent capability: Isolate persistence without PostgreSQL regression
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Security and database reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: a reader would bypass `subject_effective_grants`, duplicate scope matching, weaken ABAC fail-closed, or change deny precedence.
+
+## Scope
+
+**In scope:** PostgreSQL adapter contract for PDP/explain context, effective
+grants, scope matching, access-token ceilings, gates, tenant/audit visibility,
+and entity/resource/group authorized listings.
+
+**Out of scope:** Role/policy mutations, reverse assignment guardrails, SQLite queries.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/authz/engine.rs`, `src/authz/repo.rs`, `src/authz/access.rs`, `src/auth.rs`, authorized GraphQL/gRPC readers, `subject_effective_grants` and `grant_scope_matches` in migrations.
+- Existing conventions/contracts: one canonical subject-forward expansion; online checks hit DB; deny overrides; conditions fail closed; tenant lifecycle and token ceilings filter visibility.
+- Change boundaries: preserve PostgreSQL functions/views and query plans inside the adapter.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: Auth context, action, object, optional request context/credential ceiling.
+- Outputs/postconditions: Existing decision, explanation, grants, and visible IDs.
+- API/schema/event contract: No change.
+- Compatibility requirement: Normalized output and query count/performance remain within current contracts and NFR-2.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-002
+- Blocks: DB-006 boundary gate, DB-010
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Missing/invalid conditions -> fail closed.
+- Inactive/deleted entity or tenant -> deny/hide consistently.
+- Matching deny plus allow -> deny immediately.
+- Group cycles/corrupt paths -> current database guards and fail-closed behavior remain.
+
+## Acceptance criteria
+
+- Existing PDP, explain, gate, scope-parity, ceiling, and authorized-listing tests produce unchanged results.
+- Every subject-forward reader calls the authorization-read façade and ultimately the same PostgreSQL canonical expansion.
+- Benchmark p95 remains within NFR-2 and no per-grant round trips are introduced.
+
+## Verification
+
+- Tests to add/update: boundary/dispatch tests; existing authz, inheritance, conditions, gates, listings, audit visibility, and ceiling suites.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; PostgreSQL ignored tests; benchmark command established by DB-001.
+- Manual/operational evidence: Query-flow and benchmark comparison in PR.
+
+## Definition of done
+
+- [ ] Decision and visibility parity evidence passes.
+- [ ] No subject-forward alternative expansion was introduced.
+- [ ] PostgreSQL-specific logic is contained in its adapter.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-005-authz-write-postgres-adapter.md
+++ b/product-docs/development/database-backends/issues/DB-005-authz-write-postgres-adapter.md
@@ -1,0 +1,74 @@
+# DB-005 — Isolate PostgreSQL authorization mutations and guardrails
+
+## Objective
+
+Move roles, permission blocks, policies, assignments, groups, capabilities,
+applicability, hierarchy locking, and reverse guardrail validation behind
+backend-neutral write contracts without changing authorization state semantics.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-2, FR-5, FR-8, FR-10; NFR-1, NFR-6, NFR-7, NFR-9
+- Parent capability: Isolate persistence without PostgreSQL regression
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Security and database reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: assignment tenant boundaries, hierarchy serialization, policy cleanup, idempotent membership, or guardrail precedence would change.
+
+## Scope
+
+**In scope:** PostgreSQL adapter boundaries for authorization management and
+reverse assignment-time validation, including transaction-scoped locks and purge references.
+
+**Out of scope:** PDP/read paths from DB-004, SQLite SQL, and public API changes.
+
+## Verified repository context
+
+- Relevant paths/symbols: mutation sections of `src/authz/repo.rs`, `src/guardrails.rs`, group mutation sections of `src/identity/repo.rs`, GraphQL authorization mutations.
+- Existing conventions/contracts: hierarchy advisory/row locks, reverse `effective_access_edges` use is limited to guardrails/object lookups/assignment metadata, membership no-ops publish no event, policy-object cleanup trigger reaches a fixpoint.
+- Change boundaries: preserve all PostgreSQL SQL and transaction behavior inside the adapter.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: Valid authenticated mutation inputs and DB-002 transactions.
+- Outputs/postconditions: Existing role/policy/group/capability state and events.
+- API/schema/event contract: No change.
+- Compatibility requirement: Preserve idempotency, guardrails, cascade cleanup, soft delete/restore/purge, and conflict errors.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-002
+- Blocks: DB-006 boundary gate, DB-011
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Concurrent hierarchy/membership edits -> serialized without cycles or stale validation.
+- Deleting policy/assignment through direct or cascaded path -> target blocks are removed to fixpoint.
+- No-op membership/assignment -> commits without false domain event.
+- One-connection pool -> validators stay on the caller transaction.
+
+## Acceptance criteria
+
+- Existing role, permission-block, policy, capability, hierarchy, guardrail, soft-delete, restore, purge, and event tests remain unchanged and green.
+- Reverse guardrail expansion remains distinct from subject-forward decision expansion.
+- Domain/transport code in scope contains no PostgreSQL types or raw SQL.
+
+## Verification
+
+- Tests to add/update: adapter dispatch, concurrent hierarchy/assignment, no-op event, cascade cleanup, guardrail precedence, one-connection deletion.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; PostgreSQL ignored tests single-threaded.
+- Manual/operational evidence: Lock and transaction inventory in PR.
+
+## Definition of done
+
+- [ ] Acceptance and concurrency criteria pass.
+- [ ] Canonical forward/reverse boundaries remain documented and enforced.
+- [ ] No unrelated read-path or SQLite implementation is included.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-006-pki-workers-postgres-adapter.md
+++ b/product-docs/development/database-backends/issues/DB-006-pki-workers-postgres-adapter.md
@@ -1,0 +1,77 @@
+# DB-006 — Isolate PostgreSQL PKI, bootstrap, and background storage
+
+## Objective
+
+Complete the PostgreSQL boundary for signing keys, PKI, audit retention, outbox,
+purge, lifecycle, startup/bootstrap, and custom endpoints, then enforce the
+architecture rule in CI.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-2, FR-5, FR-10; NFR-1, NFR-2, NFR-5 through NFR-7, NFR-10
+- Parent capability: Isolate persistence without PostgreSQL regression
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Database, PKI/security, and operations reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: PKI trust/issuer semantics, secret handling, outbox delivery, purge retention, or startup ordering would change.
+
+## Scope
+
+**In scope:** PostgreSQL adapter boundaries for `keys`, all `certs` repositories
+and services with SQL, audit/event/purge/lifecycle workers, API endpoints,
+startup bootstraps, and the final static boundary check/removal of transitional accessors.
+
+**Out of scope:** SQLite implementation and changes to certificate/public API semantics.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/keys.rs`, `src/certs/`, `src/audit.rs`, `src/events/mod.rs`, `src/purge.rs`, `src/api_endpoints/repo.rs`, `src/main.rs`, `src/bootstrap.rs`, `.github/workflows/rust.yml`.
+- Existing conventions/contracts: nested serial-collision savepoints, async startup file I/O, transactional events, post-commit audit asymmetry, no key material in debug/logs, background advisory locks.
+- Change boundaries: all remaining persistence; transports stay contract-identical.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-002 plus completion of DB-003/004/005 before activating the global guard.
+- Outputs/postconditions: No production code outside storage depends on a SQLx backend type or raw SQL.
+- API/schema/event contract: No change.
+- Compatibility requirement: Existing PKI, audit, event, purge, bootstrap, and custom endpoint suites remain exact.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-002; final guard activation also requires DB-003, DB-004, DB-005
+- Blocks: DB-007
+- External dependency: Existing PKCS#11/AMQP test infrastructure where required
+
+## Failure modes and edge cases
+
+- Serial collision -> savepoint retry leaves caller transaction valid.
+- Audit storage failure after valid commit -> operation remains successful.
+- Broker stall -> bounded timeout and retryable undelivered rows.
+- Purge/lifecycle overlap -> PostgreSQL locks retain current single-worker semantics.
+- Architecture guard false positives -> allow only storage/migration/test-fixture paths.
+
+## Acceptance criteria
+
+- Existing PKI, signing, bootstrap, custom endpoint, audit, event, purge, and lifecycle tests pass unchanged on PostgreSQL.
+- A CI check reports zero prohibited PostgreSQL type/raw-SQL references outside approved paths.
+- Transitional PostgreSQL accessors are removed or private to the PostgreSQL adapter.
+- NFR-2 benchmark and v1 contract checks still pass.
+
+## Verification
+
+- Tests to add/update: adapter dispatch; architecture guard; existing PKI migration/issuance/renewal/revocation/CRL/OCSP/enrollment/lifecycle; audit/outbox/purge/bootstrap.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test --no-run --locked`; `cargo test`; PostgreSQL ignored suite; `scripts/check-v1-contracts.sh`.
+- Manual/operational evidence: Final source-boundary inventory in PR.
+
+## Definition of done
+
+- [ ] Milestone A exit gate passes.
+- [ ] No secret-bearing type gains unsafe `Debug`/logging.
+- [ ] No released migration changes.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-007-sqlite-runtime-baseline.md
+++ b/product-docs/development/database-backends/issues/DB-007-sqlite-runtime-baseline.md
@@ -1,0 +1,82 @@
+# DB-007 — Add SQLite runtime policy and migration baseline
+
+## Objective
+
+Add bundled SQLite connection support, durable file and memory modes, single-owner
+enforcement, backend migration selection, and the version-025 SQLite baseline.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-1, FR-4, FR-7, FR-8; NFR-3, NFR-4, NFR-8
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Database and operations reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: SQLite cannot enforce the selected durability/topology or the baseline cannot represent the current logical schema without changing a public meaning.
+
+## Scope
+
+**In scope**
+
+- SQLx bundled SQLite driver, URL parsing, file creation rules, memory pool rules,
+  process-lifetime sibling lock, connection PRAGMAs, immediate-write support.
+- `migrations/sqlite/025_baseline.sql` with current tables, seeds, indexes, views,
+  foreign keys, and expressible triggers.
+- Migration selection and paired-post-025 migration validation foundation.
+
+**Out of scope**
+
+- Domain query implementations, cross-backend transfer, SQLCipher, or production support announcement.
+
+## Verified repository context
+
+- Relevant paths/symbols: `Cargo.toml`, `src/db.rs`, `src/config.rs`, `src/main.rs`, `migrations/001_initial.sql` through `025_case_insensitive_entity_email_unique.sql`, `product-docs/14-v1-compatibility.md`.
+- Existing conventions/contracts: migrations are embedded and automatic; current released PostgreSQL migrations are immutable; UUIDs and JSONB dominate the schema.
+- Change boundaries: SQLite startup/schema only, with placeholder repository support sufficient for migration tests.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: Milestone A boundary complete; `sqlite://` or `sqlite::memory:` URL.
+- Outputs/postconditions: Correct SQLite database opens/migrates with required durability; second owner fails.
+- API/schema/event contract: No public contract change; SQLite storage encoding follows RFC.
+- Compatibility requirement: PostgreSQL migration selection remains unchanged.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-006/Milestone A
+- Blocks: DB-008
+- External dependency: Bundled SQLite compile support verified in CI
+
+## Failure modes and edge cases
+
+- Missing parent or unwritable path -> startup failure before serving.
+- Second Atom owner -> clear startup failure.
+- Memory pool greater than one -> force one connection.
+- WAL/PRAGMA failure or incompatible SQLite -> startup failure, never silent downgrade.
+- Partial migration -> migrator reports failure and Atom does not serve.
+
+## Acceptance criteria
+
+- File and memory URLs create a migrated database and report the selected backend without leaking sensitive paths.
+- File connections prove `foreign_keys`, `recursive_triggers`, WAL, `synchronous=FULL`, and 30-second busy timeout; write transactions reserve immediately.
+- A second Atom lock attempt fails; restart after releasing the lock preserves file data.
+- PostgreSQL still uses only its existing migration history.
+
+## Verification
+
+- Tests to add/update: URL/path matrix, pool defaults, PRAGMAs, file lock, restart, migration idempotency/checksum, memory isolation, malformed baseline.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; startup integration tests for PostgreSQL and SQLite.
+- Manual/operational evidence: Inspect `_sqlx_migrations` and PRAGMAs in a fresh file.
+
+## Definition of done
+
+- [ ] Acceptance criteria pass on Linux and Windows CI-supported behavior.
+- [ ] SQLite remains unadvertised as supported.
+- [ ] PostgreSQL migration checks remain green.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-008-sqlite-codecs-invariants.md
+++ b/product-docs/development/database-backends/issues/DB-008-sqlite-codecs-invariants.md
@@ -1,0 +1,75 @@
+# DB-008 — Add SQLite codecs, error mapping, and invariant coverage
+
+## Objective
+
+Provide reusable SQLite value conversion and error classification, and establish
+an explicit schema/application invariant matrix before domain adapters write data.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-8, FR-10; NFR-4, NFR-5, NFR-8, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Database and security reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: a persisted enum/string meaning, uniqueness behavior, or security invariant cannot be represented consistently.
+
+## Scope
+
+**In scope:** UUID/time/boolean/enum/JSON/array adapters, SQLite row conversion
+helpers, backend-neutral extended error mapping, constraint attribution, and
+positive/negative tests for every baseline invariant.
+
+**Out of scope:** Complete identity/authz/PKI repository queries.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/models/`, especially `models/enums.rs`; `src/error.rs`; all `sqlx::FromRow` models; PostgreSQL CHECK/FK/index/trigger definitions in migrations.
+- Existing conventions/contracts: project enums serialize to stored text; unique/FK/check errors have stable caller semantics; PKI and policy cleanup use database triggers.
+- Change boundaries: shared SQLite adapter support and baseline invariant tests.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-007 migrated SQLite database.
+- Outputs/postconditions: Domain values round-trip losslessly; database errors classify consistently; invariant coverage gaps are explicit and closed.
+- API/schema/event contract: No public change.
+- Compatibility requirement: Persisted strings and normalized transport errors match PostgreSQL meanings.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-007
+- Blocks: DB-009 through DB-014
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Invalid UUID/time/enum/JSON/array -> rejected without panic or permissive fallback.
+- Unique error lacks index name -> adapter/repository context still returns the documented field-specific conflict.
+- SQLite busy/locked after timeout -> service unavailable, not generic internal or partial commit.
+- Trigger-inexpressible invariant -> documented same-transaction validator plus race test owner.
+
+## Acceptance criteria
+
+- Every supported scalar/JSON/array representation round-trips optional and required values.
+- Unique, FK, CHECK, not-found, malformed-value, and busy errors map to the RFC matrix.
+- An invariant table maps every PostgreSQL constraint/trigger relied on by Atom to a SQLite constraint/trigger or named same-transaction validator with a planned domain owner.
+- Negative direct-schema tests reject invalid tenant, credential, policy-cleanup, and PKI shapes covered by the baseline.
+
+## Verification
+
+- Tests to add/update: codec property/table tests, malformed row tests, backend error matrix, schema invariant suite, busy timeout.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite integration tests.
+- Manual/operational evidence: Invariant matrix attached or checked into the RFC appendix if implementation changes it.
+
+## Definition of done
+
+- [ ] Acceptance criteria pass.
+- [ ] No codec logs sensitive data or silently coerces invalid values.
+- [ ] Every deferred application validator has a blocking owner among DB-009 through DB-014.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-009-sqlite-identity-tenant.md
+++ b/product-docs/development/database-backends/issues/DB-009-sqlite-identity-tenant.md
@@ -1,0 +1,75 @@
+# DB-009 — Implement SQLite identity, tenant, and authentication storage
+
+## Objective
+
+Implement SQLite parity for identity, credentials, sessions, profiles, tenants,
+invitations, authentication, and bootstrap using the established repository contracts.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-3, FR-5, FR-8; NFR-4 through NFR-7, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Identity, database, and security reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: password/shared-key verification, revocation provenance, tenant boundaries, or restore semantics would differ from PostgreSQL.
+
+## Scope
+
+**In scope:** SQLite adapter implementations for the DB-003 contracts, including
+entity/group membership portions owned by identity, credentials/access tokens,
+sessions, profiles, tenants/invitations, auth lookups, and bootstrap idempotency.
+
+**Out of scope:** Authorization decision/mutation adapters and certificate-specific PKI lifecycle.
+
+## Verified repository context
+
+- Relevant paths/symbols: PostgreSQL adapters originating from `src/identity/`, `src/tenants/repo.rs`, `src/auth.rs`, and `src/bootstrap.rs`; SQLite support from DB-007/008.
+- Existing conventions/contracts: API key IDs allow O(1) lookup; access-token ceilings are online; membership no-ops publish no event; tenant/entity restore credential rules differ deliberately.
+- Change boundaries: implement the same repository contracts without transport changes.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-008 codecs/invariants and a migrated SQLite database.
+- Outputs/postconditions: Existing identity and tenant models, events, and errors match PostgreSQL.
+- API/schema/event contract: No change.
+- Compatibility requirement: Password, HMAC/argon2 fallback, session, soft-delete, restore, purge-reference, and bootstrap behavior remain equivalent.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-003, DB-008
+- Blocks: DB-015
+- External dependency: Redis only for existing cache-gated tests
+
+## Failure modes and edge cases
+
+- Concurrent duplicate email/name/external ID -> one success and documented conflict.
+- Entity/tenant delete or restore -> immediate write transaction preserves revocation and event state.
+- No-op membership/bootstrap -> no false event.
+- One SQLite connection -> no nested pool acquisition.
+
+## Acceptance criteria
+
+- Every identity, tenant, authentication, profile, invitation, bootstrap, credential, session, delete/restore/purge test passes against SQLite.
+- Normalized success and error outputs match the PostgreSQL fixture.
+- Cache barriers and transactional events remain correctly ordered.
+- Concurrency tests leave one valid result without partial state.
+
+## Verification
+
+- Tests to add/update: backend-parameterized DB-003 suite, duplicate-write races, one-connection flows, restart persistence, no-op events.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite DB-gated tests with `--include-ignored --test-threads=1`.
+- Manual/operational evidence: Normalized PostgreSQL/SQLite comparison summary.
+
+## Definition of done
+
+- [ ] Acceptance and parity criteria pass.
+- [ ] No authorization/PKI scope was silently stubbed.
+- [ ] All same-transaction validators assigned by DB-008 are implemented for this domain.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-010-sqlite-authz-read.md
+++ b/product-docs/development/database-backends/issues/DB-010-sqlite-authz-read.md
@@ -1,0 +1,76 @@
+# DB-010 — Implement SQLite authorization decisions and visibility
+
+## Objective
+
+Implement the canonical SQLite grant expansion, scope matcher, PDP/explain
+context, control-plane gates, access-token ceilings, and authorized visibility
+readers with PostgreSQL-equivalent results.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-3, FR-6; NFR-2, NFR-4, NFR-7, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Security and database reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: more than one subject-forward expansion/scope implementation is needed or a PostgreSQL result cannot be matched without changing public semantics.
+
+## Scope
+
+**In scope:** SQLite implementation of all DB-004 contracts using one reusable
+recursive grant CTE and one scope-matching fragment; explicit null/sort/time/JSON
+semantics where dialect defaults differ.
+
+**Out of scope:** Authorization mutations, reverse guardrails, and PostgreSQL function rewrites.
+
+## Verified repository context
+
+- Relevant paths/symbols: DB-004 authorization-read façade; PostgreSQL `subject_effective_grants`, `grant_scope_matches`, `permission_block_scopes`, credential ceiling view, and `src/authz/engine.rs`.
+- Existing conventions/contracts: batched online evaluation, deny-overrides, ABAC fail-closed, recursive groups, tenant lifecycle deny, visibility/PDP ceiling parity.
+- Change boundaries: SQLite adapter only plus backend-neutral differential fixtures where necessary.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: SQLite identity/tenant data from DB-009 and DB-008 codecs.
+- Outputs/postconditions: Identical normalized decision/explain/grant/listing outputs.
+- API/schema/event contract: No change.
+- Compatibility requirement: No permissions in tokens and no per-grant query round trips.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-004, DB-008, DB-009
+- Blocks: DB-015
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Conditional/malformed grant -> same fail-closed result as PostgreSQL.
+- Multiple parent object groups -> membership and ancestor scopes match all valid paths.
+- Inactive/deleted tenant/entity -> deny and hide consistently.
+- NULL ordering/case/time comparison -> explicit dialect logic matches tested contract.
+
+## Acceptance criteria
+
+- PDP, bulk check, explain, gates, inheritance, ABAC operators, deny precedence, ceilings, tenant/audit visibility, and every authorized listing pass on SQLite.
+- Differential fixtures compare normalized evaluated bindings and reasons, not generated IDs/timestamps.
+- Static review finds exactly one SQLite subject-forward grant expansion and scope matcher consumed by all required readers.
+- Query-count tests show no per-grant or per-binding round trips.
+
+## Verification
+
+- Tests to add/update: full DB-004 suite on SQLite plus differential scope/ABAC/ceiling/visibility matrices and query-count guard.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite and PostgreSQL authz integration suites.
+- Manual/operational evidence: Canonical query/data-flow review attached to PR.
+
+## Definition of done
+
+- [ ] Authorization parity and fail-closed criteria pass.
+- [ ] Canonical expansion rule is documented and statically reviewable.
+- [ ] No mutation or reverse-guardrail implementation is bundled.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-011-sqlite-authz-write.md
+++ b/product-docs/development/database-backends/issues/DB-011-sqlite-authz-write.md
@@ -1,0 +1,76 @@
+# DB-011 — Implement SQLite authorization mutations and guardrails
+
+## Objective
+
+Implement SQLite role, permission-block, policy, assignment, capability, group
+hierarchy, membership, cleanup, and reverse guardrail behavior with safe writer
+serialization and PostgreSQL-equivalent outcomes.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-3, FR-5, FR-8; NFR-3, NFR-4, NFR-6, NFR-7, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Security and database reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: SQLite trigger recursion, immediate transactions, or guardrail queries cannot preserve policy cleanup or assignment correctness under concurrency.
+
+## Scope
+
+**In scope:** SQLite implementation of DB-005 contracts, including hierarchy
+serialization through immediate writes, reverse recursive guardrail queries,
+idempotent membership/assignment behavior, and policy-target cleanup triggers.
+
+**Out of scope:** Subject-forward decision queries and background purge scheduling.
+
+## Verified repository context
+
+- Relevant paths/symbols: DB-005 façades; PostgreSQL hierarchy locks and reverse queries; `purge_blocks_targeting_policy` triggers; role/permission/policy repositories.
+- Existing conventions/contracts: object membership many-to-many; hierarchy is a tree; no-op mutations publish no event; policy cleanup must reach a fixpoint through cascades.
+- Change boundaries: SQLite adapter and corresponding invariant/concurrency tests.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-008 and SQLite identity data; immediate-write transaction support.
+- Outputs/postconditions: Equivalent authorization management state, events, and conflicts.
+- API/schema/event contract: No change.
+- Compatibility requirement: Guardrail precedence, tenant boundaries, cleanup, soft-delete/restore/purge, and idempotency remain exact.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-005, DB-008, DB-009
+- Blocks: DB-015
+- External dependency: None
+
+## Failure modes and edge cases
+
+- Concurrent parent changes -> one serialized valid tree, never a cycle.
+- Concurrent link/delete -> FK/transaction prevents dangling role-block links.
+- Cascade deletes policy objects -> recursive trigger cleanup reaches stable state.
+- Busy timeout -> fail unavailable with full rollback.
+
+## Acceptance criteria
+
+- All role, permission block, policy, capability, applicability, group, guardrail, restore, and purge-reference tests pass on SQLite.
+- Concurrent hierarchy, membership, assignment, and deletion scenarios preserve invariants and event idempotency.
+- Reverse guardrail evaluation matches PostgreSQL without becoming a subject-forward decision source.
+- One-connection tests complete without deadlock.
+
+## Verification
+
+- Tests to add/update: DB-005 suite on SQLite, trigger fixpoint, writer races, busy rollback, no-op events, one-connection flows.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite and PostgreSQL authorization mutation suites.
+- Manual/operational evidence: Concurrency/trigger invariant report.
+
+## Definition of done
+
+- [ ] Acceptance and concurrency evidence passes.
+- [ ] Every DB-008 authz invariant owner is closed.
+- [ ] No public or PostgreSQL semantic change is included.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-012-sqlite-audit-workers.md
+++ b/product-docs/development/database-backends/issues/DB-012-sqlite-audit-workers.md
@@ -1,0 +1,76 @@
+# DB-012 — Implement SQLite audit, outbox, purge, and worker semantics
+
+## Objective
+
+Implement SQLite audit retention, transactional event outbox, delivery, purge,
+and background lifecycle coordination without holding a SQLite write lock across
+external I/O or losing committed events.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-3, FR-5, FR-7, FR-8; NFR-3, NFR-4, NFR-6, NFR-7, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Database and operations reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: an outbox design could mark unpublished work delivered, hold a write lock during broker I/O, or weaken purge/audit retention semantics.
+
+## Scope
+
+**In scope:** SQLite implementations for audit write/cleanup, transactional
+outbox enqueue, single-process batch publish/result marking, outbox retention,
+soft-delete purge, and non-PKI worker coordination/observability.
+
+**Out of scope:** Broker contract changes, exactly-once delivery, multi-process worker leases, and PKI-specific lifecycle.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/audit.rs`, `src/events/mod.rs`, `src/purge.rs`, `src/state.rs`, event publisher contract.
+- Existing conventions/contracts: outbox atomic with mutation; audit insert may fail after commit; at-least-once delivery; publish timeout; PostgreSQL advisory locks prevent replica overlap; SQLite supports one process.
+- Change boundaries: SQLite worker adapter and shared dispatch only.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-007 single-owner guarantee and domain transactions from DB-009/011.
+- Outputs/postconditions: Equivalent audit/outbox/purge results and safe recovery.
+- API/schema/event contract: Event payload and audit API unchanged; duplicates remain allowed.
+- Compatibility requirement: A committed enabled event is durable; an unpublished event is never marked delivered.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-008, DB-009, DB-011
+- Blocks: DB-015
+- External dependency: Existing AMQP integration infrastructure for live publish proof
+
+## Failure modes and edge cases
+
+- Broker timeout/failure -> row remains retryable and writers are not blocked during network wait.
+- Crash after publish before mark -> duplicate on retry, never loss.
+- Unparseable payload -> attempts/error/exhaustion remain visible and never marked delivered.
+- Purge overlaps request -> immediate transactions serialize and canonical authz references are cleaned.
+
+## Acceptance criteria
+
+- Audit success/failure asymmetry, hot-path policy, outbox enqueue/delivery/error, retention, and purge suites pass on SQLite.
+- Instrumented test proves no SQLite write transaction is held while `publisher.publish` awaits.
+- Crash-window tests prove at-least-once behavior and no false delivered state.
+- Busy/purge/contention tests rollback completely and return required errors.
+
+## Verification
+
+- Tests to add/update: mock publisher timing/locking, crash windows, malformed payload, retention, purge, one-connection, restart, optional live AMQP.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite audit/event/purge suites; existing live AMQP test where infrastructure exists.
+- Manual/operational evidence: State-transition table and lock-duration evidence.
+
+## Definition of done
+
+- [ ] Acceptance and recovery criteria pass.
+- [ ] No write lock spans external broker I/O.
+- [ ] Event wire contract remains unchanged.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-013-sqlite-pki-foundation.md
+++ b/product-docs/development/database-backends/issues/DB-013-sqlite-pki-foundation.md
@@ -1,0 +1,76 @@
+# DB-013 — Implement SQLite signing keys and PKI foundation
+
+## Objective
+
+Implement SQLite persistence for signing keys, encrypted database key providers,
+authority registry/provisioning, certificate profiles, and PKI startup bootstrap
+while preserving key isolation and tenant/issuer invariants.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-3, FR-5, FR-8; NFR-4 through NFR-7, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: PKI/security and database reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: issuer selection, authority hierarchy, profile ceilings, KEK behavior, or secret observability would change.
+
+## Scope
+
+**In scope:** SQLite adapters for ES256 signing-key bootstrap/load/rotation,
+encrypted authority keys, authority registry/import/provisioning, profile/version
+storage and validation, and configured root/intermediate startup bootstrap.
+
+**Out of scope:** Leaf issuance, renewal, revocation, CRL/OCSP, enrollment, and lifecycle automation.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/keys.rs`, `src/certs/authority/`, `src/certs/profile.rs`, profile repositories, PKI bootstrap in `src/main.rs`, migrations 011 through 013 and 021 through 024.
+- Existing conventions/contracts: ES256 `kid` rotation, AES-GCM field encryption, no plaintext/unsafe `Debug`, issuer derived from entity scope, profile ceilings enforced in PostgreSQL functions/triggers.
+- Change boundaries: SQLite adapter and invariant tests only.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-008 codecs/invariants and configured KEKs/certificate files.
+- Outputs/postconditions: Existing active keys, authorities, and profiles round-trip with equivalent validation.
+- API/schema/event contract: No change.
+- Compatibility requirement: Key material never becomes caller-selectable or observable; root/private-key trust boundary remains intact.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-008, DB-009
+- Blocks: DB-014, DB-015
+- External dependency: Existing PKCS#11 tests remain compile/run gates where configured
+
+## Failure modes and edge cases
+
+- Missing/wrong KEK -> safe startup/operation failure without key bytes in errors.
+- Concurrent key/authority enablement -> unique invariant and serialized result.
+- Invalid authority parent/scope/validity or profile ceiling -> rejected in same transaction.
+- Startup file I/O -> remains asynchronous/time-bounded as current conventions require.
+
+## Acceptance criteria
+
+- Signing-key, authority, provisioning, profile, bootstrap, encryption, rotation, and recovery suites pass on SQLite.
+- Negative cross-tenant, parent, validity, enabled-issuer, profile ceiling, and secret-redaction tests match PostgreSQL.
+- Nested transactions and one-connection pool behavior do not deadlock.
+- No secret-bearing type or error emits key material.
+
+## Verification
+
+- Tests to add/update: DB-013 domain suites on SQLite, concurrent enable/rotation, invalid hierarchy/profile, KEK failures, debug/log redaction, restart persistence.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite PKI foundation tests; configured PKCS#11 suite.
+- Manual/operational evidence: Security review of storage and observable output.
+
+## Definition of done
+
+- [ ] Acceptance and security evidence passes.
+- [ ] Every DB-008 PKI-foundation invariant owner is closed.
+- [ ] Lifecycle scope remains in DB-014.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-014-sqlite-pki-lifecycle.md
+++ b/product-docs/development/database-backends/issues/DB-014-sqlite-pki-lifecycle.md
@@ -1,0 +1,77 @@
+# DB-014 — Implement SQLite certificate and PKI lifecycle parity
+
+## Objective
+
+Implement SQLite certificate issuance, CSR/generated-key flows, renewal,
+revocation evidence, CRL, OCSP, resolver, enrollment, lifecycle automation, and
+purge behavior with PostgreSQL-equivalent security and recovery semantics.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-3, FR-5, FR-8; NFR-4 through NFR-7, NFR-9
+- Parent capability: Implement full SQLite behavior
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: PKI/security, database, and operations reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: certificate identity, issuer derivation, serial collision, revocation immutability, CRL/OCSP correctness, or enrollment trust would differ.
+
+## Scope
+
+**In scope:** SQLite adapters for remaining certificate repositories/services,
+nested serial-collision savepoints, issuance requests, renewal links, revocation
+evidence, issuer CRLs, OCSP/resolver, enrollment accounting, automation, and PKI purge ordering.
+
+**Out of scope:** New certificate APIs/profiles/transports or PKCS#11 provider design changes.
+
+## Verified repository context
+
+- Relevant paths/symbols: `src/certs/repo.rs`, `src/certs/service.rs`, `src/certs/enrollment/`, `src/certs/lifecycle/`, `src/certs/graphql.rs`, `src/grpc.rs`, migrations 014 through 023.
+- Existing conventions/contracts: each serial-collision attempt is a nested transaction; revocation evidence is immutable/durable; certificates remain revoked across restore; issuer artifacts and tenant purge have strict ordering.
+- Change boundaries: SQLite lifecycle adapter and parity tests.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-013 authorities/profiles/keys and DB-009 entities/credentials.
+- Outputs/postconditions: Existing certificate responses, stored evidence, artifacts, and lifecycle results.
+- API/schema/event contract: No change.
+- Compatibility requirement: Issuer/serial/fingerprint, tenant identity, audit/events, CRL/OCSP, and enrollment semantics match PostgreSQL.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-009, DB-012, DB-013
+- Blocks: DB-015
+- External dependency: Existing real PKI smoke and PKCS#11 infrastructure where configured
+
+## Failure modes and edge cases
+
+- Serial collision -> savepoint retry without poisoning outer mutation.
+- Crash/rollback during issuance/revocation -> no credential/event mismatch.
+- Revocation update/delete attempt -> immutable evidence rejects it.
+- Tenant purge -> ordered credential/evidence/authority cleanup without dangling authz references.
+- Lifecycle overlap -> single-process worker and immediate transactions serialize safely.
+
+## Acceptance criteria
+
+- All CSR, generated issuance, renewal, revocation, CRL, OCSP, resolver, enrollment, lifecycle, legacy migration, and purge tests pass on SQLite.
+- Cross-tenant/issuer and invalid-link cases fail identically to PostgreSQL.
+- Serial collision, one-connection, rollback, and restart tests preserve atomicity and immutable evidence.
+- Independent certificate/CRL/OCSP verification succeeds for SQLite-produced state.
+
+## Verification
+
+- Tests to add/update: backend-parameterized PKI suite, savepoint collision, revocation immutability, lifecycle contention, purge ordering, independent artifact verification.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; SQLite PKI integration suite; existing PKI smoke commands where infrastructure is available.
+- Manual/operational evidence: Security review plus artifact verification report.
+
+## Definition of done
+
+- [ ] Milestone B functional PKI parity passes.
+- [ ] Every DB-008 lifecycle invariant owner is closed.
+- [ ] No public PKI contract or trust boundary changes.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-015-dual-backend-quality-gate.md
+++ b/product-docs/development/database-backends/issues/DB-015-dual-backend-quality-gate.md
@@ -1,0 +1,78 @@
+# DB-015 — Enforce dual-backend parity, concurrency, and performance gates
+
+## Objective
+
+Make SQLite support release-verifiable by running the complete database matrix,
+differential scenarios, failure/concurrency tests, architecture/migration checks,
+and PostgreSQL performance guard in CI. This issue owns final end-to-end proof.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-1 through FR-8, FR-10; NFR-1 through NFR-10
+- Parent capability: Prove parity and release safely
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Product/API, database, security, CI, and operations reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: a test is excluded for backend convenience, parity normalization hides a real semantic difference, or performance exceeds the approved budget.
+
+## Scope
+
+**In scope:** Backend-parameterized fixtures, clean-database-per-binary CI,
+differential result normalizers, architecture and paired-migration gates,
+concurrency/failure/restart suites, benchmark comparison, and release evidence generation.
+
+**Out of scope:** Fixing domain defects discovered by the gate in the same PR unless narrowly test-infrastructure-related; feature implementation returns to its owning issue.
+
+## Verified repository context
+
+- Relevant paths/symbols: `tests/common/mod.rs`, all DB-gated tests in `tests/`, `.github/workflows/rust.yml`, `scripts/check-v1-contracts.sh`, DB-001 benchmark.
+- Existing conventions/contracts: each PostgreSQL test binary gets a fresh database and runs single-threaded; AMQP and PKCS#11 tests have separate infrastructure handling; exact UUID/timestamp assertions are avoided.
+- Change boundaries: test/CI/evidence infrastructure and minimal production observability hooks already specified by RFC.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-009 through DB-014 complete.
+- Outputs/postconditions: One CI result demonstrates every traceable requirement except operator documentation/restore runbook owned by DB-016.
+- API/schema/event contract: v1 artifacts remain byte-for-byte unchanged.
+- Compatibility requirement: PostgreSQL suite and benchmark remain mandatory, not replaced by SQLite.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-009, DB-010, DB-011, DB-012, DB-013, DB-014
+- Blocks: DB-016 and SQLite support release
+- External dependency: PostgreSQL, Redis, and specialized AMQP/PKCS#11/PKI smoke infrastructure as currently documented
+
+## Failure modes and edge cases
+
+- Shared seeded rows -> fresh database per binary and single-threading preserved.
+- SQLite file collision -> unique temporary file and cleanup per process.
+- Normalization hides ordering/semantic drift -> normalize only generated IDs/timestamps; compare all contract fields and reasons.
+- CI time exceeds budget -> measure and split exhaustive lane without reducing required release evidence.
+
+## Acceptance criteria
+
+- Every database-relevant test binary runs against fresh PostgreSQL and SQLite storage; documented external-infrastructure exclusions compile and retain their explicit lanes.
+- Differential authz, error, lifecycle, audit/outbox, purge, and PKI results match after only approved normalization.
+- Single-connection, busy timeout, concurrent writer, nested savepoint, crash-window, restart, process-lock, and migration pairing tests pass.
+- Architecture check finds zero prohibited backend coupling.
+- v1 contract check passes and PostgreSQL authz p95 regression is no greater than 10%.
+- A machine-readable or Markdown release evidence summary maps every FR/NFR to passing jobs/tests.
+
+## Verification
+
+- Tests to add/update: all matrix and differential suites described above.
+- Commands: `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test --no-run --locked`; `cargo test`; both ignored DB suites single-threaded; `scripts/check-v1-contracts.sh`; DB-001 benchmark command.
+- Manual/operational evidence: Reviewer-approved CI/evidence report linked from the Epic.
+
+## Definition of done
+
+- [ ] All requirements owned by this issue have linked passing evidence.
+- [ ] No skipped backend test lacks an explicit external-infrastructure reason and owner.
+- [ ] Performance and contract gates pass.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/DB-016-operations-release.md
+++ b/product-docs/development/database-backends/issues/DB-016-operations-release.md
@@ -1,0 +1,78 @@
+# DB-016 — Publish SQLite operations guidance and complete release readiness
+
+## Objective
+
+Provide PostgreSQL-first and SQLite single-instance deployment guidance,
+container examples, backup/restore and rollback procedures, observability/support
+boundaries, and the final human release review.
+
+## Product and design context
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+- Requirements: FR-4, FR-7, FR-9, FR-10; NFR-3 through NFR-5, NFR-8 through NFR-10
+- Parent capability: Prove parity and release safely
+
+## Ownership and AI execution contract
+
+- Accountable human: `@arvindh123` (proposed)
+- Human reviewer: Product, database, security, documentation, and operations reviewers TBD
+- AI executor: Any approved coding agent
+- Expected PR: One focused PR
+- Stop and escalate when: documentation would imply multi-instance/shared-storage support, safe transfer between backends, SQLCipher, or a rollback path not proven by a drill.
+
+## Scope
+
+**In scope:** README/config reference, quick-start choice, SQLite container volume
+example, backup/restore/integrity procedure, file permissions/disk encryption,
+capacity/topology guidance, observability, paired migration contributor rules,
+rollback/upgrade notes, and release checklist/evidence review.
+
+**Out of scope:** Changing PostgreSQL as default, data transfer tooling, managed backup automation, or release publication without approval.
+
+## Verified repository context
+
+- Relevant paths/symbols: `README.md`, `docker-compose.yml`, `Makefile`, `.env` guidance, `docs/content/docs/quickstart.mdx`, architecture docs, `product-docs/14-v1-compatibility.md`, `.github/workflows/rust.yml`.
+- Existing conventions/contracts: PostgreSQL is current Quick Start/default Compose dependency; automatic migrations and release checks are documented; startup/readiness and graceful shutdown are production contracts.
+- Change boundaries: documentation, examples, release checks, and only minimal safe container configuration needed for SQLite persistence.
+
+## Inputs, outputs, and interfaces
+
+- Inputs/preconditions: DB-015 passing evidence and a release-candidate binary.
+- Outputs/postconditions: Operators can deploy, back up, restore, diagnose, upgrade, and roll back within the supported SQLite boundary.
+- API/schema/event contract: No change.
+- Compatibility requirement: Existing PostgreSQL Quick Start and Compose remain default and functional.
+
+## Dependencies and sequencing
+
+- Blocked by: DB-015
+- Blocks: Epic acceptance and SQLite support announcement
+- External dependency: Human reviewers and a durable-volume environment for restore drill
+
+## Failure modes and edge cases
+
+- Backup omits WAL state -> documented safe snapshot/checkpoint procedure and restore verification.
+- File permissions/disk controls weak -> explicit production checklist.
+- Operator starts two replicas/shared volume -> documentation and startup failure explain unsupported topology.
+- Downgrade after SQLite migration -> only documented compatible binary or backup restore is allowed.
+
+## Acceptance criteria
+
+- A new operator can start PostgreSQL using the unchanged default path and SQLite using the documented file/memory paths.
+- A clean SQLite volume survives restart; a documented backup restored to a new path passes integrity and Atom readiness checks with representative data.
+- Docs clearly state one process/local file, WAL/full durability, pool defaults, busy behavior, disk encryption responsibility, no transfer tool, and PostgreSQL scaling recommendation.
+- Contributor docs require paired post-025 migrations and both backend tests.
+- Product, database, security, and operations reviewers sign off on DB-015 evidence and the release checklist.
+
+## Verification
+
+- Tests to add/update: documentation command smoke tests where automatable, Compose/config validation, backup/restore drill script or runbook verification.
+- Commands: documented Quick Starts; `cargo fmt --check`; `cargo clippy --locked -- -D warnings`; `cargo test`; both DB suites; `scripts/check-v1-contracts.sh`.
+- Manual/operational evidence: Fresh deploy, restart, backup, restore, integrity check, and rollback rehearsal report.
+
+## Definition of done
+
+- [ ] Acceptance criteria pass with operator evidence.
+- [ ] PostgreSQL remains the recommended/default production path.
+- [ ] No unsupported capability is implied.
+- [ ] PR description includes `Closes #<leaf-issue-number>` after publication.

--- a/product-docs/development/database-backends/issues/README.md
+++ b/product-docs/development/database-backends/issues/README.md
@@ -1,0 +1,42 @@
+# Draft GitHub Delivery Hierarchy
+
+These files are draft issue bodies. They are subordinate to `../PRD.md` and
+`../RFC.md`. No issue has been created.
+
+## Epic
+
+- `epic.md` — Run Atom on PostgreSQL or SQLite with equivalent behavior
+
+## Capability 1 — Isolate persistence without PostgreSQL regression
+
+- `story-1-postgres-boundary.md`
+  - `DB-001-database-facade.md`
+  - `DB-002-transaction-error-boundary.md`
+  - `DB-003-identity-tenant-postgres-adapter.md`
+  - `DB-004-authz-read-postgres-adapter.md`
+  - `DB-005-authz-write-postgres-adapter.md`
+  - `DB-006-pki-workers-postgres-adapter.md`
+
+## Capability 2 — Implement full SQLite behavior
+
+- `story-2-sqlite-parity.md`
+  - `DB-007-sqlite-runtime-baseline.md`
+  - `DB-008-sqlite-codecs-invariants.md`
+  - `DB-009-sqlite-identity-tenant.md`
+  - `DB-010-sqlite-authz-read.md`
+  - `DB-011-sqlite-authz-write.md`
+  - `DB-012-sqlite-audit-workers.md`
+  - `DB-013-sqlite-pki-foundation.md`
+  - `DB-014-sqlite-pki-lifecycle.md`
+
+## Capability 3 — Prove parity and release safely
+
+- `story-3-release-readiness.md`
+  - `DB-015-dual-backend-quality-gate.md`
+  - `DB-016-operations-release.md`
+
+## Publication order
+
+Create the Epic first, then the three capabilities as native sub-issues, then
+their leaf issues as native sub-issues. Apply dependencies from `ROADMAP.md`.
+Do not replace native hierarchy with Markdown checklists after publication.

--- a/product-docs/development/database-backends/issues/epic.md
+++ b/product-docs/development/database-backends/issues/epic.md
@@ -1,0 +1,58 @@
+# [Epic] Run Atom on PostgreSQL or SQLite with equivalent behavior
+
+## Outcome
+
+Operators can run the same Atom binary on an existing PostgreSQL deployment or
+as a production single-instance SQLite deployment, while clients receive the
+same identity, authorization, audit, lifecycle, and PKI behavior.
+
+## Source of truth
+
+- PRD: `product-docs/development/database-backends/PRD.md`
+- RFC: `product-docs/development/database-backends/RFC.md`
+
+## Goals and non-goals
+
+- Goal: G-1 through G-5 — runtime backend choice, full parity, PostgreSQL safety,
+  future internal extensibility, and explicit topology guidance.
+- Non-goal: NG-1 through NG-7 — no transfer tool, SQLite replicas, SQLCipher,
+  public plugin ABI, ORM rewrite, public contract change, or issue #42 expansion.
+
+## Success and release gates
+
+- All FR-1 through FR-10 and NFR-1 through NFR-10 have linked evidence.
+- PostgreSQL and SQLite DB suites, differential tests, v1 contracts, lint, and
+  format checks pass.
+- PostgreSQL authz p95 stays within the approved 10% regression budget.
+- SQLite restart, contention, single-owner, backup, and restore evidence passes.
+- Required database, security, product, and operations reviews are complete.
+
+## Delivery hierarchy
+
+- Isolate persistence without PostgreSQL regression
+  - DB-001 through DB-006
+- Implement full SQLite behavior
+  - DB-007 through DB-014
+- Prove parity and release safely
+  - DB-015 through DB-016
+
+## Dependencies and risks
+
+- Existing PostgreSQL migration immutability and v1 contract checks are hard gates.
+- SQLite cannot be advertised before every domain adapter and parity test lands.
+- Authorization, outbox, purge, and PKI semantics require specialized review.
+- GitHub issue #42 is related but remains independently scoped.
+
+## Ownership
+
+- Accountable owner: `@arvindh123` (proposed)
+- Product reviewer: TBD before publication
+- Engineering/database reviewer: TBD before publication
+- Security/operations reviewer: TBD before publication
+
+## Epic acceptance
+
+- [ ] All child capabilities have passed acceptance and are closed.
+- [ ] Requirement traceability has no gaps.
+- [ ] Required rollout, observability, security, and support readiness checks pass.
+- [ ] Outcome evidence or the agreed measurement window is active.

--- a/product-docs/development/database-backends/issues/story-1-postgres-boundary.md
+++ b/product-docs/development/database-backends/issues/story-1-postgres-boundary.md
@@ -1,0 +1,47 @@
+# Isolate persistence without PostgreSQL regression
+
+## Capability
+
+As an Atom maintainer, I can evolve persistence behind backend-neutral
+interfaces so that existing PostgreSQL behavior stays stable and SQLite can be
+implemented without leaking dialect concerns into domain or transport code.
+
+## Requirements
+
+- FR-2, FR-5, FR-8, FR-10
+- NFR-1, NFR-2, NFR-6, NFR-7, NFR-10
+
+## Scope boundaries
+
+**In scope:** PostgreSQL-preserving database, transaction, error, and repository
+boundaries plus a static architecture gate.
+
+**Out of scope:** A selectable SQLite production path or SQLite schema.
+
+## Acceptance criteria
+
+- Given the existing PostgreSQL URL and data, when each child lands, then the
+  full current PostgreSQL suite and v1 contract checks remain green.
+- Given source outside storage and test fixtures, when the final child lands,
+  then no PostgreSQL SQLx type or raw SQL is present.
+- Transactional audit, outbox, cache invalidation, and one-connection tests pass.
+
+## Dependencies
+
+- Blocked by: None
+- Blocks: Implement full SQLite behavior
+
+## Agent-sized child issues
+
+- DB-001 Database façade, runtime URL classification, and benchmark baseline
+- DB-002 Backend-neutral transactions, commit helpers, and error classification
+- DB-003 PostgreSQL identity, tenant, and authentication adapter boundary
+- DB-004 PostgreSQL authorization decision and visibility adapter boundary
+- DB-005 PostgreSQL authorization mutation and guardrail adapter boundary
+- DB-006 PostgreSQL PKI, bootstrap, and worker adapter boundary plus CI guard
+
+## Story acceptance
+
+- [ ] Every child issue is closed with linked verification evidence.
+- [ ] Capability-level acceptance passes end to end.
+- [ ] Canonical PRD/RFC remains accurate.

--- a/product-docs/development/database-backends/issues/story-2-sqlite-parity.md
+++ b/product-docs/development/database-backends/issues/story-2-sqlite-parity.md
@@ -1,0 +1,44 @@
+# Implement full SQLite behavior
+
+## Capability
+
+As a single-instance Atom operator, I can use a local SQLite file or ephemeral
+memory database so that I receive the same supported identity and authorization
+service without provisioning PostgreSQL.
+
+## Requirements
+
+- FR-1, FR-3 through FR-8
+- NFR-3 through NFR-9
+
+## Scope boundaries
+
+**In scope:** SQLite runtime, schema, every storage domain, background workers,
+and operational semantics required for parity.
+
+**Out of scope:** Multiple processes per file, shared/network storage,
+cross-backend transfer, SQLCipher, and release advertising before parity proof.
+
+## Acceptance criteria
+
+- Given `sqlite://` or `sqlite::memory:`, when Atom starts, then the correct
+  migration and durability policy is applied before serving.
+- Given each supported public operation, when run on SQLite, then its observable
+  result and failure semantics match PostgreSQL.
+- Given invalid, concurrent, or rollback scenarios, then authorization fails
+  closed and no partial mutation or orphan event remains.
+
+## Dependencies
+
+- Blocked by: Isolate persistence without PostgreSQL regression
+- Blocks: Prove parity and release safely
+
+## Agent-sized child issues
+
+- DB-007 through DB-014 as listed in `README.md`
+
+## Story acceptance
+
+- [ ] Every child issue is closed with linked verification evidence.
+- [ ] Capability-level acceptance passes end to end.
+- [ ] Canonical PRD/RFC remains accurate.

--- a/product-docs/development/database-backends/issues/story-3-release-readiness.md
+++ b/product-docs/development/database-backends/issues/story-3-release-readiness.md
@@ -1,0 +1,45 @@
+# Prove parity and release safely
+
+## Capability
+
+As an Atom operator or reviewer, I can rely on automated parity evidence and a
+tested runbook so that selecting SQLite does not create an undocumented security,
+durability, or recovery risk and PostgreSQL remains regression-free.
+
+## Requirements
+
+- FR-2, FR-3, FR-7 through FR-10
+- NFR-1 through NFR-10
+
+## Scope boundaries
+
+**In scope:** Dual-backend CI, differential/concurrency/performance gates,
+documentation, container guidance, backup/restore proof, and release approval.
+
+**Out of scope:** Publishing support before all gates pass or adding a data
+transfer utility.
+
+## Acceptance criteria
+
+- Given a pull request, when CI runs, then every DB-relevant suite executes on
+  both backends and contract/migration architecture gates run.
+- Given the release candidate, when reviewers inspect evidence, then authz,
+  lifecycle, transaction, PKI, performance, and recovery criteria are complete.
+- Given operator documentation, when a clean SQLite deployment and restore drill
+  follow it, then Atom reaches ready state with preserved data.
+
+## Dependencies
+
+- Blocked by: Implement full SQLite behavior
+- Blocks: SQLite support announcement/release
+
+## Agent-sized child issues
+
+- DB-015 Dual-backend parity, concurrency, and performance quality gate
+- DB-016 Operator documentation, deployment examples, and release readiness
+
+## Story acceptance
+
+- [ ] Every child issue is closed with linked verification evidence.
+- [ ] Capability-level acceptance passes end to end.
+- [ ] Canonical PRD/RFC remains accurate.


### PR DESCRIPTION
## Summary

- add a decision-complete PRD and RFC for runtime PostgreSQL/SQLite backends
- define the staged delivery roadmap: PostgreSQL-safe abstraction, full SQLite parity, and release hardening
- provide draft GitHub bodies for 1 Epic, 3 capabilities, and 16 agent-ready leaf issues
- include requirement traceability and an approval-gated publication manifest

## Scope

Planning documentation only. This PR does not implement SQLite, alter source code, edit migrations, change v1 contracts, publish the planned issues, or absorb the separate serverless PostgreSQL work in #42.

## Validation

- verified FR-1 through FR-10 and NFR-1 through NFR-10 are defined and traceable
- verified all 16 leaf drafts contain the required execution-contract sections
- verified dependency graph and milestone gates
- passed git diff --check
- rebased onto current origin/main

Tests were not run because this PR changes Markdown planning artifacts only.