### PR TITLE
fix: declare api_endpoint applicability for demo bootstrap execute capability

### DIFF
--- a/config/demo/bootstrap.yaml
+++ b/config/demo/bootstrap.yaml
@@ -14,6 +14,14 @@
 #
 #   psql $DATABASE_URL -c \
 #     "SELECT name, managed_by FROM entities WHERE managed_by='config'"
+#
+# Recovering from "bootstrap capability execute has persisted applicability
+# not declared in config: api_endpoint:<any>": that error means your database
+# already has the `execute`/`api_endpoint` row seeded by migration 001, from
+# before this file declared it. No manual DB change is needed and nothing is
+# lost — pull this updated file (which now declares that applicability) and
+# restart; bootstrap only claims and stamps the pre-existing row, it never
+# deletes it.
 
 # --- Tenants -------------------------------------------------------------
 tenants:

--- a/config/demo/bootstrap.yaml
+++ b/config/demo/bootstrap.yaml
@@ -104,6 +104,10 @@ capabilities:
     applicability:
       - object_kind: resource
         object_type: resource:rule
+      # Matches the applicability the launch migration already persists for
+      # `execute`/`api_endpoint` (see migrations/001_initial.sql); omitting
+      # it here makes bootstrap reject the pre-existing row as undeclared.
+      - object_kind: api_endpoint
 
 # --- Assignment guardrails ---------------------------------------------
 action_assignment_rules:

--- a/tests/m26_config_managed_capabilities.rs
+++ b/tests/m26_config_managed_capabilities.rs
@@ -257,6 +257,33 @@ async fn assignment_rule_bootstrap_stamps_managed_by_and_guards_delete() {
     );
 }
 
+/// Parity check: the demo bootstrap file's declared capability applicability
+/// must exactly match what the launch migration persists for those actions
+/// (issue #110, workstream C). Applying just the `capabilities:` section
+/// twice against a freshly migrated database proves both that a fresh
+/// database bootstraps cleanly and that a database which already carries the
+/// applicability (every database does, since migration 001 seeds it)
+/// reconciles idempotently, matching what `make up` does on every start.
+#[tokio::test]
+#[ignore]
+async fn demo_bootstrap_capability_applicability_matches_seeded_database_contract() {
+    let p = pool().await;
+    let signing_keys = Config::for_tests().signing_keys;
+    let demo_yaml = include_str!("../config/demo/bootstrap.yaml");
+    let demo: BootstrapConfig = serde_yaml::from_str(demo_yaml).expect("parse demo bootstrap.yaml");
+    let capabilities_only = BootstrapConfig {
+        capabilities: demo.capabilities,
+        ..Default::default()
+    };
+
+    apply(&p, &signing_keys, &capabilities_only)
+        .await
+        .expect("demo bootstrap capabilities must match the seeded database contract");
+    apply(&p, &signing_keys, &capabilities_only)
+        .await
+        .expect("second apply must be idempotent");
+}
+
 #[tokio::test]
 #[ignore]
 async fn api_created_capability_stays_api_managed() {


### PR DESCRIPTION
## Problem

- migration 001 persists `execute`/`api_endpoint` applicability, but `config/demo/bootstrap.yaml` never declared it, so bootstrap rejects the pre-existing row and startup fails: `bootstrap capability execute has persisted applicability not declared in config: api_endpoint:<any>`. Blocks `make up` on any already-migrated database.

## Fix

- declare `object_kind: api_endpoint` on the demo `execute` capability, matching the persisted row
- document the data-preserving recovery step in the bootstrap file's header for anyone who already hit the error — no manual DB change needed, just redeploy the fixed config
- add a parity test that loads the real demo config and proves it reconciles against a freshly migrated database, twice (idempotence)

## Tests

- `cargo fmt --check` / `cargo clippy -- -D warnings` clean
- new test fails with the exact issue error text when reverted, passes once fixed
- real `cargo run` against a fresh migrated DB applies the demo bootstrap cleanly

Part of #110 (workstream C).